### PR TITLE
feat(observability): add span instrumentation utilities for agents and tools

### DIFF
--- a/src/monitoring/index.ts
+++ b/src/monitoring/index.ts
@@ -261,3 +261,18 @@ export type {
 } from './types.js';
 
 export { ADSDLC_SPAN_ATTRIBUTES } from './types.js';
+
+// Tracing utilities
+export {
+  startAgentSpan,
+  startToolSpan,
+  recordToolResult,
+  withAgentSpan,
+  withToolSpan,
+  propagateToSubagent,
+  getCurrentContext,
+  runInContext,
+  runInContextAsync,
+  SpanWrapper,
+} from './tracing.js';
+export type { AgentSpanOptions, ToolSpanOptions, ToolResult } from './tracing.js';

--- a/src/monitoring/tracing.ts
+++ b/src/monitoring/tracing.ts
@@ -1,0 +1,431 @@
+/**
+ * Tracing utilities for span instrumentation
+ *
+ * Provides helper functions for automatic instrumentation of agents and tools,
+ * with span context propagation across subagents.
+ *
+ * @packageDocumentation
+ */
+
+import { context, type Context, type Span, trace } from '@opentelemetry/api';
+import { getOpenTelemetryProvider } from './OpenTelemetryProvider.js';
+import { ADSDLC_SPAN_ATTRIBUTES, type PipelineMode } from './types.js';
+
+/**
+ * Options for starting an agent span
+ */
+export interface AgentSpanOptions {
+  /** Agent name */
+  readonly agentName: string;
+  /** Agent type (e.g., 'processor', 'analyzer') */
+  readonly agentType: string;
+  /** Correlation ID for tracing */
+  readonly correlationId?: string;
+  /** Parent tool use ID for subagent correlation */
+  readonly parentToolUseId?: string;
+  /** Pipeline stage */
+  readonly pipelineStage?: string;
+  /** Pipeline mode (greenfield/enhancement) */
+  readonly pipelineMode?: PipelineMode;
+  /** Parent context for span hierarchy */
+  readonly parentContext?: Context;
+}
+
+/**
+ * Options for starting a tool span
+ */
+export interface ToolSpanOptions {
+  /** Tool name */
+  readonly toolName: string;
+  /** Parent context for span hierarchy */
+  readonly parentContext?: Context;
+}
+
+/**
+ * Result of a tool invocation for recording
+ */
+export interface ToolResult {
+  /** Whether the tool succeeded */
+  readonly success: boolean;
+  /** Result summary or error message */
+  readonly result?: string;
+  /** Error if tool failed */
+  readonly error?: Error;
+}
+
+/**
+ * Span wrapper that provides a convenient API for span lifecycle management
+ */
+export class SpanWrapper {
+  private readonly span: Span | null;
+  private ended = false;
+
+  constructor(span: Span | null) {
+    this.span = span;
+  }
+
+  /**
+   * Get the underlying span (may be null if tracing is disabled)
+   */
+  public getSpan(): Span | null {
+    return this.span;
+  }
+
+  /**
+   * Get the context for this span (for creating child spans)
+   */
+  public getContext(): Context {
+    if (this.span === null) {
+      return context.active();
+    }
+    return trace.setSpan(context.active(), this.span);
+  }
+
+  /**
+   * Set an attribute on the span
+   */
+  public setAttribute(key: string, value: string | number | boolean): this {
+    this.span?.setAttribute(key, value);
+    return this;
+  }
+
+  /**
+   * Set multiple attributes on the span
+   */
+  public setAttributes(attributes: Record<string, string | number | boolean>): this {
+    if (this.span !== null) {
+      for (const [key, value] of Object.entries(attributes)) {
+        this.span.setAttribute(key, value);
+      }
+    }
+    return this;
+  }
+
+  /**
+   * Add an event to the span
+   */
+  public addEvent(name: string, attributes?: Record<string, string | number | boolean>): this {
+    this.span?.addEvent(name, attributes);
+    return this;
+  }
+
+  /**
+   * Record token usage on the span
+   */
+  public recordTokenUsage(inputTokens: number, outputTokens: number, costUsd?: number): this {
+    if (this.span !== null) {
+      this.span.setAttribute(ADSDLC_SPAN_ATTRIBUTES.TOKENS_INPUT, inputTokens);
+      this.span.setAttribute(ADSDLC_SPAN_ATTRIBUTES.TOKENS_OUTPUT, outputTokens);
+      if (costUsd !== undefined) {
+        this.span.setAttribute(ADSDLC_SPAN_ATTRIBUTES.TOKENS_COST, costUsd);
+      }
+    }
+    return this;
+  }
+
+  /**
+   * End the span with success status
+   */
+  public endSuccess(attributes?: Record<string, string | number>): void {
+    if (this.ended) {
+      return;
+    }
+    this.ended = true;
+    getOpenTelemetryProvider().endSpanSuccess(this.span, attributes);
+  }
+
+  /**
+   * End the span with error status
+   */
+  public endError(error: Error): void {
+    if (this.ended) {
+      return;
+    }
+    this.ended = true;
+    getOpenTelemetryProvider().endSpanError(this.span, error);
+  }
+
+  /**
+   * Check if the span has been ended
+   */
+  public isEnded(): boolean {
+    return this.ended;
+  }
+}
+
+/**
+ * Start a span for agent execution with all relevant attributes
+ *
+ * @param options - Agent span options
+ * @returns SpanWrapper for managing the span lifecycle
+ *
+ * @example
+ * ```typescript
+ * const span = startAgentSpan({
+ *   agentName: 'worker',
+ *   agentType: 'processor',
+ *   correlationId: 'uuid-123',
+ *   pipelineStage: 'implementation',
+ *   pipelineMode: 'greenfield'
+ * });
+ *
+ * try {
+ *   // Agent execution logic
+ *   span.recordTokenUsage(1000, 500, 0.05);
+ *   span.endSuccess();
+ * } catch (error) {
+ *   span.endError(error instanceof Error ? error : new Error(String(error)));
+ *   throw error;
+ * }
+ * ```
+ */
+export function startAgentSpan(options: AgentSpanOptions): SpanWrapper {
+  const provider = getOpenTelemetryProvider();
+
+  const span = provider.startSpan(
+    `agent:${options.agentName}`,
+    {
+      attributes: {
+        [ADSDLC_SPAN_ATTRIBUTES.AGENT_NAME]: options.agentName,
+        [ADSDLC_SPAN_ATTRIBUTES.AGENT_TYPE]: options.agentType,
+      },
+    },
+    options.parentContext
+  );
+
+  const wrapper = new SpanWrapper(span);
+
+  // Set optional attributes
+  if (options.correlationId !== undefined) {
+    wrapper.setAttribute(ADSDLC_SPAN_ATTRIBUTES.CORRELATION_ID, options.correlationId);
+  }
+
+  if (options.parentToolUseId !== undefined) {
+    wrapper.setAttribute(ADSDLC_SPAN_ATTRIBUTES.PARENT_TOOL_USE_ID, options.parentToolUseId);
+  }
+
+  if (options.pipelineStage !== undefined) {
+    wrapper.setAttribute(ADSDLC_SPAN_ATTRIBUTES.PIPELINE_STAGE, options.pipelineStage);
+  }
+
+  if (options.pipelineMode !== undefined) {
+    wrapper.setAttribute(ADSDLC_SPAN_ATTRIBUTES.PIPELINE_MODE, options.pipelineMode);
+  }
+
+  return wrapper;
+}
+
+/**
+ * Start a span for tool invocation
+ *
+ * @param options - Tool span options
+ * @returns SpanWrapper for managing the span lifecycle
+ *
+ * @example
+ * ```typescript
+ * const toolSpan = startToolSpan({ toolName: 'Read', parentContext: agentSpan.getContext() });
+ *
+ * try {
+ *   const result = await readFile(path);
+ *   toolSpan.setAttribute(ADSDLC_SPAN_ATTRIBUTES.TOOL_RESULT, 'success');
+ *   toolSpan.endSuccess();
+ *   return result;
+ * } catch (error) {
+ *   toolSpan.endError(error instanceof Error ? error : new Error(String(error)));
+ *   throw error;
+ * }
+ * ```
+ */
+export function startToolSpan(options: ToolSpanOptions): SpanWrapper {
+  const provider = getOpenTelemetryProvider();
+
+  const span = provider.startSpan(
+    `tool:${options.toolName}`,
+    {
+      attributes: {
+        [ADSDLC_SPAN_ATTRIBUTES.TOOL_NAME]: options.toolName,
+      },
+    },
+    options.parentContext
+  );
+
+  return new SpanWrapper(span);
+}
+
+/**
+ * Record tool result on a span and end it appropriately
+ *
+ * @param span - SpanWrapper to record result on
+ * @param result - Tool invocation result
+ */
+export function recordToolResult(span: SpanWrapper, result: ToolResult): void {
+  if (result.success) {
+    if (result.result !== undefined) {
+      span.setAttribute(ADSDLC_SPAN_ATTRIBUTES.TOOL_RESULT, result.result);
+    } else {
+      span.setAttribute(ADSDLC_SPAN_ATTRIBUTES.TOOL_RESULT, 'success');
+    }
+    span.endSuccess();
+  } else {
+    span.setAttribute(ADSDLC_SPAN_ATTRIBUTES.TOOL_RESULT, 'error');
+    if (result.error !== undefined) {
+      span.endError(result.error);
+    } else {
+      span.endError(new Error(result.result ?? 'Unknown error'));
+    }
+  }
+}
+
+/**
+ * Execute a function within an agent span context
+ *
+ * This helper automatically manages span lifecycle including error handling.
+ *
+ * @param options - Agent span options
+ * @param fn - Function to execute within the span
+ * @returns Result of the function
+ *
+ * @example
+ * ```typescript
+ * const result = await withAgentSpan(
+ *   {
+ *     agentName: 'collector',
+ *     agentType: 'analyzer',
+ *     correlationId: 'uuid-123'
+ *   },
+ *   async (span) => {
+ *     // Perform agent work
+ *     span.addEvent('processing_started');
+ *     const data = await processData();
+ *     span.recordTokenUsage(data.inputTokens, data.outputTokens);
+ *     return data.result;
+ *   }
+ * );
+ * ```
+ */
+export async function withAgentSpan<T>(
+  options: AgentSpanOptions,
+  fn: (span: SpanWrapper) => Promise<T>
+): Promise<T> {
+  const span = startAgentSpan(options);
+
+  try {
+    const result = await fn(span);
+    if (!span.isEnded()) {
+      span.endSuccess();
+    }
+    return result;
+  } catch (error) {
+    if (!span.isEnded()) {
+      span.endError(error instanceof Error ? error : new Error(String(error)));
+    }
+    throw error;
+  }
+}
+
+/**
+ * Execute a function within a tool span context
+ *
+ * This helper automatically manages span lifecycle including error handling.
+ *
+ * @param options - Tool span options
+ * @param fn - Function to execute within the span
+ * @returns Result of the function
+ *
+ * @example
+ * ```typescript
+ * const content = await withToolSpan(
+ *   { toolName: 'Read', parentContext: agentSpan.getContext() },
+ *   async (span) => {
+ *     span.addEvent('reading_file', { path: filePath });
+ *     const content = await readFile(filePath);
+ *     span.setAttribute(ADSDLC_SPAN_ATTRIBUTES.TOOL_RESULT, 'success');
+ *     return content;
+ *   }
+ * );
+ * ```
+ */
+export async function withToolSpan<T>(
+  options: ToolSpanOptions,
+  fn: (span: SpanWrapper) => Promise<T>
+): Promise<T> {
+  const span = startToolSpan(options);
+
+  try {
+    const result = await fn(span);
+    if (!span.isEnded()) {
+      span.setAttribute(ADSDLC_SPAN_ATTRIBUTES.TOOL_RESULT, 'success');
+      span.endSuccess();
+    }
+    return result;
+  } catch (error) {
+    if (!span.isEnded()) {
+      span.setAttribute(ADSDLC_SPAN_ATTRIBUTES.TOOL_RESULT, 'error');
+      span.endError(error instanceof Error ? error : new Error(String(error)));
+    }
+    throw error;
+  }
+}
+
+/**
+ * Propagate span context to a subagent via parent tool use ID
+ *
+ * Use this to establish parent-child relationships between agents.
+ *
+ * @param parentSpan - Parent agent's span
+ * @param toolUseId - Tool use ID for the subagent invocation
+ * @returns Context for the subagent
+ *
+ * @example
+ * ```typescript
+ * const parentSpan = startAgentSpan({ agentName: 'orchestrator', agentType: 'coordinator' });
+ *
+ * // When invoking a subagent
+ * const subagentContext = propagateToSubagent(parentSpan, 'tool-use-123');
+ *
+ * // Pass context to subagent
+ * const childSpan = startAgentSpan({
+ *   agentName: 'worker',
+ *   agentType: 'processor',
+ *   parentToolUseId: 'tool-use-123',
+ *   parentContext: subagentContext
+ * });
+ * ```
+ */
+export function propagateToSubagent(parentSpan: SpanWrapper, toolUseId: string): Context {
+  parentSpan.addEvent('subagent_invocation', {
+    [ADSDLC_SPAN_ATTRIBUTES.PARENT_TOOL_USE_ID]: toolUseId,
+  });
+  return parentSpan.getContext();
+}
+
+/**
+ * Get current active span context for manual propagation
+ *
+ * @returns Current context or default context if no active span
+ */
+export function getCurrentContext(): Context {
+  return context.active();
+}
+
+/**
+ * Run a function within a specific context
+ *
+ * @param ctx - Context to use
+ * @param fn - Function to execute
+ * @returns Result of the function
+ */
+export function runInContext<T>(ctx: Context, fn: () => T): T {
+  return context.with(ctx, fn);
+}
+
+/**
+ * Run an async function within a specific context
+ *
+ * @param ctx - Context to use
+ * @param fn - Async function to execute
+ * @returns Promise of the function result
+ */
+export async function runInContextAsync<T>(ctx: Context, fn: () => Promise<T>): Promise<T> {
+  return context.with(ctx, fn);
+}

--- a/tests/monitoring/tracing.test.ts
+++ b/tests/monitoring/tracing.test.ts
@@ -1,0 +1,489 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  OpenTelemetryProvider,
+  resetOpenTelemetryProvider,
+  startAgentSpan,
+  startToolSpan,
+  recordToolResult,
+  withAgentSpan,
+  withToolSpan,
+  propagateToSubagent,
+  getCurrentContext,
+  runInContext,
+  runInContextAsync,
+  SpanWrapper,
+  ADSDLC_SPAN_ATTRIBUTES,
+} from '../../src/monitoring/index.js';
+
+describe('Tracing Utilities', () => {
+  beforeEach(async () => {
+    await resetOpenTelemetryProvider();
+  });
+
+  afterEach(async () => {
+    await resetOpenTelemetryProvider();
+  });
+
+  describe('SpanWrapper', () => {
+    it('should wrap null span gracefully', () => {
+      const wrapper = new SpanWrapper(null);
+      expect(wrapper.getSpan()).toBeNull();
+      expect(wrapper.isEnded()).toBe(false);
+
+      // All operations should be no-ops
+      wrapper.setAttribute('key', 'value');
+      wrapper.setAttributes({ key: 'value' });
+      wrapper.addEvent('event');
+      wrapper.recordTokenUsage(100, 50, 0.1);
+      wrapper.endSuccess();
+
+      expect(wrapper.isEnded()).toBe(true);
+    });
+
+    it('should prevent double ending', () => {
+      const wrapper = new SpanWrapper(null);
+      wrapper.endSuccess();
+      expect(wrapper.isEnded()).toBe(true);
+
+      // Second end should be no-op
+      wrapper.endError(new Error('test'));
+      expect(wrapper.isEnded()).toBe(true);
+    });
+
+    it('should return context even with null span', () => {
+      const wrapper = new SpanWrapper(null);
+      const ctx = wrapper.getContext();
+      expect(ctx).toBeDefined();
+    });
+
+    it('should support chained setAttribute calls', () => {
+      const wrapper = new SpanWrapper(null);
+      const result = wrapper
+        .setAttribute('key1', 'value1')
+        .setAttribute('key2', 'value2')
+        .setAttributes({ key3: 'value3' });
+      expect(result).toBe(wrapper);
+    });
+  });
+
+  describe('startAgentSpan', () => {
+    it('should return SpanWrapper when tracing disabled', () => {
+      const span = startAgentSpan({
+        agentName: 'test-agent',
+        agentType: 'processor',
+      });
+
+      expect(span).toBeInstanceOf(SpanWrapper);
+      expect(span.getSpan()).toBeNull();
+      span.endSuccess();
+    });
+
+    it('should create span with basic attributes', async () => {
+      const provider = new OpenTelemetryProvider({
+        enabled: true,
+        serviceName: 'test-service',
+        exporters: [{ type: 'console', enabled: true }],
+      });
+      await provider.initialize();
+
+      const span = startAgentSpan({
+        agentName: 'worker',
+        agentType: 'processor',
+      });
+
+      expect(span).toBeInstanceOf(SpanWrapper);
+      span.endSuccess();
+    });
+
+    it('should include optional attributes when provided', async () => {
+      const provider = new OpenTelemetryProvider({
+        enabled: true,
+        serviceName: 'test-service',
+        exporters: [{ type: 'console', enabled: true }],
+      });
+      await provider.initialize();
+
+      const span = startAgentSpan({
+        agentName: 'worker',
+        agentType: 'processor',
+        correlationId: 'corr-123',
+        parentToolUseId: 'tool-use-456',
+        pipelineStage: 'implementation',
+        pipelineMode: 'greenfield',
+      });
+
+      expect(span).toBeInstanceOf(SpanWrapper);
+      span.endSuccess();
+    });
+  });
+
+  describe('startToolSpan', () => {
+    it('should return SpanWrapper when tracing disabled', () => {
+      const span = startToolSpan({
+        toolName: 'Read',
+      });
+
+      expect(span).toBeInstanceOf(SpanWrapper);
+      expect(span.getSpan()).toBeNull();
+      span.endSuccess();
+    });
+
+    it('should create span with tool name', async () => {
+      const provider = new OpenTelemetryProvider({
+        enabled: true,
+        serviceName: 'test-service',
+        exporters: [{ type: 'console', enabled: true }],
+      });
+      await provider.initialize();
+
+      const span = startToolSpan({
+        toolName: 'Read',
+      });
+
+      expect(span).toBeInstanceOf(SpanWrapper);
+      span.endSuccess();
+    });
+
+    it('should accept parent context', async () => {
+      const provider = new OpenTelemetryProvider({
+        enabled: true,
+        serviceName: 'test-service',
+        exporters: [{ type: 'console', enabled: true }],
+      });
+      await provider.initialize();
+
+      const parentSpan = startAgentSpan({
+        agentName: 'parent',
+        agentType: 'orchestrator',
+      });
+
+      const childSpan = startToolSpan({
+        toolName: 'Write',
+        parentContext: parentSpan.getContext(),
+      });
+
+      childSpan.endSuccess();
+      parentSpan.endSuccess();
+    });
+  });
+
+  describe('recordToolResult', () => {
+    it('should record success result', () => {
+      const span = startToolSpan({ toolName: 'Read' });
+
+      recordToolResult(span, {
+        success: true,
+        result: 'file content loaded',
+      });
+
+      expect(span.isEnded()).toBe(true);
+    });
+
+    it('should record success without explicit result', () => {
+      const span = startToolSpan({ toolName: 'Read' });
+
+      recordToolResult(span, {
+        success: true,
+      });
+
+      expect(span.isEnded()).toBe(true);
+    });
+
+    it('should record error result with Error object', () => {
+      const span = startToolSpan({ toolName: 'Read' });
+      const error = new Error('File not found');
+
+      recordToolResult(span, {
+        success: false,
+        error,
+      });
+
+      expect(span.isEnded()).toBe(true);
+    });
+
+    it('should record error result without Error object', () => {
+      const span = startToolSpan({ toolName: 'Read' });
+
+      recordToolResult(span, {
+        success: false,
+        result: 'Permission denied',
+      });
+
+      expect(span.isEnded()).toBe(true);
+    });
+
+    it('should record error result with no details', () => {
+      const span = startToolSpan({ toolName: 'Read' });
+
+      recordToolResult(span, {
+        success: false,
+      });
+
+      expect(span.isEnded()).toBe(true);
+    });
+  });
+
+  describe('withAgentSpan', () => {
+    it('should execute function and return result', async () => {
+      const result = await withAgentSpan(
+        {
+          agentName: 'test-agent',
+          agentType: 'processor',
+        },
+        async (span) => {
+          expect(span).toBeInstanceOf(SpanWrapper);
+          return 'success';
+        }
+      );
+
+      expect(result).toBe('success');
+    });
+
+    it('should handle errors and rethrow', async () => {
+      await expect(
+        withAgentSpan(
+          {
+            agentName: 'test-agent',
+            agentType: 'processor',
+          },
+          async () => {
+            throw new Error('Test error');
+          }
+        )
+      ).rejects.toThrow('Test error');
+    });
+
+    it('should not end span twice if already ended in function', async () => {
+      const result = await withAgentSpan(
+        {
+          agentName: 'test-agent',
+          agentType: 'processor',
+        },
+        async (span) => {
+          span.endSuccess({ 'custom.attr': 42 });
+          return 'ended early';
+        }
+      );
+
+      expect(result).toBe('ended early');
+    });
+
+    it('should handle non-Error throws', async () => {
+      await expect(
+        withAgentSpan(
+          {
+            agentName: 'test-agent',
+            agentType: 'processor',
+          },
+          async () => {
+            throw 'string error';
+          }
+        )
+      ).rejects.toBe('string error');
+    });
+  });
+
+  describe('withToolSpan', () => {
+    it('should execute function and return result', async () => {
+      const result = await withToolSpan(
+        {
+          toolName: 'Read',
+        },
+        async (span) => {
+          expect(span).toBeInstanceOf(SpanWrapper);
+          return 'file content';
+        }
+      );
+
+      expect(result).toBe('file content');
+    });
+
+    it('should handle errors and rethrow', async () => {
+      await expect(
+        withToolSpan(
+          {
+            toolName: 'Read',
+          },
+          async () => {
+            throw new Error('File not found');
+          }
+        )
+      ).rejects.toThrow('File not found');
+    });
+
+    it('should not end span twice if already ended in function', async () => {
+      const result = await withToolSpan(
+        {
+          toolName: 'Read',
+        },
+        async (span) => {
+          span.setAttribute(ADSDLC_SPAN_ATTRIBUTES.TOOL_RESULT, 'custom result');
+          span.endSuccess();
+          return 'ended early';
+        }
+      );
+
+      expect(result).toBe('ended early');
+    });
+
+    it('should handle non-Error throws', async () => {
+      await expect(
+        withToolSpan(
+          {
+            toolName: 'Read',
+          },
+          async () => {
+            throw 'string error';
+          }
+        )
+      ).rejects.toBe('string error');
+    });
+  });
+
+  describe('propagateToSubagent', () => {
+    it('should add event and return context', () => {
+      const parentSpan = startAgentSpan({
+        agentName: 'orchestrator',
+        agentType: 'coordinator',
+      });
+
+      const context = propagateToSubagent(parentSpan, 'tool-use-123');
+
+      expect(context).toBeDefined();
+      parentSpan.endSuccess();
+    });
+
+    it('should work with enabled tracing', async () => {
+      const provider = new OpenTelemetryProvider({
+        enabled: true,
+        serviceName: 'test-service',
+        exporters: [{ type: 'console', enabled: true }],
+      });
+      await provider.initialize();
+
+      const parentSpan = startAgentSpan({
+        agentName: 'orchestrator',
+        agentType: 'coordinator',
+      });
+
+      const subagentContext = propagateToSubagent(parentSpan, 'tool-use-456');
+
+      const childSpan = startAgentSpan({
+        agentName: 'worker',
+        agentType: 'processor',
+        parentToolUseId: 'tool-use-456',
+        parentContext: subagentContext,
+      });
+
+      childSpan.endSuccess();
+      parentSpan.endSuccess();
+    });
+  });
+
+  describe('getCurrentContext', () => {
+    it('should return current context', () => {
+      const ctx = getCurrentContext();
+      expect(ctx).toBeDefined();
+    });
+  });
+
+  describe('runInContext', () => {
+    it('should execute function in context', () => {
+      const ctx = getCurrentContext();
+      const result = runInContext(ctx, () => 'executed');
+      expect(result).toBe('executed');
+    });
+  });
+
+  describe('runInContextAsync', () => {
+    it('should execute async function in context', async () => {
+      const ctx = getCurrentContext();
+      const result = await runInContextAsync(ctx, async () => {
+        return 'executed async';
+      });
+      expect(result).toBe('executed async');
+    });
+  });
+
+  describe('Integration scenarios', () => {
+    it('should support nested agent and tool spans', async () => {
+      const provider = new OpenTelemetryProvider({
+        enabled: true,
+        serviceName: 'test-service',
+        exporters: [{ type: 'console', enabled: true }],
+      });
+      await provider.initialize();
+
+      await withAgentSpan(
+        {
+          agentName: 'orchestrator',
+          agentType: 'coordinator',
+          correlationId: 'req-123',
+          pipelineStage: 'planning',
+          pipelineMode: 'greenfield',
+        },
+        async (agentSpan) => {
+          // Simulate tool invocation
+          await withToolSpan(
+            {
+              toolName: 'Read',
+              parentContext: agentSpan.getContext(),
+            },
+            async (toolSpan) => {
+              toolSpan.addEvent('file_read', { path: '/test/file.ts' });
+              return 'file content';
+            }
+          );
+
+          // Simulate subagent invocation
+          const subagentContext = propagateToSubagent(agentSpan, 'task-001');
+
+          await withAgentSpan(
+            {
+              agentName: 'worker',
+              agentType: 'processor',
+              correlationId: 'req-123',
+              parentToolUseId: 'task-001',
+              parentContext: subagentContext,
+            },
+            async (workerSpan) => {
+              workerSpan.recordTokenUsage(1000, 500, 0.05);
+              return 'work completed';
+            }
+          );
+
+          agentSpan.recordTokenUsage(500, 200, 0.02);
+        }
+      );
+    });
+
+    it('should handle complex error propagation', async () => {
+      const provider = new OpenTelemetryProvider({
+        enabled: true,
+        serviceName: 'test-service',
+        exporters: [{ type: 'console', enabled: true }],
+      });
+      await provider.initialize();
+
+      await expect(
+        withAgentSpan(
+          {
+            agentName: 'orchestrator',
+            agentType: 'coordinator',
+          },
+          async (agentSpan) => {
+            await withToolSpan(
+              {
+                toolName: 'Write',
+                parentContext: agentSpan.getContext(),
+              },
+              async () => {
+                throw new Error('Write failed');
+              }
+            );
+          }
+        )
+      ).rejects.toThrow('Write failed');
+    });
+  });
+});


### PR DESCRIPTION
Closes #347

## Summary
- Add `tracing.ts` with span instrumentation helper functions
- Implement `SpanWrapper` class for convenient span lifecycle management
- Add `startAgentSpan()` and `startToolSpan()` helper functions
- Add `withAgentSpan()` and `withToolSpan()` context managers for automatic span lifecycle
- Add `propagateToSubagent()` for span context propagation across agents
- Add comprehensive unit tests (30 tests)

## Test Plan
- [x] All tracing utility tests pass (30 tests)
- [x] All existing monitoring tests pass (626 tests)
- [x] Build succeeds without errors
- [x] Verify span creation with enabled tracing
- [x] Verify graceful handling when tracing is disabled