### PR TITLE
refactor(scripts): extract common functions to shared library

### DIFF
--- a/.ad-sdlc/scripts/ad-sdlc-analyze-docs.sh
+++ b/.ad-sdlc/scripts/ad-sdlc-analyze-docs.sh
@@ -18,82 +18,30 @@
 
 set -euo pipefail
 
-# Colors for output
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-BLUE='\033[0;34m'
-NC='\033[0m' # No Color
+# Source common library
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/common.sh"
 
 # Default values
 PROJECT_PATH="${1:-.}"
 
 # Resolve absolute path
-PROJECT_PATH="$(cd "$PROJECT_PATH" 2>/dev/null && pwd)" || {
-    echo -e "${RED}Error: Directory does not exist: $1${NC}" >&2
-    exit 1
-}
+PROJECT_PATH="$(resolve_path "$PROJECT_PATH")" || exit 1
 
-# Check for required environment
-check_environment() {
-    if [[ -z "${ANTHROPIC_API_KEY:-}" ]]; then
-        echo -e "${RED}Error: ANTHROPIC_API_KEY environment variable is not set${NC}" >&2
-        echo "Please set your API key: export ANTHROPIC_API_KEY=\"your-key\"" >&2
-        exit 1
-    fi
-
-    if ! command -v claude &>/dev/null; then
-        echo -e "${RED}Error: 'claude' CLI is not installed${NC}" >&2
-        echo "Please install: npm install -g @anthropic-ai/claude-code" >&2
-        exit 1
-    fi
-}
-
-# Print header
-print_header() {
-    echo ""
-    echo -e "${BLUE}======================================"
-    echo -e "  AD-SDLC Document Analysis"
-    echo -e "======================================${NC}"
-    echo ""
-    echo -e "  ${GREEN}Project:${NC} $PROJECT_PATH"
-    echo -e "  ${GREEN}Started:${NC} $(date '+%Y-%m-%d %H:%M:%S')"
-    echo ""
-}
-
-# Print footer
-print_footer() {
-    local exit_code=$?
-    echo ""
-    if [[ $exit_code -eq 0 ]]; then
-        echo -e "${GREEN}======================================"
-        echo -e "  Document Analysis Complete"
-        echo -e "======================================${NC}"
-        echo ""
-        echo -e "  ${GREEN}Finished:${NC} $(date '+%Y-%m-%d %H:%M:%S')"
-        echo ""
-        echo "Generated files:"
-        echo "  - .ad-sdlc/scratchpad/documents/current_state.yaml"
-        echo ""
-        echo "Next steps:"
-        echo "  1. Review the analysis summary"
-        echo "  2. Run: ./ad-sdlc-generate-issues.sh"
-        echo ""
-    else
-        echo -e "${RED}======================================"
-        echo -e "  Document Analysis Failed (exit code: $exit_code)"
-        echo -e "======================================${NC}"
-        echo ""
-        echo "Check the output above for error details."
-        echo ""
-    fi
+# Footer trap function
+_print_footer() {
+    print_footer_with_files "Document Analysis Complete" \
+        ".ad-sdlc/scratchpad/documents/current_state.yaml" \
+        -- \
+        "1. Review the analysis summary" \
+        "2. Run: ./ad-sdlc-generate-issues.sh"
 }
 
 # Main execution
 main() {
     check_environment
-    print_header
-    trap print_footer EXIT
+    print_header "AD-SDLC Document Analysis" "$PROJECT_PATH"
+    trap _print_footer EXIT
 
     cd "$PROJECT_PATH"
 

--- a/.ad-sdlc/scripts/ad-sdlc-implement.sh
+++ b/.ad-sdlc/scripts/ad-sdlc-implement.sh
@@ -23,12 +23,9 @@
 
 set -euo pipefail
 
-# Colors for output
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-BLUE='\033[0;34m'
-NC='\033[0m' # No Color
+# Source common library
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/common.sh"
 
 # Default values
 PROJECT_PATH="${1:-.}"
@@ -36,79 +33,30 @@ ISSUE_NUMBER="${2:-}"
 SKIP_TESTS="${SKIP_TESTS:-false}"
 
 # Resolve absolute path
-PROJECT_PATH="$(cd "$PROJECT_PATH" 2>/dev/null && pwd)" || {
-    echo -e "${RED}Error: Directory does not exist: $1${NC}" >&2
-    exit 1
-}
+PROJECT_PATH="$(resolve_path "$PROJECT_PATH")" || exit 1
 
-# Check for required environment
-check_environment() {
-    if [[ -z "${ANTHROPIC_API_KEY:-}" ]]; then
-        echo -e "${RED}Error: ANTHROPIC_API_KEY environment variable is not set${NC}" >&2
-        echo "Please set your API key: export ANTHROPIC_API_KEY=\"your-key\"" >&2
-        exit 1
-    fi
-
-    if ! command -v claude &>/dev/null; then
-        echo -e "${RED}Error: 'claude' CLI is not installed${NC}" >&2
-        echo "Please install: npm install -g @anthropic-ai/claude-code" >&2
-        exit 1
-    fi
-}
-
-# Print header
-print_header() {
-    echo ""
-    echo -e "${BLUE}======================================"
-    echo -e "  AD-SDLC Implementation"
-    echo -e "======================================${NC}"
-    echo ""
-    echo -e "  ${GREEN}Project:${NC} $PROJECT_PATH"
-    if [[ -n "$ISSUE_NUMBER" ]]; then
-        echo -e "  ${GREEN}Issue:${NC} #$ISSUE_NUMBER"
-    else
-        echo -e "  ${GREEN}Mode:${NC} All pending issues (P0 first)"
-    fi
-    echo -e "  ${GREEN}Skip Tests:${NC} $SKIP_TESTS"
-    echo -e "  ${GREEN}Started:${NC} $(date '+%Y-%m-%d %H:%M:%S')"
-    echo ""
-}
-
-# Print footer
-print_footer() {
-    local exit_code=$?
-    echo ""
-    if [[ $exit_code -eq 0 ]]; then
-        echo -e "${GREEN}======================================"
-        echo -e "  Implementation Complete"
-        echo -e "======================================${NC}"
-        echo ""
-        echo -e "  ${GREEN}Finished:${NC} $(date '+%Y-%m-%d %H:%M:%S')"
-        echo ""
-        echo "Next steps:"
-        echo "  1. Review changes: git diff"
-        echo "  2. Run tests: npm test (or your test command)"
-        echo "  3. Create PR: gh pr create"
-        echo ""
-    else
-        echo -e "${RED}======================================"
-        echo -e "  Implementation Failed (exit code: $exit_code)"
-        echo -e "======================================${NC}"
-        echo ""
-        echo "Check the output above for error details."
-        echo "You may need to:"
-        echo "  1. Review partial changes: git diff"
-        echo "  2. Fix issues manually"
-        echo "  3. Re-run the script"
-        echo ""
-    fi
+# Footer trap function
+_print_footer() {
+    print_footer_with_recovery "Implementation Complete" \
+        "1. Review partial changes: git diff" \
+        "2. Fix issues manually" \
+        "3. Re-run the script"
 }
 
 # Main execution
 main() {
     check_environment
-    print_header
-    trap print_footer EXIT
+
+    local extra_lines=()
+    if [[ -n "$ISSUE_NUMBER" ]]; then
+        extra_lines+=("${GREEN}Issue:${NC} #$ISSUE_NUMBER")
+    else
+        extra_lines+=("${GREEN}Mode:${NC} All pending issues (P0 first)")
+    fi
+    extra_lines+=("${GREEN}Skip Tests:${NC} $SKIP_TESTS")
+
+    print_header "AD-SDLC Implementation" "$PROJECT_PATH" "${extra_lines[@]}"
+    trap _print_footer EXIT
 
     cd "$PROJECT_PATH"
 

--- a/.ad-sdlc/scripts/common.sh
+++ b/.ad-sdlc/scripts/common.sh
@@ -1,0 +1,259 @@
+#!/usr/bin/env bash
+#
+# AD-SDLC Common Script Library
+# Shared functions for headless execution scripts.
+#
+# Usage: source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
+#
+# Version: 1.0.0
+
+# Prevent double-sourcing
+[[ -n "${_ADSDLC_COMMON_LOADED:-}" ]] && return 0
+readonly _ADSDLC_COMMON_LOADED=1
+
+# =============================================================================
+# Color Definitions
+# =============================================================================
+readonly RED='\033[0;31m'
+readonly GREEN='\033[0;32m'
+readonly YELLOW='\033[1;33m'
+readonly BLUE='\033[0;34m'
+readonly MAGENTA='\033[0;35m'
+readonly NC='\033[0m'  # No Color
+
+# =============================================================================
+# Logging Functions
+# =============================================================================
+
+# Log informational message
+# Usage: log_info "message"
+log_info() {
+    echo -e "${GREEN}[INFO]${NC} $*"
+}
+
+# Log warning message (to stderr)
+# Usage: log_warn "message"
+log_warn() {
+    echo -e "${YELLOW}[WARN]${NC} $*" >&2
+}
+
+# Log error message (to stderr)
+# Usage: log_error "message"
+log_error() {
+    echo -e "${RED}[ERROR]${NC} $*" >&2
+}
+
+# =============================================================================
+# Utility Functions
+# =============================================================================
+
+# Check if a command exists
+# Usage: require_command "cmd" ["install hint"]
+# Returns: 0 if exists, 1 if not
+require_command() {
+    local cmd="$1"
+    local install_hint="${2:-}"
+    if ! command -v "$cmd" &>/dev/null; then
+        log_error "'$cmd' is not installed"
+        [[ -n "$install_hint" ]] && echo "$install_hint" >&2
+        return 1
+    fi
+    return 0
+}
+
+# Resolve path to absolute path with error handling
+# Usage: resolve_path "path"
+# Returns: Absolute path or exits with error
+resolve_path() {
+    local path="$1"
+    local resolved
+    resolved="$(cd "$path" 2>/dev/null && pwd)" || {
+        log_error "Directory does not exist: $path"
+        return 1
+    }
+    echo "$resolved"
+}
+
+# =============================================================================
+# Environment Check Functions
+# =============================================================================
+
+# Check AD-SDLC environment requirements
+# Usage: check_environment
+check_environment() {
+    if [[ -z "${ANTHROPIC_API_KEY:-}" ]]; then
+        log_error "ANTHROPIC_API_KEY environment variable is not set"
+        echo "Please set your API key: export ANTHROPIC_API_KEY=\"your-key\"" >&2
+        exit 1
+    fi
+
+    require_command "claude" "Please install: npm install -g @anthropic-ai/claude-code" || exit 1
+}
+
+# =============================================================================
+# Header/Footer Functions
+# =============================================================================
+
+# Print script header with standard style
+# Usage: print_header "Script Title" "project_path" ["extra_line1" "extra_line2" ...]
+print_header() {
+    local title="$1"
+    local project_path="$2"
+    shift 2
+    local extra_lines=("$@")
+
+    echo ""
+    echo -e "${BLUE}======================================"
+    echo -e "  $title"
+    echo -e "======================================${NC}"
+    echo ""
+    echo -e "  ${GREEN}Project:${NC} $project_path"
+    for line in "${extra_lines[@]}"; do
+        echo -e "  $line"
+    done
+    echo -e "  ${GREEN}Started:${NC} $(date '+%Y-%m-%d %H:%M:%S')"
+    echo ""
+}
+
+# Print script header with magenta box style (for full pipeline)
+# Usage: print_header_box "Script Title" "project_path" ["extra_line1" "extra_line2" ...]
+print_header_box() {
+    local title="$1"
+    local project_path="$2"
+    shift 2
+    local extra_lines=("$@")
+
+    echo ""
+    echo -e "${MAGENTA}======================================"
+    echo -e "  $title"
+    echo -e "======================================${NC}"
+    echo ""
+    echo -e "  ${GREEN}Project:${NC}  $project_path"
+    for line in "${extra_lines[@]}"; do
+        echo -e "  $line"
+    done
+    echo -e "  ${GREEN}Started:${NC}  $(date '+%Y-%m-%d %H:%M:%S')"
+    echo ""
+}
+
+# Print script footer with success message and next steps
+# Usage: print_footer "Success Title" ["next_step1" "next_step2" ...]
+# Note: Call from EXIT trap. Uses $? to determine success/failure
+print_footer() {
+    local exit_code=$?
+    local success_title="${1:-Complete}"
+    shift
+    local next_steps=("$@")
+
+    echo ""
+    if [[ $exit_code -eq 0 ]]; then
+        echo -e "${GREEN}======================================"
+        echo -e "  $success_title"
+        echo -e "======================================${NC}"
+        echo ""
+        echo -e "  ${GREEN}Finished:${NC} $(date '+%Y-%m-%d %H:%M:%S')"
+        if [[ ${#next_steps[@]} -gt 0 ]]; then
+            echo ""
+            echo "Next steps:"
+            for step in "${next_steps[@]}"; do
+                echo "  $step"
+            done
+        fi
+        echo ""
+    else
+        echo -e "${RED}======================================"
+        echo -e "  Failed (exit code: $exit_code)"
+        echo -e "======================================${NC}"
+        echo ""
+        echo "Check the output above for error details."
+        echo ""
+    fi
+}
+
+# Print script footer with generated files list
+# Usage: print_footer_with_files "Success Title" "file1" "file2" ... -- "next_step1" "next_step2" ...
+# Note: Use -- to separate files from next steps
+print_footer_with_files() {
+    local exit_code=$?
+    local success_title="${1:-Complete}"
+    shift
+
+    local files=()
+    local next_steps=()
+    local in_files=true
+
+    for arg in "$@"; do
+        if [[ "$arg" == "--" ]]; then
+            in_files=false
+            continue
+        fi
+        if [[ "$in_files" == "true" ]]; then
+            files+=("$arg")
+        else
+            next_steps+=("$arg")
+        fi
+    done
+
+    echo ""
+    if [[ $exit_code -eq 0 ]]; then
+        echo -e "${GREEN}======================================"
+        echo -e "  $success_title"
+        echo -e "======================================${NC}"
+        echo ""
+        echo -e "  ${GREEN}Finished:${NC} $(date '+%Y-%m-%d %H:%M:%S')"
+        if [[ ${#files[@]} -gt 0 ]]; then
+            echo ""
+            echo "Generated files:"
+            for file in "${files[@]}"; do
+                echo "  - $file"
+            done
+        fi
+        if [[ ${#next_steps[@]} -gt 0 ]]; then
+            echo ""
+            echo "Next steps:"
+            for step in "${next_steps[@]}"; do
+                echo "  $step"
+            done
+        fi
+        echo ""
+    else
+        echo -e "${RED}======================================"
+        echo -e "  Failed (exit code: $exit_code)"
+        echo -e "======================================${NC}"
+        echo ""
+        echo "Check the output above for error details."
+        echo ""
+    fi
+}
+
+# Print script footer with failure recovery tips
+# Usage: print_footer_with_recovery "Success Title" "recovery_tip1" "recovery_tip2" ...
+print_footer_with_recovery() {
+    local exit_code=$?
+    local success_title="${1:-Complete}"
+    shift
+    local recovery_tips=("$@")
+
+    echo ""
+    if [[ $exit_code -eq 0 ]]; then
+        echo -e "${GREEN}======================================"
+        echo -e "  $success_title"
+        echo -e "======================================${NC}"
+        echo ""
+        echo -e "  ${GREEN}Finished:${NC} $(date '+%Y-%m-%d %H:%M:%S')"
+        echo ""
+    else
+        echo -e "${RED}======================================"
+        echo -e "  Failed (exit code: $exit_code)"
+        echo -e "======================================${NC}"
+        echo ""
+        echo "Check the output above for error details."
+        if [[ ${#recovery_tips[@]} -gt 0 ]]; then
+            echo "You may need to:"
+            for tip in "${recovery_tips[@]}"; do
+                echo "  $tip"
+            done
+        fi
+        echo ""
+    fi
+}

--- a/scripts/init-project.sh
+++ b/scripts/init-project.sh
@@ -17,11 +17,19 @@
 
 set -euo pipefail
 
-# Colors for output
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-NC='\033[0m' # No Color
+# Source common library (relative path from scripts/ to .ad-sdlc/scripts/)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+COMMON_LIB="$SCRIPT_DIR/../.ad-sdlc/scripts/common.sh"
+
+if [[ -f "$COMMON_LIB" ]]; then
+    source "$COMMON_LIB"
+else
+    # Fallback color definitions if common.sh not available
+    RED='\033[0;31m'
+    GREEN='\033[0;32m'
+    YELLOW='\033[1;33m'
+    NC='\033[0m'
+fi
 
 # Parse arguments
 TARGET_PATH="${1:-.}"
@@ -44,9 +52,9 @@ create_dir() {
     local dir="$1"
     if [[ ! -d "$dir" ]]; then
         mkdir -p "$dir"
-        echo -e "  ${GREEN}✓${NC} Created: $dir"
+        echo -e "  ${GREEN}+${NC} Created: $dir"
     else
-        echo -e "  ${YELLOW}○${NC} Exists:  $dir"
+        echo -e "  ${YELLOW}o${NC} Exists:  $dir"
     fi
 }
 
@@ -56,9 +64,9 @@ create_placeholder() {
     local content="${2:-# Placeholder file}"
     if [[ ! -f "$file" ]]; then
         echo "$content" > "$file"
-        echo -e "  ${GREEN}✓${NC} Created: $file"
+        echo -e "  ${GREEN}+${NC} Created: $file"
     else
-        echo -e "  ${YELLOW}○${NC} Exists:  $file"
+        echo -e "  ${YELLOW}o${NC} Exists:  $file"
     fi
 }
 
@@ -66,17 +74,17 @@ echo "Creating directory structure..."
 echo ""
 
 # .claude directory
-echo "📁 .claude/"
+echo ".claude/"
 create_dir "$PROJECT_ROOT/.claude/agents"
 
 # .ad-sdlc directory
-echo "📁 .ad-sdlc/"
+echo ".ad-sdlc/"
 create_dir "$PROJECT_ROOT/.ad-sdlc/config"
 create_dir "$PROJECT_ROOT/.ad-sdlc/logs/agent-logs"
 create_dir "$PROJECT_ROOT/.ad-sdlc/templates"
 
 # Scratchpad directories
-echo "📁 .ad-sdlc/scratchpad/"
+echo ".ad-sdlc/scratchpad/"
 create_dir "$PROJECT_ROOT/.ad-sdlc/scratchpad/info/$PROJECT_ID"
 create_dir "$PROJECT_ROOT/.ad-sdlc/scratchpad/documents/$PROJECT_ID"
 create_dir "$PROJECT_ROOT/.ad-sdlc/scratchpad/issues/$PROJECT_ID"
@@ -85,7 +93,7 @@ create_dir "$PROJECT_ROOT/.ad-sdlc/scratchpad/progress/$PROJECT_ID/results"
 create_dir "$PROJECT_ROOT/.ad-sdlc/scratchpad/progress/$PROJECT_ID/reviews"
 
 # docs directory
-echo "📁 docs/"
+echo "docs/"
 create_dir "$PROJECT_ROOT/docs/prd"
 create_dir "$PROJECT_ROOT/docs/srs"
 create_dir "$PROJECT_ROOT/docs/sds"
@@ -93,11 +101,11 @@ create_dir "$PROJECT_ROOT/docs/guides"
 create_dir "$PROJECT_ROOT/docs/reference"
 
 # src directory
-echo "📁 src/"
+echo "src/"
 create_dir "$PROJECT_ROOT/src"
 
 # scripts directory
-echo "📁 scripts/"
+echo "scripts/"
 create_dir "$PROJECT_ROOT/scripts"
 
 echo ""


### PR DESCRIPTION
## Summary
- Create `common.sh` shared library with reusable functions for AD-SDLC scripts
- Extract duplicated color definitions, logging, environment checks, and header/footer functions
- Update all 6 scripts to source the common library
- Reduce code duplication by approximately 200 lines

## What
### Common Library (`common.sh`)
| Category | Functions |
|----------|-----------|
| Colors | `RED`, `GREEN`, `YELLOW`, `BLUE`, `MAGENTA`, `NC` |
| Logging | `log_info()`, `log_warn()`, `log_error()` |
| Utilities | `require_command()`, `resolve_path()` |
| Environment | `check_environment()` |
| Headers/Footers | `print_header()`, `print_header_box()`, `print_footer()`, `print_footer_with_files()`, `print_footer_with_recovery()` |

### Updated Scripts
- `.ad-sdlc/scripts/ad-sdlc-init.sh`
- `.ad-sdlc/scripts/ad-sdlc-analyze-docs.sh`
- `.ad-sdlc/scripts/ad-sdlc-generate-issues.sh`
- `.ad-sdlc/scripts/ad-sdlc-implement.sh`
- `.ad-sdlc/scripts/ad-sdlc-full-pipeline.sh`
- `scripts/init-project.sh` (with fallback if common.sh not found)

## Why
- Duplicated code across 6 scripts (~250-300 lines total)
- Maintenance burden: changes to common functionality required editing multiple files
- Risk of inconsistencies between scripts

## Test Plan
- [x] All scripts pass bash syntax check (`bash -n`)
- [x] `init-project.sh` executes successfully with common.sh sourced
- [x] Scripts work correctly after refactoring

Closes #403