### PR TITLE
fix(agents): add explicit Write tool usage instructions to document writer agents

### DIFF
--- a/.claude/agents/collector.kr.md
+++ b/.claude/agents/collector.kr.md
@@ -175,6 +175,32 @@ sources:
 - 충돌하는 요구사항 없음
 - 완료를 위해 신뢰도 점수 >= 0.8
 
+## 중요: 도구 사용법
+
+파일을 작성할 때, 반드시 정확한 매개변수 이름으로 `Write` 도구를 사용해야 합니다:
+
+```
+Write 도구 호출:
+- 도구 이름: Write (대문자 W, write_file 아님)
+- 매개변수:
+  - file_path: "/absolute/path/to/file.yaml" (반드시 절대 경로)
+  - content: "파일 내용"
+```
+
+**중요**:
+- `write_file`을 사용하지 마세요 - 이 함수는 존재하지 않습니다
+- `writeFile`을 사용하지 마세요 - 이 함수는 존재하지 않습니다
+- 항상 `file_path`와 `content` 매개변수와 함께 `Write` 도구를 사용하세요
+- 항상 절대 경로(`/`로 시작)를 사용하세요
+
+**이 에이전트용 예시**:
+```
+Write(
+  file_path: ".ad-sdlc/scratchpad/info/{project_id}/collected_info.yaml",
+  content: "<YAML 내용>"
+)
+```
+
 ## 워크플로우
 
 ```

--- a/.claude/agents/collector.md
+++ b/.claude/agents/collector.md
@@ -175,6 +175,32 @@ sources:
 - No conflicting requirements
 - Confidence score >= 0.8 for completion
 
+## CRITICAL: Tool Usage
+
+When writing files, you MUST use the `Write` tool with the exact parameter names:
+
+```
+Write tool invocation:
+- Tool name: Write (capital W, not write_file)
+- Parameters:
+  - file_path: "/absolute/path/to/file.yaml" (must be absolute path)
+  - content: "file content here"
+```
+
+**IMPORTANT**:
+- DO NOT use `write_file` - this function does not exist
+- DO NOT use `writeFile` - this function does not exist
+- Always use the `Write` tool with `file_path` and `content` parameters
+- Always use absolute paths (starting with `/`)
+
+**Example for this agent**:
+```
+Write(
+  file_path: ".ad-sdlc/scratchpad/info/{project_id}/collected_info.yaml",
+  content: "<YAML content>"
+)
+```
+
 ## Workflow
 
 ```

--- a/.claude/agents/issue-generator.kr.md
+++ b/.claude/agents/issue-generator.kr.md
@@ -190,6 +190,32 @@ XL: 사용자 인증 시스템 구현
 - [ ] 각 하위 이슈는 독립적으로 구현 가능
 - [ ] 하위 이슈 간 의존성이 문서화됨
 
+## 중요: 도구 사용법
+
+파일을 작성할 때, 반드시 정확한 매개변수 이름으로 `Write` 도구를 사용해야 합니다:
+
+```
+Write 도구 호출:
+- 도구 이름: Write (대문자 W, write_file 아님)
+- 매개변수:
+  - file_path: "/absolute/path/to/file.json" (반드시 절대 경로)
+  - content: "파일 내용"
+```
+
+**중요**:
+- `write_file`을 사용하지 마세요 - 이 함수는 존재하지 않습니다
+- `writeFile`을 사용하지 마세요 - 이 함수는 존재하지 않습니다
+- 항상 `file_path`와 `content` 매개변수와 함께 `Write` 도구를 사용하세요
+- 항상 절대 경로(`/`로 시작)를 사용하세요
+
+**이 에이전트용 예시**:
+```
+Write(
+  file_path: ".ad-sdlc/scratchpad/issues/{project_id}/issue_list.json",
+  content: "<JSON 내용>"
+)
+```
+
 ## 워크플로우
 
 1. **SDS 읽기**: `.ad-sdlc/scratchpad/documents/{project_id}/sds.md`에서 로드

--- a/.claude/agents/issue-generator.md
+++ b/.claude/agents/issue-generator.md
@@ -190,6 +190,32 @@ XL: Implement User Authentication System
 - [ ] Each sub-issue is independently implementable
 - [ ] Dependencies between sub-issues are documented
 
+## CRITICAL: Tool Usage
+
+When writing files, you MUST use the `Write` tool with the exact parameter names:
+
+```
+Write tool invocation:
+- Tool name: Write (capital W, not write_file)
+- Parameters:
+  - file_path: "/absolute/path/to/file.json" (must be absolute path)
+  - content: "file content here"
+```
+
+**IMPORTANT**:
+- DO NOT use `write_file` - this function does not exist
+- DO NOT use `writeFile` - this function does not exist
+- Always use the `Write` tool with `file_path` and `content` parameters
+- Always use absolute paths (starting with `/`)
+
+**Example for this agent**:
+```
+Write(
+  file_path: ".ad-sdlc/scratchpad/issues/{project_id}/issue_list.json",
+  content: "<JSON content>"
+)
+```
+
 ## Workflow
 
 1. **Read SDS**: Load from `.ad-sdlc/scratchpad/documents/{project_id}/sds.md`

--- a/.claude/agents/prd-writer.kr.md
+++ b/.claude/agents/prd-writer.kr.md
@@ -117,6 +117,32 @@ model: sonnet
 ### 12.3 Document History
 ```
 
+## 중요: 도구 사용법
+
+파일을 작성할 때, 반드시 정확한 매개변수 이름으로 `Write` 도구를 사용해야 합니다:
+
+```
+Write 도구 호출:
+- 도구 이름: Write (대문자 W, write_file 아님)
+- 매개변수:
+  - file_path: "/absolute/path/to/file.md" (반드시 절대 경로)
+  - content: "파일 내용"
+```
+
+**중요**:
+- `write_file`을 사용하지 마세요 - 이 함수는 존재하지 않습니다
+- `writeFile`을 사용하지 마세요 - 이 함수는 존재하지 않습니다
+- 항상 `file_path`와 `content` 매개변수와 함께 `Write` 도구를 사용하세요
+- 항상 절대 경로(`/`로 시작)를 사용하세요
+
+**이 에이전트용 예시**:
+```
+Write(
+  file_path: ".ad-sdlc/scratchpad/documents/{project_id}/prd.md",
+  content: "<PRD 마크다운 내용>"
+)
+```
+
 ## 워크플로우
 
 1. **수집된 정보 읽기**: `.ad-sdlc/scratchpad/info/`에서 YAML 로드

--- a/.claude/agents/prd-writer.md
+++ b/.claude/agents/prd-writer.md
@@ -117,6 +117,32 @@ You are a PRD Writer Agent responsible for transforming collected information in
 ### 12.3 Document History
 ```
 
+## CRITICAL: Tool Usage
+
+When writing files, you MUST use the `Write` tool with the exact parameter names:
+
+```
+Write tool invocation:
+- Tool name: Write (capital W, not write_file)
+- Parameters:
+  - file_path: "/absolute/path/to/file.md" (must be absolute path)
+  - content: "file content here"
+```
+
+**IMPORTANT**:
+- DO NOT use `write_file` - this function does not exist
+- DO NOT use `writeFile` - this function does not exist
+- Always use the `Write` tool with `file_path` and `content` parameters
+- Always use absolute paths (starting with `/`)
+
+**Example for this agent**:
+```
+Write(
+  file_path: ".ad-sdlc/scratchpad/documents/{project_id}/prd.md",
+  content: "<PRD markdown content>"
+)
+```
+
 ## Workflow
 
 1. **Read Collected Information**: Load YAML from `.ad-sdlc/scratchpad/info/`

--- a/.claude/agents/sds-writer.kr.md
+++ b/.claude/agents/sds-writer.kr.md
@@ -251,6 +251,32 @@ component:
   implementation_notes: string
 ```
 
+## 중요: 도구 사용법
+
+파일을 작성할 때, 반드시 정확한 매개변수 이름으로 `Write` 도구를 사용해야 합니다:
+
+```
+Write 도구 호출:
+- 도구 이름: Write (대문자 W, write_file 아님)
+- 매개변수:
+  - file_path: "/absolute/path/to/file.md" (반드시 절대 경로)
+  - content: "파일 내용"
+```
+
+**중요**:
+- `write_file`을 사용하지 마세요 - 이 함수는 존재하지 않습니다
+- `writeFile`을 사용하지 마세요 - 이 함수는 존재하지 않습니다
+- 항상 `file_path`와 `content` 매개변수와 함께 `Write` 도구를 사용하세요
+- 항상 절대 경로(`/`로 시작)를 사용하세요
+
+**이 에이전트용 예시**:
+```
+Write(
+  file_path: ".ad-sdlc/scratchpad/documents/{project_id}/sds.md",
+  content: "<SDS 마크다운 내용>"
+)
+```
+
 ## 워크플로우
 
 1. **SRS 읽기**: `.ad-sdlc/scratchpad/documents/{project_id}/srs.md`에서 로드

--- a/.claude/agents/sds-writer.md
+++ b/.claude/agents/sds-writer.md
@@ -251,6 +251,32 @@ component:
   implementation_notes: string
 ```
 
+## CRITICAL: Tool Usage
+
+When writing files, you MUST use the `Write` tool with the exact parameter names:
+
+```
+Write tool invocation:
+- Tool name: Write (capital W, not write_file)
+- Parameters:
+  - file_path: "/absolute/path/to/file.md" (must be absolute path)
+  - content: "file content here"
+```
+
+**IMPORTANT**:
+- DO NOT use `write_file` - this function does not exist
+- DO NOT use `writeFile` - this function does not exist
+- Always use the `Write` tool with `file_path` and `content` parameters
+- Always use absolute paths (starting with `/`)
+
+**Example for this agent**:
+```
+Write(
+  file_path: ".ad-sdlc/scratchpad/documents/{project_id}/sds.md",
+  content: "<SDS markdown content>"
+)
+```
+
 ## Workflow
 
 1. **Read SRS**: Load from `.ad-sdlc/scratchpad/documents/{project_id}/srs.md`

--- a/.claude/agents/srs-writer.kr.md
+++ b/.claude/agents/srs-writer.kr.md
@@ -185,6 +185,32 @@ feature:
     operations: list
 ```
 
+## 중요: 도구 사용법
+
+파일을 작성할 때, 반드시 정확한 매개변수 이름으로 `Write` 도구를 사용해야 합니다:
+
+```
+Write 도구 호출:
+- 도구 이름: Write (대문자 W, write_file 아님)
+- 매개변수:
+  - file_path: "/absolute/path/to/file.md" (반드시 절대 경로)
+  - content: "파일 내용"
+```
+
+**중요**:
+- `write_file`을 사용하지 마세요 - 이 함수는 존재하지 않습니다
+- `writeFile`을 사용하지 마세요 - 이 함수는 존재하지 않습니다
+- 항상 `file_path`와 `content` 매개변수와 함께 `Write` 도구를 사용하세요
+- 항상 절대 경로(`/`로 시작)를 사용하세요
+
+**이 에이전트용 예시**:
+```
+Write(
+  file_path: ".ad-sdlc/scratchpad/documents/{project_id}/srs.md",
+  content: "<SRS 마크다운 내용>"
+)
+```
+
 ## 워크플로우
 
 1. **PRD 읽기**: `.ad-sdlc/scratchpad/documents/{project_id}/prd.md`에서 로드

--- a/.claude/agents/srs-writer.md
+++ b/.claude/agents/srs-writer.md
@@ -186,6 +186,32 @@ feature:
     operations: list
 ```
 
+## CRITICAL: Tool Usage
+
+When writing files, you MUST use the `Write` tool with the exact parameter names:
+
+```
+Write tool invocation:
+- Tool name: Write (capital W, not write_file)
+- Parameters:
+  - file_path: "/absolute/path/to/file.md" (must be absolute path)
+  - content: "file content here"
+```
+
+**IMPORTANT**:
+- DO NOT use `write_file` - this function does not exist
+- DO NOT use `writeFile` - this function does not exist
+- Always use the `Write` tool with `file_path` and `content` parameters
+- Always use absolute paths (starting with `/`)
+
+**Example for this agent**:
+```
+Write(
+  file_path: ".ad-sdlc/scratchpad/documents/{project_id}/srs.md",
+  content: "<SRS markdown content>"
+)
+```
+
 ## Workflow
 
 1. **Read PRD**: Load from `.ad-sdlc/scratchpad/documents/{project_id}/prd.md`


### PR DESCRIPTION
## Summary

- Add "CRITICAL: Tool Usage" section to all document writer agents (collector, prd-writer, srs-writer, sds-writer, issue-generator)
- Explicitly document that `write_file`/`writeFile` do not exist and agents must use the `Write` tool
- Provide concrete examples with correct `Write` tool parameter names (`file_path`, `content`)
- Include both English and Korean versions for all affected agents

## Problem

Document writer agents were calling `write_file()` which does not exist in Claude Code's tool interface. The actual tool is named `Write` with parameters `file_path` and `content`. This caused silent failures where agents reported success but no files were created.

## Solution

Added explicit tool usage documentation to each agent definition with:
1. Clear statement that `write_file` does not exist
2. Correct `Write` tool format with exact parameter names
3. Agent-specific file path examples

## Affected Files

| Agent | English | Korean |
|-------|---------|--------|
| collector | `.claude/agents/collector.md` | `.claude/agents/collector.kr.md` |
| prd-writer | `.claude/agents/prd-writer.md` | `.claude/agents/prd-writer.kr.md` |
| srs-writer | `.claude/agents/srs-writer.md` | `.claude/agents/srs-writer.kr.md` |
| sds-writer | `.claude/agents/sds-writer.md` | `.claude/agents/sds-writer.kr.md` |
| issue-generator | `.claude/agents/issue-generator.md` | `.claude/agents/issue-generator.kr.md` |

## Test Plan

- [ ] Invoke prd-writer via Task tool and verify file creation
- [ ] Invoke collector via Task tool and verify YAML output
- [ ] Verify all agent output files are created in correct locations

Fixes #183