### PR TITLE
fix(scripts): remove invalid CLI options and non-existent tools

### DIFF
--- a/.ad-sdlc/scripts/ad-sdlc-analyze-docs.sh
+++ b/.ad-sdlc/scripts/ad-sdlc-analyze-docs.sh
@@ -14,7 +14,6 @@
 #
 # Environment:
 #   ANTHROPIC_API_KEY  Required. Your Anthropic API key.
-#   MAX_TURNS          Optional. Maximum agent turns (default: 15)
 #
 
 set -euo pipefail
@@ -28,7 +27,6 @@ NC='\033[0m' # No Color
 
 # Default values
 PROJECT_PATH="${1:-.}"
-MAX_TURNS="${MAX_TURNS:-15}"
 
 # Resolve absolute path
 PROJECT_PATH="$(cd "$PROJECT_PATH" 2>/dev/null && pwd)" || {
@@ -118,8 +116,7 @@ Generate a comprehensive summary in .ad-sdlc/scratchpad/documents/current_state.
 
 If no documents are found, report that and suggest next steps." \
         --allowedTools "Read,Write,Edit,Glob,Grep,Bash(ls:*),Bash(find:*)" \
-        --output-format text \
-        --max-turns "$MAX_TURNS"
+        --output-format text
 }
 
 main "$@"

--- a/.ad-sdlc/scripts/ad-sdlc-full-pipeline.sh
+++ b/.ad-sdlc/scripts/ad-sdlc-full-pipeline.sh
@@ -23,7 +23,6 @@
 #
 # Environment:
 #   ANTHROPIC_API_KEY              Required. Your Anthropic API key.
-#   MAX_TURNS                      Optional. Maximum agent turns (default: 100)
 #   SKIP_CONFIRMATION              Optional. Skip confirmation prompts (default: false)
 #   DANGEROUSLY_SKIP_PERMISSIONS   Optional. Skip all permission prompts (default: false)
 #
@@ -44,7 +43,6 @@ NC='\033[0m' # No Color
 # Default values
 PROJECT_PATH="${1:-.}"
 MODE="${2:-auto}"
-MAX_TURNS="${MAX_TURNS:-100}"
 SKIP_CONFIRMATION="${SKIP_CONFIRMATION:-false}"
 DANGEROUSLY_SKIP_PERMISSIONS="${DANGEROUSLY_SKIP_PERMISSIONS:-false}"
 
@@ -108,7 +106,6 @@ print_header() {
     echo ""
     echo -e "  ${GREEN}Project:${NC}  $PROJECT_PATH"
     echo -e "  ${GREEN}Mode:${NC}     $MODE"
-    echo -e "  ${GREEN}Turns:${NC}    $MAX_TURNS"
     echo -e "  ${GREEN}Started:${NC}  $(date '+%Y-%m-%d %H:%M:%S')"
     echo ""
     if [[ "$DANGEROUSLY_SKIP_PERMISSIONS" == "true" ]]; then
@@ -186,9 +183,8 @@ Guidelines:
 Run fully automated without confirmation prompts."
 
     claude_args+=("$prompt")
-    claude_args+=("--allowedTools" "Read,Write,Edit,Glob,Grep,Bash,Task,LSP,WebFetch")
+    claude_args+=("--allowedTools" "Read,Write,Edit,Glob,Grep,Bash,Task,WebFetch")
     claude_args+=("--output-format" "text")
-    claude_args+=("--max-turns" "$MAX_TURNS")
 
     if [[ "$DANGEROUSLY_SKIP_PERMISSIONS" == "true" ]]; then
         claude_args+=("--dangerously-skip-permissions")

--- a/.ad-sdlc/scripts/ad-sdlc-generate-issues.sh
+++ b/.ad-sdlc/scripts/ad-sdlc-generate-issues.sh
@@ -17,7 +17,6 @@
 # Environment:
 #   ANTHROPIC_API_KEY  Required. Your Anthropic API key.
 #   GH_TOKEN           Optional. GitHub token (falls back to gh auth)
-#   MAX_TURNS          Optional. Maximum agent turns (default: 25)
 #
 
 set -euo pipefail
@@ -32,7 +31,6 @@ NC='\033[0m' # No Color
 # Default values
 PROJECT_PATH="."
 DRY_RUN=false
-MAX_TURNS="${MAX_TURNS:-25}"
 
 # Parse arguments
 while [[ $# -gt 0 ]]; do
@@ -166,8 +164,7 @@ Also save the issue list to .ad-sdlc/scratchpad/issues/generated_issues.yaml for
 
     claude -p "$prompt" \
         --allowedTools "Read,Write,Edit,Glob,Grep,Bash(gh:*),Bash(ls:*),Bash(find:*)" \
-        --output-format text \
-        --max-turns "$MAX_TURNS"
+        --output-format text
 }
 
 main "$@"

--- a/.ad-sdlc/scripts/ad-sdlc-implement.sh
+++ b/.ad-sdlc/scripts/ad-sdlc-implement.sh
@@ -18,7 +18,6 @@
 #
 # Environment:
 #   ANTHROPIC_API_KEY  Required. Your Anthropic API key.
-#   MAX_TURNS          Optional. Maximum agent turns (default: 50)
 #   SKIP_TESTS         Optional. Skip running tests (default: false)
 #
 
@@ -34,7 +33,6 @@ NC='\033[0m' # No Color
 # Default values
 PROJECT_PATH="${1:-.}"
 ISSUE_NUMBER="${2:-}"
-MAX_TURNS="${MAX_TURNS:-50}"
 SKIP_TESTS="${SKIP_TESTS:-false}"
 
 # Resolve absolute path
@@ -71,7 +69,6 @@ print_header() {
     else
         echo -e "  ${GREEN}Mode:${NC} All pending issues (P0 first)"
     fi
-    echo -e "  ${GREEN}Max Turns:${NC} $MAX_TURNS"
     echo -e "  ${GREEN}Skip Tests:${NC} $SKIP_TESTS"
     echo -e "  ${GREEN}Started:${NC} $(date '+%Y-%m-%d %H:%M:%S')"
     echo ""
@@ -160,9 +157,8 @@ Update .ad-sdlc/scratchpad/progress/ with implementation details."
     fi
 
     claude -p "$prompt" \
-        --allowedTools "Read,Write,Edit,Glob,Grep,Bash,LSP,Task" \
-        --output-format text \
-        --max-turns "$MAX_TURNS"
+        --allowedTools "Read,Write,Edit,Glob,Grep,Bash,Task" \
+        --output-format text
 }
 
 main "$@"

--- a/.ad-sdlc/scripts/ad-sdlc-init.sh
+++ b/.ad-sdlc/scripts/ad-sdlc-init.sh
@@ -14,7 +14,6 @@
 #
 # Environment:
 #   ANTHROPIC_API_KEY  Required. Your Anthropic API key.
-#   MAX_TURNS          Optional. Maximum agent turns (default: 10)
 #
 
 set -euo pipefail
@@ -28,7 +27,6 @@ NC='\033[0m' # No Color
 
 # Default values
 PROJECT_PATH="${1:-.}"
-MAX_TURNS="${MAX_TURNS:-10}"
 
 # Resolve absolute path
 PROJECT_PATH="$(cd "$PROJECT_PATH" 2>/dev/null && pwd)" || {
@@ -108,8 +106,7 @@ main() {
 
 Use the standard AD-SDLC structure and best practices." \
         --allowedTools "Read,Write,Edit,Glob,Grep,Bash(mkdir:*),Bash(cp:*),Bash(ln:*),Bash(ls:*),Bash(chmod:*)" \
-        --output-format text \
-        --max-turns "$MAX_TURNS"
+        --output-format text
 }
 
 main "$@"

--- a/docs/headless-execution.md
+++ b/docs/headless-execution.md
@@ -73,7 +73,6 @@ claude -p "Initialize AD-SDLC" \
 |------|-------|---------|---------|
 | `--print` | `-p` | Non-interactive mode (auto-exit) | `claude -p "task"` |
 | `--allowedTools` | | Pre-approve specific tools | `--allowedTools "Read,Write"` |
-| `--max-turns` | | Limit agent iterations | `--max-turns 20` |
 | `--output-format` | | Output format (text/json) | `--output-format json` |
 
 ### Additional Flags
@@ -110,13 +109,13 @@ AD-SDLC provides ready-to-use scripts in `.ad-sdlc/scripts/`:
 
 ### Script Overview
 
-| Script | Purpose | Max Turns |
-|--------|---------|-----------|
-| `ad-sdlc-init.sh` | Initialize AD-SDLC for a project | 10 |
-| `ad-sdlc-analyze-docs.sh` | Analyze existing documents | 15 |
-| `ad-sdlc-generate-issues.sh` | Generate GitHub issues from SDS | 25 |
-| `ad-sdlc-implement.sh` | Implement specific or all issues | 50 |
-| `ad-sdlc-full-pipeline.sh` | Run complete pipeline | 100 |
+| Script | Purpose |
+|--------|---------|
+| `ad-sdlc-init.sh` | Initialize AD-SDLC for a project |
+| `ad-sdlc-analyze-docs.sh` | Analyze existing documents |
+| `ad-sdlc-generate-issues.sh` | Generate GitHub issues from SDS |
+| `ad-sdlc-implement.sh` | Implement specific or all issues |
+| `ad-sdlc-full-pipeline.sh` | Run complete pipeline |
 
 ### Usage Examples
 
@@ -183,9 +182,6 @@ export ANTHROPIC_API_KEY="sk-ant-api03-..."
 ### Optional
 
 ```bash
-# Maximum agent turns (overrides script defaults)
-export MAX_TURNS=50
-
 # Skip test execution during implementation
 export SKIP_TESTS=true
 
@@ -329,17 +325,7 @@ Always preview before creating resources:
 cat .ad-sdlc/scratchpad/issues/generated_issues.yaml
 ```
 
-### 2. Use Appropriate Turn Limits
-
-| Task Type | Recommended Turns |
-|-----------|-------------------|
-| Simple init | 10-15 |
-| Document analysis | 15-20 |
-| Issue generation | 20-30 |
-| Single issue impl | 30-50 |
-| Full pipeline | 100+ |
-
-### 3. Limit Tool Permissions
+### 2. Limit Tool Permissions
 
 Only allow necessary tools:
 
@@ -351,10 +337,10 @@ Only allow necessary tools:
 --allowedTools "Read,Write,Edit,Glob,Grep"
 
 # Full development
---allowedTools "Read,Write,Edit,Glob,Grep,Bash,LSP"
+--allowedTools "Read,Write,Edit,Glob,Grep,Bash,Task"
 ```
 
-### 4. Capture Output for Debugging
+### 3. Capture Output for Debugging
 
 ```bash
 # Save output to file
@@ -364,7 +350,7 @@ Only allow necessary tools:
 claude -p "task" --output-format json > result.json
 ```
 
-### 5. Handle Interruptions
+### 4. Handle Interruptions
 
 ```bash
 # Resume interrupted session
@@ -409,13 +395,10 @@ npx @anthropic-ai/claude-code -p "task"
 
 ### Pipeline Timeout
 
-Increase max turns or break into smaller tasks:
+Break into smaller tasks if timeout occurs:
 
 ```bash
-# Higher turn limit
-MAX_TURNS=150 ./.ad-sdlc/scripts/ad-sdlc-full-pipeline.sh
-
-# Or run stages separately
+# Run stages separately
 ./.ad-sdlc/scripts/ad-sdlc-analyze-docs.sh
 ./.ad-sdlc/scripts/ad-sdlc-generate-issues.sh
 ./.ad-sdlc/scripts/ad-sdlc-implement.sh


### PR DESCRIPTION
## Summary
- Remove `--max-turns` option from all 5 headless scripts (not a valid Claude CLI option)
- Remove `LSP` from `--allowedTools` in ad-sdlc-implement.sh and ad-sdlc-full-pipeline.sh (tool does not exist)
- Update docs/headless-execution.md to reflect correct CLI options
- Remove `MAX_TURNS` environment variable references from scripts

## Test Plan
- [x] All 5 bash scripts pass syntax validation (`bash -n`)
- [x] Verified `--max-turns` removed from all scripts
- [x] Verified `LSP` removed from all `--allowedTools` lists
- [x] Documentation updated to reflect correct CLI options

Closes #401