### PR TITLE
fix: implement graceful cycle detection without blocking entire queue

### DIFF
--- a/src/controller/index.ts
+++ b/src/controller/index.ts
@@ -32,6 +32,8 @@ export type {
   GraphAnalysisResult,
   GraphStatistics,
   PriorityAnalyzerConfig,
+  CycleInfo,
+  CycleStatus,
   // Worker Pool types
   WorkerStatus,
   WorkerInfo,

--- a/src/controller/types.ts
+++ b/src/controller/types.ts
@@ -138,6 +138,25 @@ export interface PrioritizedQueue {
 }
 
 /**
+ * Cycle status for graceful cycle handling
+ */
+export type CycleStatus = 'detected' | 'breaking' | 'resolved' | 'escalated';
+
+/**
+ * Information about a detected circular dependency
+ */
+export interface CycleInfo {
+  /** Node IDs forming the cycle (includes closing node) */
+  readonly nodes: readonly string[];
+  /** When the cycle was detected */
+  readonly detectedAt: Date;
+  /** Current status of cycle handling */
+  readonly status: CycleStatus;
+  /** If cycle was broken, which edge was removed */
+  readonly breakpoint?: string;
+}
+
+/**
  * Graph analysis result
  */
 export interface GraphAnalysisResult {
@@ -153,6 +172,10 @@ export interface GraphAnalysisResult {
   readonly prioritizedQueue: PrioritizedQueue;
   /** Graph statistics */
   readonly statistics: GraphStatistics;
+  /** Detected cycles (empty if no cycles) */
+  readonly cycles: readonly CycleInfo[];
+  /** Issue IDs blocked by circular dependencies */
+  readonly blockedByCycle: readonly string[];
 }
 
 /**

--- a/tests/e2e/orchestration.e2e.test.ts
+++ b/tests/e2e/orchestration.e2e.test.ts
@@ -826,9 +826,19 @@ describe('Multi-Agent Orchestration', () => {
       const graphPath = path.join(testDir, 'circular-graph.json');
       fs.writeFileSync(graphPath, JSON.stringify(graph, null, 2));
 
-      // When/Then: Should throw CircularDependencyError
+      // When: Analyze graph with cycles
       const loadedGraph = await analyzer.loadGraph(graphPath);
-      expect(() => analyzer.analyze(loadedGraph)).toThrow('Circular dependency');
+      const result = analyzer.analyze(loadedGraph);
+
+      // Then: Should detect cycles gracefully without throwing
+      expect(result.cycles.length).toBeGreaterThan(0);
+      expect(result.blockedByCycle.length).toBeGreaterThan(0);
+      expect(analyzer.hasCycles()).toBe(true);
+
+      // All nodes in the cycle should be blocked
+      expect(result.blockedByCycle).toContain('ISS-001');
+      expect(result.blockedByCycle).toContain('ISS-002');
+      expect(result.blockedByCycle).toContain('ISS-003');
     });
   });
 


### PR DESCRIPTION
## Summary
- Replace throwing `CircularDependencyError` with graceful cycle recording
- Add `CycleInfo` and `CycleStatus` types for structured cycle information
- Implement `propagateBlocking()` to block dependent nodes transitively
- Add public API methods: `getCycles()`, `hasCycles()`, `isBlockedByCycle()`, `getBlockedByCycle()`, `getExecutableIssues()`
- Allow partial execution of non-cyclic nodes while cycles are detected and reported

## Changes
- `src/controller/types.ts`: Add `CycleInfo`, `CycleStatus` types; extend `GraphAnalysisResult` with `cycles` and `blockedByCycle` fields
- `src/controller/PriorityAnalyzer.ts`: Refactor `detectCycles()` to record cycles instead of throwing; add `propagateBlocking()` and public cycle API methods
- `src/controller/index.ts`: Export new types `CycleInfo` and `CycleStatus`
- `docs/controller.md`: Add "Graceful Cycle Handling" section with usage examples
- `tests/controller/PriorityAnalyzer.test.ts`: Add 8 new tests for cycle detection and isolation
- `tests/e2e/orchestration.e2e.test.ts`: Update e2e test to verify graceful handling

## Test plan
- [x] All 3291 tests pass
- [x] New unit tests verify cycle detection, isolation, and propagation
- [x] E2E test verifies graceful handling without throwing
- [x] Build succeeds with no TypeScript errors

Resolves #216