### PR TITLE
docs(prd): align FR-009 and FR-010 agent assignment with SDS

### DIFF
--- a/docs/PRD-001-agent-driven-sdlc.kr.md
+++ b/docs/PRD-001-agent-driven-sdlc.kr.md
@@ -856,8 +856,8 @@ Review Checklist:
 
 | Req ID | Requirement | Priority | Agent(s) |
 |--------|-------------|----------|----------|
-| FR-009 | 문서 간 추적성 매트릭스 유지 | P1 | All |
-| FR-010 | 각 단계별 사용자 승인 게이트 | P1 | All |
+| FR-009 | 문서 간 추적성 매트릭스 유지 | P1 | Orchestrator |
+| FR-010 | 각 단계별 사용자 승인 게이트 | P1 | Orchestrator |
 | FR-011 | 작업 진행률 실시간 모니터링 | P1 | Controller |
 | FR-012 | 실패 시 자동 재시도 (최대 3회) | P1 | Worker, PR Review |
 | FR-013 | 에이전트 활동 로깅 및 감사 추적 | P1 | All |

--- a/docs/PRD-001-agent-driven-sdlc.md
+++ b/docs/PRD-001-agent-driven-sdlc.md
@@ -861,8 +861,8 @@ Review Checklist:
 
 | Req ID | Requirement | Priority | Agent(s) |
 |--------|-------------|----------|----------|
-| FR-009 | Maintain traceability matrix between documents | P1 | All |
-| FR-010 | User approval gate at each stage | P1 | All |
+| FR-009 | Maintain traceability matrix between documents | P1 | Orchestrator |
+| FR-010 | User approval gate at each stage | P1 | Orchestrator |
 | FR-011 | Real-time work progress monitoring | P1 | Controller |
 | FR-012 | Auto-retry on failure (max 3 times) | P1 | Worker, PR Review |
 | FR-013 | Agent activity logging and audit trail | P1 | All |

--- a/docs/api/_media/PRD-001-agent-driven-sdlc.kr.md
+++ b/docs/api/_media/PRD-001-agent-driven-sdlc.kr.md
@@ -856,8 +856,8 @@ Review Checklist:
 
 | Req ID | Requirement | Priority | Agent(s) |
 |--------|-------------|----------|----------|
-| FR-009 | 문서 간 추적성 매트릭스 유지 | P1 | All |
-| FR-010 | 각 단계별 사용자 승인 게이트 | P1 | All |
+| FR-009 | 문서 간 추적성 매트릭스 유지 | P1 | Orchestrator |
+| FR-010 | 각 단계별 사용자 승인 게이트 | P1 | Orchestrator |
 | FR-011 | 작업 진행률 실시간 모니터링 | P1 | Controller |
 | FR-012 | 실패 시 자동 재시도 (최대 3회) | P1 | Worker, PR Review |
 | FR-013 | 에이전트 활동 로깅 및 감사 추적 | P1 | All |

--- a/docs/api/_media/PRD-001-agent-driven-sdlc.md
+++ b/docs/api/_media/PRD-001-agent-driven-sdlc.md
@@ -861,8 +861,8 @@ Review Checklist:
 
 | Req ID | Requirement | Priority | Agent(s) |
 |--------|-------------|----------|----------|
-| FR-009 | Maintain traceability matrix between documents | P1 | All |
-| FR-010 | User approval gate at each stage | P1 | All |
+| FR-009 | Maintain traceability matrix between documents | P1 | Orchestrator |
+| FR-010 | User approval gate at each stage | P1 | Orchestrator |
 | FR-011 | Real-time work progress monitoring | P1 | Controller |
 | FR-012 | Auto-retry on failure (max 3 times) | P1 | Worker, PR Review |
 | FR-013 | Agent activity logging and audit trail | P1 | All |


### PR DESCRIPTION
## Summary
- Update FR-009 (Traceability Matrix) and FR-010 (Approval Gates) agent assignment from generic "All" to "Orchestrator"
- Aligns PRD with CMP-025 (AD-SDLC Orchestrator) mapping established in SDS via #415
- Updates EN/KR primary documents and `docs/api/_media/` mirror copies
- Cascade update triggered by Document Cascade Check on #415

## Context
The cascade check introduced in #415 correctly flagged PRD-001 as needing review after SDS-001 was modified. This follow-up PR addresses that review item.

## Test Plan
- [x] `validate-traceability.sh` passes with 100% coverage
- [x] All 4 PRD files (EN/KR primary + mirrors) updated consistently