### PR TITLE
feat(monitoring): add budget transfer between agents

### DIFF
--- a/src/monitoring/index.ts
+++ b/src/monitoring/index.ts
@@ -147,7 +147,11 @@ export {
   getAgentBudgetRegistry,
   resetAgentBudgetRegistry,
 } from './AgentBudgetRegistry.js';
-export type { AgentBudgetRegistryConfig } from './AgentBudgetRegistry.js';
+export type {
+  AgentBudgetRegistryConfig,
+  BudgetTransferResult,
+  BudgetTransferRecord,
+} from './AgentBudgetRegistry.js';
 
 // BudgetAggregator
 export {


### PR DESCRIPTION
## Summary
- Add `transferTokenBudget()` method to AgentBudgetRegistry for transferring token budgets between agents
- Add `transferCostBudget()` method for cost budget transfers
- Add `adjustTokenLimit()` and `adjustCostLimit()` methods to TokenBudgetManager for dynamic budget adjustment
- Add transfer history tracking with `getTransferHistory()` and `clearTransferHistory()`
- Update TokenBudgetManager comments to reflect per-agent isolation is now implemented via AgentBudgetRegistry

## Changes
- `src/monitoring/AgentBudgetRegistry.ts`: Add budget transfer methods and types
- `src/monitoring/TokenBudgetManager.ts`: Add budget adjustment methods and update comments
- `src/monitoring/index.ts`: Export new types
- `tests/monitoring/AgentBudgetRegistry.test.ts`: Add comprehensive transfer tests
- `tests/monitoring/TokenBudgetManager.test.ts`: Add budget adjustment tests

## Test plan
- [x] All existing tests pass
- [x] New budget transfer tests pass (token and cost transfers)
- [x] Transfer validation tests (insufficient budget, non-existent agents, same agent)
- [x] Transfer history tracking tests
- [x] Build succeeds with no type errors
- [x] Lint passes

Closes #248