### PR TITLE
test(orchestrator): add CMP-025 integration tests and register in agents barrel

### DIFF
--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -727,6 +727,9 @@ export * as CIFixer from '../ci-fixer/index.js';
 // PR Reviewer
 export * as PRReviewer from '../pr-reviewer/index.js';
 
+// AD-SDLC Orchestrator - top-level pipeline coordinator
+export * as AdsdlcOrchestrator from '../ad-sdlc-orchestrator/index.js';
+
 // GitHub Repo Setup - has conflicts with repo-detector (visibility, session types)
 export * as GitHubRepoSetup from '../github-repo-setup/index.js';
 


### PR DESCRIPTION
## Summary

- Register `AdsdlcOrchestrator` namespace export in `src/agents/index.ts` for unified agent access
- Add comprehensive integration tests for pipeline dependency chain validation:
  - Topological order validation for all 3 pipelines (Greenfield, Enhancement, Import)
  - Circular dependency detection
  - End-to-end stage sequencing with `OrderTrackingOrchestrator` subclass
  - Cross-pipeline agent type consistency verification
  - Module registration source-level validation

Closes #435

## Changes

| File | Change |
|------|--------|
| `src/agents/index.ts` | Add `AdsdlcOrchestrator` namespace export |
| `tests/ad-sdlc-orchestrator/AdsdlcOrchestratorAgent.test.ts` | Add 14 integration tests (78 total) |

## Test Plan

- [x] All 78 orchestrator tests pass locally
- [x] Prettier formatting applied
- [x] CI passes (Security Scan, Lint, Test, Build)