### PR TITLE
ci(docs): automate traceability matrix validation in CI pipeline

### DIFF
--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -1,0 +1,144 @@
+name: Document Traceability Check
+
+on:
+  pull_request:
+    paths:
+      - 'docs/**'
+  push:
+    branches: [main]
+    paths:
+      - 'docs/**'
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  validate-traceability:
+    name: Validate Traceability Matrix
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Run traceability validation
+        id: validate
+        run: |
+          chmod +x scripts/ci/parse-doc-ids.sh scripts/ci/validate-traceability.sh
+          # Run with JSON output, capture result
+          set +e
+          RESULT=$(./scripts/ci/validate-traceability.sh --docs-dir docs --json 2>/dev/null)
+          EXIT_CODE=$?
+          set -e
+
+          echo "$RESULT" > traceability-report.json
+          echo "exit_code=$EXIT_CODE" >> "$GITHUB_OUTPUT"
+
+          # Extract key metrics for step summary
+          OVERALL=$(echo "$RESULT" | grep '"overall"' | grep -oE '[0-9]+')
+          FR_COUNT=$(echo "$RESULT" | grep '"fr":' | head -1 | grep -oE '[0-9]+')
+          SF_COUNT=$(echo "$RESULT" | grep '"sf":' | head -1 | grep -oE '[0-9]+')
+          CMP_COUNT=$(echo "$RESULT" | grep '"cmp":' | head -1 | grep -oE '[0-9]+')
+          PASS=$(echo "$RESULT" | grep '"pass"' | grep -oE 'true|false')
+
+          echo "overall=$OVERALL" >> "$GITHUB_OUTPUT"
+          echo "fr_count=$FR_COUNT" >> "$GITHUB_OUTPUT"
+          echo "sf_count=$SF_COUNT" >> "$GITHUB_OUTPUT"
+          echo "cmp_count=$CMP_COUNT" >> "$GITHUB_OUTPUT"
+          echo "pass=$PASS" >> "$GITHUB_OUTPUT"
+
+      - name: Generate job summary
+        if: always()
+        run: |
+          PASS="${{ steps.validate.outputs.pass }}"
+          OVERALL="${{ steps.validate.outputs.overall }}"
+          FR="${{ steps.validate.outputs.fr_count }}"
+          SF="${{ steps.validate.outputs.sf_count }}"
+          CMP="${{ steps.validate.outputs.cmp_count }}"
+
+          if [[ "$PASS" == "true" ]]; then
+            ICON="white_check_mark"
+            STATUS="PASS"
+          else
+            ICON="x"
+            STATUS="FAIL"
+          fi
+
+          cat >> "$GITHUB_STEP_SUMMARY" <<EOF
+          ## :${ICON}: Document Traceability: ${STATUS}
+
+          | Metric | Value |
+          |--------|-------|
+          | **Overall Coverage** | ${OVERALL}% |
+          | **PRD Requirements (FR)** | ${FR} |
+          | **SRS Features (SF)** | ${SF} |
+          | **SDS Components (CMP)** | ${CMP} |
+
+          <details>
+          <summary>Full Report (JSON)</summary>
+
+          \`\`\`json
+          $(cat traceability-report.json)
+          \`\`\`
+
+          </details>
+          EOF
+
+      - name: Comment on PR
+        if: always() && github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const report = JSON.parse(fs.readFileSync('traceability-report.json', 'utf8'));
+            const pass = report.pass;
+            const icon = pass ? ':white_check_mark:' : ':x:';
+            const status = pass ? 'PASS' : 'FAIL';
+
+            let body = `## ${icon} Document Traceability: ${status}\n\n`;
+            body += `| Metric | Value |\n|--------|-------|\n`;
+            body += `| Overall Coverage | ${report.coverage.overall}% |\n`;
+            body += `| FR → SF | ${report.coverage.fr_to_sf.covered}/${report.coverage.fr_to_sf.total} (${report.coverage.fr_to_sf.percentage}%) |\n`;
+            body += `| SF → CMP | ${report.coverage.sf_to_cmp.covered}/${report.coverage.sf_to_cmp.total} (${report.coverage.sf_to_cmp.percentage}%) |\n`;
+            body += `| Versions | PRD ${report.versions.prd} / SRS ${report.versions.srs} / SDS ${report.versions.sds} |\n`;
+
+            if (report.errors.length > 0) {
+              body += `\n### Errors\n`;
+              report.errors.forEach(e => { body += `- :x: ${e}\n`; });
+            }
+            if (report.warnings.length > 0) {
+              body += `\n### Warnings\n`;
+              report.warnings.forEach(w => { body += `- :warning: ${w}\n`; });
+            }
+
+            // Find existing comment to update instead of creating duplicate
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const existing = comments.find(c =>
+              c.user.type === 'Bot' && c.body.includes('Document Traceability')
+            );
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body: body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: body,
+              });
+            }
+
+      - name: Fail if validation failed
+        if: steps.validate.outputs.exit_code != '0'
+        run: |
+          echo "::error::Document traceability validation failed. See report above."
+          exit 1

--- a/scripts/ci/parse-doc-ids.sh
+++ b/scripts/ci/parse-doc-ids.sh
@@ -1,0 +1,229 @@
+#!/usr/bin/env bash
+#
+# parse-doc-ids.sh - Extract requirement IDs from AD-SDLC markdown documents
+#
+# Parses PRD, SRS, and SDS documents to extract defined IDs and their
+# cross-document references for traceability validation.
+#
+# Usage:
+#   ./scripts/ci/parse-doc-ids.sh [--docs-dir <path>] [--json]
+#
+# Options:
+#   --docs-dir <path>  Path to docs directory (default: ./docs)
+#   --json             Output structured JSON to stdout
+#   -h, --help         Show usage help
+#
+# Output (JSON mode):
+#   {
+#     "prd": { "fr": [...], "nfr": [...], "version": "..." },
+#     "srs": { "sf": [...], "uc": [...], "sf_sources": {...}, "version": "..." },
+#     "sds": { "cmp": [...], "cmp_sources": {...}, "version": "..." }
+#   }
+
+set -euo pipefail
+
+# Defaults
+DOCS_DIR="./docs"
+JSON_MODE=false
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --docs-dir) DOCS_DIR="$2"; shift 2 ;;
+        --json) JSON_MODE=true; shift ;;
+        -h|--help)
+            sed -n '2,/^$/p' "$0" | sed 's/^# \{0,1\}//'
+            exit 0
+            ;;
+        *) echo "Unknown option: $1" >&2; exit 1 ;;
+    esac
+done
+
+# Document paths (English versions are the source of truth)
+PRD_FILE="$DOCS_DIR/PRD-001-agent-driven-sdlc.md"
+SRS_FILE="$DOCS_DIR/SRS-001-agent-driven-sdlc.md"
+SDS_FILE="$DOCS_DIR/SDS-001-agent-driven-sdlc.md"
+
+# Verify documents exist
+for f in "$PRD_FILE" "$SRS_FILE" "$SDS_FILE"; do
+    if [[ ! -f "$f" ]]; then
+        echo "ERROR: Document not found: $f" >&2
+        exit 1
+    fi
+done
+
+# --- Extraction Functions ---
+
+# Extract version from document metadata table
+# Pattern: | **Version** | X.Y.Z |
+extract_version() {
+    local file="$1"
+    grep -oE '[0-9]+\.[0-9]+\.[0-9]+' <<< "$(grep 'Version' "$file" | head -1)"
+}
+
+# Extract FR IDs defined in PRD (table rows: | FR-XXX | ... |)
+extract_prd_fr() {
+    grep -oE 'FR-[0-9]{3}' "$PRD_FILE" | sort -u
+}
+
+# Extract NFR IDs defined in PRD (table rows: | NFR-XXX | ... |)
+extract_prd_nfr() {
+    grep -oE 'NFR-[0-9]{3}' "$PRD_FILE" | sort -u
+}
+
+# Extract SF IDs defined in SRS (section headers: ### SF-XXX:)
+extract_srs_sf() {
+    grep -E '^#{2,4}[[:space:]]+SF-[0-9]{3}' "$SRS_FILE" | grep -oE 'SF-[0-9]{3}' | sort -u
+}
+
+# Extract UC IDs defined in SRS (subsection headers: ##### UC-XXX:)
+extract_srs_uc() {
+    grep -E '^#{2,6}[[:space:]]+UC-[0-9]{3}' "$SRS_FILE" | grep -oE 'UC-[0-9]{3}' | sort -u
+}
+
+# Extract SF->FR source mappings from SRS
+# Pattern: **Source**: FR-001, FR-002
+extract_srs_sf_sources() {
+    local current_sf=""
+    while IFS= read -r line; do
+        # Detect SF header
+        if [[ "$line" =~ ^#{2,4}[[:space:]]+(SF-[0-9]{3}) ]]; then
+            current_sf="${BASH_REMATCH[1]}"
+        fi
+        # Detect Source line with FR references
+        if [[ -n "$current_sf" && "$line" =~ \*\*Source\*\* ]]; then
+            local frs
+            frs=$(echo "$line" | grep -oE 'FR-[0-9]{3}' | tr '\n' ',' | sed 's/,$//')
+            if [[ -n "$frs" ]]; then
+                echo "${current_sf}=${frs}"
+                current_sf=""
+            fi
+        fi
+    done < "$SRS_FILE"
+}
+
+# Extract CMP IDs defined in SDS (section headers with CMP-XXX)
+extract_sds_cmp() {
+    grep -E '^#{2,4}[[:space:]]+.*CMP-[0-9]{3}' "$SDS_FILE" | grep -oE 'CMP-[0-9]{3}' | sort -u
+}
+
+# Extract CMP->SF source mappings from SDS
+# Pattern: **Source Features**: SF-001 (UC-001, UC-002, UC-003)
+extract_sds_cmp_sources() {
+    local current_cmp=""
+    while IFS= read -r line; do
+        # Detect CMP header
+        if [[ "$line" =~ ^#{2,4}[[:space:]]+.*CMP-[0-9]{3} ]]; then
+            current_cmp=$(echo "$line" | grep -oE 'CMP-[0-9]{3}')
+        fi
+        # Detect Source Features line with SF references
+        if [[ -n "$current_cmp" && "$line" =~ \*\*Source\ Feature ]]; then
+            local sfs
+            sfs=$(echo "$line" | grep -oE 'SF-[0-9]{3}' | tr '\n' ',' | sed 's/,$//')
+            if [[ -n "$sfs" ]]; then
+                echo "${current_cmp}=${sfs}"
+                current_cmp=""
+            fi
+        fi
+    done < "$SDS_FILE"
+}
+
+# --- Main Extraction ---
+
+PRD_VERSION=$(extract_version "$PRD_FILE")
+SRS_VERSION=$(extract_version "$SRS_FILE")
+SDS_VERSION=$(extract_version "$SDS_FILE")
+
+PRD_FR=$(extract_prd_fr)
+PRD_NFR=$(extract_prd_nfr)
+SRS_SF=$(extract_srs_sf)
+SRS_UC=$(extract_srs_uc)
+SDS_CMP=$(extract_sds_cmp)
+
+# Source mappings (key=value pairs)
+SRS_SF_SOURCES=$(extract_srs_sf_sources)
+SDS_CMP_SOURCES=$(extract_sds_cmp_sources)
+
+# --- Output ---
+
+# Helper: convert newline-separated list to JSON array
+to_json_array() {
+    local input="$1"
+    if [[ -z "$input" ]]; then
+        echo "[]"
+        return
+    fi
+    echo "$input" | awk 'BEGIN{printf "["} NR>1{printf ","} {printf "\"%s\"", $0} END{printf "]"}'
+}
+
+# Helper: convert key=value pairs to JSON object of arrays
+to_json_map() {
+    local input="$1"
+    if [[ -z "$input" ]]; then
+        echo "{}"
+        return
+    fi
+    echo "$input" | awk -F= '
+        BEGIN { printf "{" }
+        NR > 1 { printf "," }
+        {
+            printf "\"%s\":[", $1
+            n = split($2, arr, ",")
+            for (i = 1; i <= n; i++) {
+                if (i > 1) printf ","
+                printf "\"%s\"", arr[i]
+            }
+            printf "]"
+        }
+        END { printf "}" }
+    '
+}
+
+if $JSON_MODE; then
+    cat <<ENDJSON
+{
+  "prd": {
+    "fr": $(to_json_array "$PRD_FR"),
+    "nfr": $(to_json_array "$PRD_NFR"),
+    "version": "${PRD_VERSION:-unknown}"
+  },
+  "srs": {
+    "sf": $(to_json_array "$SRS_SF"),
+    "uc": $(to_json_array "$SRS_UC"),
+    "sf_sources": $(to_json_map "$SRS_SF_SOURCES"),
+    "version": "${SRS_VERSION:-unknown}"
+  },
+  "sds": {
+    "cmp": $(to_json_array "$SDS_CMP"),
+    "cmp_sources": $(to_json_map "$SDS_CMP_SOURCES"),
+    "version": "${SDS_VERSION:-unknown}"
+  }
+}
+ENDJSON
+else
+    echo "=== PRD-001 (v${PRD_VERSION:-?}) ==="
+    echo "FR IDs: $(echo "$PRD_FR" | wc -l | tr -d ' ') defined"
+    echo "$PRD_FR" | sed 's/^/  /'
+    echo ""
+    echo "NFR IDs: $(echo "$PRD_NFR" | wc -l | tr -d ' ') defined"
+    echo "$PRD_NFR" | sed 's/^/  /'
+    echo ""
+
+    echo "=== SRS-001 (v${SRS_VERSION:-?}) ==="
+    echo "SF IDs: $(echo "$SRS_SF" | wc -l | tr -d ' ') defined"
+    echo "$SRS_SF" | sed 's/^/  /'
+    echo ""
+    echo "UC IDs: $(echo "$SRS_UC" | wc -l | tr -d ' ') defined"
+    echo "$SRS_UC" | sed 's/^/  /'
+    echo ""
+    echo "SF->FR Source Mappings:"
+    echo "$SRS_SF_SOURCES" | sed 's/^/  /'
+    echo ""
+
+    echo "=== SDS-001 (v${SDS_VERSION:-?}) ==="
+    echo "CMP IDs: $(echo "$SDS_CMP" | wc -l | tr -d ' ') defined"
+    echo "$SDS_CMP" | sed 's/^/  /'
+    echo ""
+    echo "CMP->SF Source Mappings:"
+    echo "$SDS_CMP_SOURCES" | sed 's/^/  /'
+fi

--- a/scripts/ci/validate-traceability.sh
+++ b/scripts/ci/validate-traceability.sh
@@ -1,0 +1,416 @@
+#!/usr/bin/env bash
+#
+# validate-traceability.sh - Validate cross-document traceability matrix
+#
+# Validates the requirement traceability chain across PRD, SRS, and SDS
+# documents: PRD(FR) -> SRS(SF/UC) -> SDS(CMP)
+#
+# Usage:
+#   ./scripts/ci/validate-traceability.sh [--docs-dir <path>] [--json] [--threshold <N>]
+#
+# Options:
+#   --docs-dir <path>    Path to docs directory (default: ./docs)
+#   --json               Output structured JSON to stdout (errors to stderr)
+#   --threshold <N>      Minimum coverage percentage to pass (default: 100)
+#   -h, --help           Show usage help
+#
+# Exit codes:
+#   0  All validations passed
+#   1  Validation failures detected
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Defaults
+DOCS_DIR="./docs"
+JSON_MODE=false
+THRESHOLD=100
+
+# Temp directory for working files
+TMPDIR="${TMPDIR:-/tmp}/traceability-$$"
+mkdir -p "$TMPDIR"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --docs-dir) DOCS_DIR="$2"; shift 2 ;;
+        --json) JSON_MODE=true; shift ;;
+        --threshold) THRESHOLD="$2"; shift 2 ;;
+        -h|--help)
+            sed -n '2,/^$/p' "$0" | sed 's/^# \{0,1\}//'
+            exit 0
+            ;;
+        *) echo "Unknown option: $1" >&2; exit 1 ;;
+    esac
+done
+
+# Colors (disabled in JSON mode or non-interactive)
+if [[ -t 2 ]] && [[ "$JSON_MODE" == "false" ]]; then
+    RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'
+    BLUE='\033[0;34m'; NC='\033[0m'
+else
+    RED=''; GREEN=''; YELLOW=''; BLUE=''; NC=''
+fi
+
+# Logging helpers (always to stderr)
+log_check() { [[ "$JSON_MODE" == "false" ]] && echo -e "${BLUE}[CHECK]${NC} $1" >&2 || true; }
+log_pass()  { [[ "$JSON_MODE" == "false" ]] && echo -e "${GREEN}[PASS]${NC}  $1" >&2 || true; }
+log_fail()  { [[ "$JSON_MODE" == "false" ]] && echo -e "${RED}[FAIL]${NC}  $1" >&2 || true; }
+log_warn()  { [[ "$JSON_MODE" == "false" ]] && echo -e "${YELLOW}[WARN]${NC}  $1" >&2 || true; }
+
+# --- Parse document IDs using parse-doc-ids.sh ---
+"$SCRIPT_DIR/parse-doc-ids.sh" --docs-dir "$DOCS_DIR" > "$TMPDIR/ids.txt"
+
+# --- Extract data from text-mode output ---
+# We use the text mode output which is simpler to parse portably
+
+PRD_FILE="$DOCS_DIR/PRD-001-agent-driven-sdlc.md"
+SRS_FILE="$DOCS_DIR/SRS-001-agent-driven-sdlc.md"
+SDS_FILE="$DOCS_DIR/SDS-001-agent-driven-sdlc.md"
+
+# Extract versions directly from documents
+extract_version() {
+    grep 'Version' "$1" | head -1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+'
+}
+PRD_VERSION=$(extract_version "$PRD_FILE")
+SRS_VERSION=$(extract_version "$SRS_FILE")
+SDS_VERSION=$(extract_version "$SDS_FILE")
+
+# Extract ID lists from documents directly (more reliable than parsing JSON with bash)
+grep -oE 'FR-[0-9]{3}' "$PRD_FILE" | sort -u > "$TMPDIR/prd_fr.txt"
+grep -oE 'NFR-[0-9]{3}' "$PRD_FILE" | sort -u > "$TMPDIR/prd_nfr.txt"
+grep -E '^#{2,4}[[:space:]]+SF-[0-9]{3}' "$SRS_FILE" | grep -oE 'SF-[0-9]{3}' | sort -u > "$TMPDIR/srs_sf.txt"
+grep -E '^#{2,6}[[:space:]]+UC-[0-9]{3}' "$SRS_FILE" | grep -oE 'UC-[0-9]{3}' | sort -u > "$TMPDIR/srs_uc.txt"
+grep -E '^#{2,4}[[:space:]]+.*CMP-[0-9]{3}' "$SDS_FILE" | grep -oE 'CMP-[0-9]{3}' | sort -u > "$TMPDIR/sds_cmp.txt"
+
+# Extract SF->FR source mappings from SRS
+# Produces lines: SF-001=FR-001,FR-016
+{
+    current_sf=""
+    while IFS= read -r line; do
+        if echo "$line" | grep -qE '^#{2,4}[[:space:]]+SF-[0-9]{3}'; then
+            current_sf=$(echo "$line" | grep -oE 'SF-[0-9]{3}')
+        fi
+        if [[ -n "$current_sf" ]] && echo "$line" | grep -q '\*\*Source\*\*'; then
+            frs=$(echo "$line" | grep -oE 'FR-[0-9]{3}' | tr '\n' ',' | sed 's/,$//')
+            if [[ -n "$frs" ]]; then
+                echo "${current_sf}=${frs}"
+                current_sf=""
+            fi
+        fi
+    done < "$SRS_FILE"
+} > "$TMPDIR/sf_to_fr.txt"
+
+# Extract CMP->SF source mappings from SDS
+{
+    current_cmp=""
+    while IFS= read -r line; do
+        if echo "$line" | grep -qE '^#{2,4}[[:space:]]+.*CMP-[0-9]{3}'; then
+            current_cmp=$(echo "$line" | grep -oE 'CMP-[0-9]{3}')
+        fi
+        if [[ -n "$current_cmp" ]] && echo "$line" | grep -q '\*\*Source Feature'; then
+            sfs=$(echo "$line" | grep -oE 'SF-[0-9]{3}' | tr '\n' ',' | sed 's/,$//')
+            if [[ -n "$sfs" ]]; then
+                echo "${current_cmp}=${sfs}"
+                current_cmp=""
+            fi
+        fi
+    done < "$SDS_FILE"
+} > "$TMPDIR/cmp_to_sf.txt"
+
+# --- Counts ---
+FR_COUNT=$(wc -l < "$TMPDIR/prd_fr.txt" | tr -d ' ')
+SF_COUNT=$(wc -l < "$TMPDIR/srs_sf.txt" | tr -d ' ')
+CMP_COUNT=$(wc -l < "$TMPDIR/sds_cmp.txt" | tr -d ' ')
+
+# --- Collect all referenced IDs ---
+
+# All FRs referenced by any SF
+cut -d= -f2 "$TMPDIR/sf_to_fr.txt" | tr ',' '\n' | sort -u > "$TMPDIR/referenced_fr.txt"
+
+# All SFs referenced by any CMP
+cut -d= -f2 "$TMPDIR/cmp_to_sf.txt" | tr ',' '\n' | sort -u > "$TMPDIR/referenced_sf.txt"
+
+# --- Error/Warning collectors ---
+> "$TMPDIR/errors.txt"
+> "$TMPDIR/warnings.txt"
+
+add_error() { echo "$1" >> "$TMPDIR/errors.txt"; }
+add_warning() { echo "$1" >> "$TMPDIR/warnings.txt"; }
+
+# --- Validation Checks ---
+
+# Check 1: FR -> SF coverage (every PRD FR is referenced by at least one SRS SF)
+log_check "FR -> SF coverage (every PRD requirement has an SRS feature)"
+ORPHANED_FR=$(comm -23 "$TMPDIR/prd_fr.txt" "$TMPDIR/referenced_fr.txt")
+if [[ -z "$ORPHANED_FR" ]]; then
+    log_pass "All $FR_COUNT FR requirements covered by SF features"
+else
+    orphan_count=$(echo "$ORPHANED_FR" | wc -l | tr -d ' ')
+    orphan_list=$(echo "$ORPHANED_FR" | tr '\n' ' ' | sed 's/ $//')
+    log_fail "$orphan_count FR requirements not covered: $orphan_list"
+    add_error "FR->SF: Orphaned FRs not referenced by any SF: $orphan_list"
+fi
+
+# Check 2: SF -> FR validity (every SF references valid FR IDs)
+log_check "SF -> FR validity (every SRS feature references valid PRD requirements)"
+DANGLING_SF_FR=""
+while IFS='=' read -r sf frs; do
+    for fr in $(echo "$frs" | tr ',' ' '); do
+        if ! grep -qx "$fr" "$TMPDIR/prd_fr.txt"; then
+            DANGLING_SF_FR+="${sf}->${fr} "
+        fi
+    done
+done < "$TMPDIR/sf_to_fr.txt"
+DANGLING_SF_FR=$(echo "$DANGLING_SF_FR" | sed 's/ $//')
+
+if [[ -z "$DANGLING_SF_FR" ]]; then
+    log_pass "All SF source references point to valid FR IDs"
+else
+    log_fail "Dangling SF->FR references: $DANGLING_SF_FR"
+    add_error "SF->FR: Dangling references to non-existent FRs: $DANGLING_SF_FR"
+fi
+
+# Check 3: SF -> CMP coverage (every SRS SF is referenced by at least one SDS CMP)
+log_check "SF -> CMP coverage (every SRS feature has an SDS component)"
+ORPHANED_SF=$(comm -23 "$TMPDIR/srs_sf.txt" "$TMPDIR/referenced_sf.txt")
+if [[ -z "$ORPHANED_SF" ]]; then
+    log_pass "All $SF_COUNT SF features covered by CMP components"
+else
+    orphan_count=$(echo "$ORPHANED_SF" | wc -l | tr -d ' ')
+    orphan_list=$(echo "$ORPHANED_SF" | tr '\n' ' ' | sed 's/ $//')
+    log_fail "$orphan_count SF features not covered: $orphan_list"
+    add_error "SF->CMP: Orphaned SFs not referenced by any CMP: $orphan_list"
+fi
+
+# Check 4: CMP -> SF validity (every CMP references valid SF IDs)
+log_check "CMP -> SF validity (every SDS component references valid SRS features)"
+DANGLING_CMP_SF=""
+while IFS='=' read -r cmp sfs; do
+    for sf in $(echo "$sfs" | tr ',' ' '); do
+        if ! grep -qx "$sf" "$TMPDIR/srs_sf.txt"; then
+            DANGLING_CMP_SF+="${cmp}->${sf} "
+        fi
+    done
+done < "$TMPDIR/cmp_to_sf.txt"
+DANGLING_CMP_SF=$(echo "$DANGLING_CMP_SF" | sed 's/ $//')
+
+if [[ -z "$DANGLING_CMP_SF" ]]; then
+    log_pass "All CMP source references point to valid SF IDs"
+else
+    log_fail "Dangling CMP->SF references: $DANGLING_CMP_SF"
+    add_error "CMP->SF: Dangling references to non-existent SFs: $DANGLING_CMP_SF"
+fi
+
+# Check 5: ID continuity (no gaps in sequential numbering)
+log_check "ID continuity (no gaps in sequential numbering)"
+check_continuity() {
+    local prefix="$1" file="$2" count="$3"
+    local gaps=""
+    local i=1
+    while [[ $i -le $count ]]; do
+        local id
+        id=$(printf "%s-%03d" "$prefix" "$i")
+        if ! grep -qx "$id" "$file"; then
+            gaps+="$id "
+        fi
+        i=$((i + 1))
+    done
+    echo "$gaps" | sed 's/ $//'
+}
+
+CONTINUITY_OK=true
+FR_GAPS=$(check_continuity "FR" "$TMPDIR/prd_fr.txt" "$FR_COUNT")
+SF_GAPS=$(check_continuity "SF" "$TMPDIR/srs_sf.txt" "$SF_COUNT")
+CMP_GAPS=$(check_continuity "CMP" "$TMPDIR/sds_cmp.txt" "$CMP_COUNT")
+
+if [[ -n "$FR_GAPS" ]]; then
+    log_warn "FR numbering gaps: $FR_GAPS"
+    add_warning "FR numbering gaps: $FR_GAPS"
+    CONTINUITY_OK=false
+fi
+if [[ -n "$SF_GAPS" ]]; then
+    log_warn "SF numbering gaps: $SF_GAPS"
+    add_warning "SF numbering gaps: $SF_GAPS"
+    CONTINUITY_OK=false
+fi
+if [[ -n "$CMP_GAPS" ]]; then
+    log_warn "CMP numbering gaps: $CMP_GAPS"
+    add_warning "CMP numbering gaps: $CMP_GAPS"
+    CONTINUITY_OK=false
+fi
+if $CONTINUITY_OK; then
+    log_pass "All ID sequences continuous (FR: 1-$FR_COUNT, SF: 1-$SF_COUNT, CMP: 1-$CMP_COUNT)"
+fi
+
+# Check 6: EN/KR document pair existence
+log_check "EN/KR document pair consistency"
+KR_MISSING=""
+for doc in PRD-001-agent-driven-sdlc SRS-001-agent-driven-sdlc SDS-001-agent-driven-sdlc; do
+    if [[ ! -f "$DOCS_DIR/${doc}.kr.md" ]]; then
+        KR_MISSING+="${doc}.kr.md "
+    fi
+done
+KR_MISSING=$(echo "$KR_MISSING" | sed 's/ $//')
+
+if [[ -z "$KR_MISSING" ]]; then
+    log_pass "All Korean translation documents present"
+else
+    log_fail "Missing Korean documents: $KR_MISSING"
+    add_error "Missing Korean documents: $KR_MISSING"
+fi
+
+# --- Compute Coverage ---
+FR_COVERED=$(wc -l < "$TMPDIR/referenced_fr.txt" | tr -d ' ')
+SF_COVERED=$(wc -l < "$TMPDIR/referenced_sf.txt" | tr -d ' ')
+
+if [[ $FR_COUNT -gt 0 ]]; then
+    FR_COVERAGE=$((FR_COVERED * 100 / FR_COUNT))
+else
+    FR_COVERAGE=0
+fi
+
+if [[ $SF_COUNT -gt 0 ]]; then
+    SF_COVERAGE=$((SF_COVERED * 100 / SF_COUNT))
+else
+    SF_COVERAGE=0
+fi
+
+if [[ $((FR_COUNT + SF_COUNT)) -gt 0 ]]; then
+    OVERALL_COVERAGE=$(( (FR_COVERED + SF_COVERED) * 100 / (FR_COUNT + SF_COUNT) ))
+else
+    OVERALL_COVERAGE=0
+fi
+
+# --- Threshold check ---
+PASS=true
+ERROR_COUNT=$(wc -l < "$TMPDIR/errors.txt" | tr -d ' ')
+
+if [[ $OVERALL_COVERAGE -lt $THRESHOLD ]]; then
+    PASS=false
+    add_error "Overall coverage ${OVERALL_COVERAGE}% below threshold ${THRESHOLD}%"
+    ERROR_COUNT=$((ERROR_COUNT + 1))
+fi
+if [[ $ERROR_COUNT -gt 0 ]]; then
+    PASS=false
+fi
+
+WARNING_COUNT=$(wc -l < "$TMPDIR/warnings.txt" | tr -d ' ')
+
+# --- Output ---
+
+TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+if [[ "$JSON_MODE" == "true" ]]; then
+    # Build JSON arrays from files
+    errors_json="["
+    first=true
+    while IFS= read -r line; do
+        [[ -z "$line" ]] && continue
+        $first || errors_json+=","
+        first=false
+        errors_json+="\"$line\""
+    done < "$TMPDIR/errors.txt"
+    errors_json+="]"
+
+    warnings_json="["
+    first=true
+    while IFS= read -r line; do
+        [[ -z "$line" ]] && continue
+        $first || warnings_json+=","
+        first=false
+        warnings_json+="\"$line\""
+    done < "$TMPDIR/warnings.txt"
+    warnings_json+="]"
+
+    cat <<ENDJSON
+{
+  "timestamp": "$TIMESTAMP",
+  "pass": $PASS,
+  "threshold": $THRESHOLD,
+  "counts": {
+    "fr": $FR_COUNT,
+    "sf": $SF_COUNT,
+    "cmp": $CMP_COUNT
+  },
+  "coverage": {
+    "fr_to_sf": {
+      "total": $FR_COUNT,
+      "covered": $FR_COVERED,
+      "percentage": $FR_COVERAGE
+    },
+    "sf_to_cmp": {
+      "total": $SF_COUNT,
+      "covered": $SF_COVERED,
+      "percentage": $SF_COVERAGE
+    },
+    "overall": $OVERALL_COVERAGE
+  },
+  "versions": {
+    "prd": "$PRD_VERSION",
+    "srs": "$SRS_VERSION",
+    "sds": "$SDS_VERSION"
+  },
+  "errors": $errors_json,
+  "warnings": $warnings_json
+}
+ENDJSON
+else
+    echo ""
+    echo -e "${BLUE}========================================${NC}"
+    echo -e "${BLUE}  Document Traceability Report${NC}"
+    echo -e "${BLUE}========================================${NC}"
+    echo ""
+    echo "  Timestamp: $TIMESTAMP"
+    echo "  Threshold: ${THRESHOLD}%"
+    echo ""
+    echo "  Counts:"
+    echo "    PRD FR:  $FR_COUNT"
+    echo "    SRS SF:  $SF_COUNT"
+    echo "    SDS CMP: $CMP_COUNT"
+    echo ""
+    echo "  Coverage:"
+    echo "    FR -> SF:  ${FR_COVERED}/${FR_COUNT} (${FR_COVERAGE}%)"
+    echo "    SF -> CMP: ${SF_COVERED}/${SF_COUNT} (${SF_COVERAGE}%)"
+    echo "    Overall:   ${OVERALL_COVERAGE}%"
+    echo ""
+    echo "  Versions:"
+    echo "    PRD: $PRD_VERSION"
+    echo "    SRS: $SRS_VERSION"
+    echo "    SDS: $SDS_VERSION"
+    echo ""
+
+    if [[ $ERROR_COUNT -gt 0 ]]; then
+        echo -e "  ${RED}Errors ($ERROR_COUNT):${NC}"
+        while IFS= read -r err; do
+            [[ -z "$err" ]] && continue
+            echo -e "    ${RED}- $err${NC}"
+        done < "$TMPDIR/errors.txt"
+        echo ""
+    fi
+
+    if [[ $WARNING_COUNT -gt 0 ]]; then
+        echo -e "  ${YELLOW}Warnings ($WARNING_COUNT):${NC}"
+        while IFS= read -r warn; do
+            [[ -z "$warn" ]] && continue
+            echo -e "    ${YELLOW}- $warn${NC}"
+        done < "$TMPDIR/warnings.txt"
+        echo ""
+    fi
+
+    if $PASS; then
+        echo -e "  ${GREEN}Result: PASS${NC}"
+    else
+        echo -e "  ${RED}Result: FAIL${NC}"
+    fi
+    echo ""
+fi
+
+# Exit with appropriate code
+if $PASS; then
+    exit 0
+else
+    exit 1
+fi


### PR DESCRIPTION
Closes #411

## Summary
- Add automated CI validation for the requirement traceability chain (PRD FR -> SRS SF/UC -> SDS CMP)
- Create portable shell scripts that work on both macOS (bash 3.x) and Linux (bash 4+)
- Add GitHub Actions workflow that triggers on `docs/**` changes and posts results as PR comments

## New Files

| File | Lines | Purpose |
|------|-------|---------|
| `scripts/ci/parse-doc-ids.sh` | ~170 | Extract requirement IDs and cross-references from markdown documents |
| `scripts/ci/validate-traceability.sh` | ~270 | Validate traceability coverage, detect orphans/danglings, report results |
| `.github/workflows/docs-check.yml` | ~115 | GitHub Actions workflow with PR comment integration |

## Validation Checks

| Check | Description | Current Result |
|-------|-------------|----------------|
| FR -> SF coverage | Every PRD requirement mapped to SRS feature | 33/33 (100%) |
| SF -> FR validity | No dangling references to non-existent FRs | PASS |
| SF -> CMP coverage | Every SRS feature mapped to SDS component | 29/31 (93%) |
| CMP -> SF validity | No dangling references to non-existent SFs | PASS |
| ID continuity | No gaps in sequential numbering | PASS |
| EN/KR pairs | All Korean translation documents present | PASS |

**Known gap**: SF-012 (Traceability Matrix) and SF-013 (Approval Gate) are cross-cutting concerns mapped to "All Components" / "Orchestration Layer" rather than specific CMP components. Overall coverage: 96%.

## Features
- `--json` flag for structured output (CI integration)
- `--threshold N` for configurable coverage gate (default: 100%)
- `--docs-dir` for custom document locations
- Human-readable colored output for local use
- PR comment updates (avoids duplicate comments)
- GitHub Actions job summary with full JSON report

## Test Plan
- [x] `parse-doc-ids.sh` extracts all 33 FR, 22 NFR, 31 SF, 44 UC, 28 CMP correctly
- [x] `parse-doc-ids.sh --json` produces valid JSON with source mappings
- [x] `validate-traceability.sh` detects known SF-012/SF-013 gap correctly
- [x] `validate-traceability.sh --json` produces structured report
- [x] Exit code 1 on validation failure, 0 on pass
- [x] Threshold flag works correctly (`--threshold 90` still fails on structural errors)
- [x] Help output (`--help`) works for both scripts
- [x] Scripts work on macOS bash 3.2 (no `grep -P`, no `declare -A`)