### PR TITLE
docs(readme): add Document Status Definitions to reference section

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,7 @@ your-project/
 ### Reference
 
 - [System Architecture](docs/system-architecture.md)
+- [Document Status Definitions](docs/DOCUMENT_STATUS_DEFINITIONS.md)
 - [PRD-001: Agent-Driven SDLC](docs/PRD-001-agent-driven-sdlc.md)
 - [SRS-001: Agent-Driven SDLC](docs/SRS-001-agent-driven-sdlc.md)
 - [SDS-001: Agent-Driven SDLC](docs/SDS-001-agent-driven-sdlc.md)


### PR DESCRIPTION
Follow-up to #417

## Summary
- Add link to `docs/DOCUMENT_STATUS_DEFINITIONS.md` in the README Documentation > Reference section
- Placed between System Architecture and PRD-001 so readers encounter status semantics before individual documents

## Context
This commit was part of the original #413 work but was pushed after PR #417 was already merged. This follow-up PR brings the README in sync.

## Test Plan
- [x] Verify README link resolves to the existing `DOCUMENT_STATUS_DEFINITIONS.md`
- [x] Confirm link ordering in Reference section is logical