### PR TITLE
docs(prd): bump PRD-001 to v1.1.0 and align with SRS/SDS versions

### DIFF
--- a/docs/PRD-001-agent-driven-sdlc.kr.md
+++ b/docs/PRD-001-agent-driven-sdlc.kr.md
@@ -5,9 +5,9 @@
 | Field | Value |
 |-------|-------|
 | **Document ID** | PRD-001 |
-| **Version** | 1.0.0 |
+| **Version** | 1.1.0 |
 | **Status** | Review |
-| **Implementation** | Not Started |
+| **Implementation** | Partial |
 | **Created** | 2025-12-27 |
 | **Author** | System Architect |
 
@@ -38,7 +38,7 @@
 **Agent-Driven SDLC (AD-SDLC)** - 에이전트 기반 소프트웨어 개발 생명주기 자동화 시스템
 
 ### 1.2 Overview
-AD-SDLC는 Claude Agent SDK를 기반으로 구축된 멀티 에이전트 시스템으로, 소프트웨어 개발의 전체 생명주기를 자동화합니다. Greenfield, Enhancement, Import 세 가지 파이프라인 모드에 걸쳐 25개의 특화된 에이전트가 사용자의 초기 요구사항부터 PRD, SRS, SDS 작성, GitHub Issue 생성, 코드 구현, PR 검토까지 전 과정을 처리합니다.
+AD-SDLC는 Claude Agent SDK를 기반으로 구축된 멀티 에이전트 시스템으로, 소프트웨어 개발의 전체 생명주기를 자동화합니다. Greenfield, Enhancement, Import 세 가지 파이프라인 모드에 걸쳐 25개의 특화된 에이전트와 3개의 인프라 서비스(총 28개 컴포넌트)가 사용자의 초기 요구사항부터 PRD, SRS, SDS 작성, GitHub Issue 생성, 코드 구현, PR 검토까지 전 과정을 처리합니다.
 
 ### 1.3 Key Value Propositions
 - **End-to-End 자동화**: 요구사항 수집부터 코드 배포까지 전 과정 자동화
@@ -1317,6 +1317,7 @@ Validation Gates:
 | Version | Date | Author | Changes |
 |---------|------|--------|---------|
 | 1.0.0 | 2025-12-27 | System Architect | Initial draft |
+| 1.1.0 | 2026-02-07 | System Architect | Enhancement Pipeline features (FR-017~FR-033), correct agent count to 28 total components |
 
 ---
 

--- a/docs/PRD-001-agent-driven-sdlc.md
+++ b/docs/PRD-001-agent-driven-sdlc.md
@@ -5,9 +5,9 @@
 | Field | Value |
 |-------|-------|
 | **Document ID** | PRD-001 |
-| **Version** | 1.0.0 |
+| **Version** | 1.1.0 |
 | **Status** | Review |
-| **Implementation** | Not Started |
+| **Implementation** | Partial |
 | **Created** | 2025-12-27 |
 | **Author** | System Architect |
 
@@ -38,7 +38,7 @@
 **Agent-Driven SDLC (AD-SDLC)** - Agent-Based Software Development Lifecycle Automation System
 
 ### 1.2 Overview
-AD-SDLC is a multi-agent system built on the Claude Agent SDK that automates the entire software development lifecycle. The system comprises 25 specialized agents across three pipeline modes (Greenfield, Enhancement, Import), covering the full process from initial user requirements through PRD, SRS, SDS creation, GitHub Issue generation, code implementation, and PR review.
+AD-SDLC is a multi-agent system built on the Claude Agent SDK that automates the entire software development lifecycle. The system comprises 25 specialized agents and 3 infrastructure services (28 total components) across three pipeline modes (Greenfield, Enhancement, Import), covering the full process from initial user requirements through PRD, SRS, SDS creation, GitHub Issue generation, code implementation, and PR review.
 
 ### 1.3 Key Value Propositions
 - **End-to-End Automation**: Full process automation from requirements gathering to code deployment
@@ -1322,6 +1322,7 @@ Validation Gates:
 | Version | Date | Author | Changes |
 |---------|------|--------|---------|
 | 1.0.0 | 2025-12-27 | System Architect | Initial draft |
+| 1.1.0 | 2026-02-07 | System Architect | Enhancement Pipeline features (FR-017~FR-033), correct agent count to 28 total components |
 
 ---
 


### PR DESCRIPTION
## Summary
- Bump PRD-001 version from 1.0.0 to 1.1.0 to align with SRS-001 and SDS-001
- Update Implementation status from "Not Started" to "Partial"
- Correct Section 1.2 agent count: "25 specialized agents" → "25 specialized agents + 3 infrastructure services (28 total components)"
- Add version history entry for 2026-02-07 Enhancement Pipeline addition (FR-017~FR-033)
- Apply identical changes to Korean version (PRD-001-agent-driven-sdlc.kr.md)

## Motivation
PRD-001 was at version 1.0.0 while SRS-001 and SDS-001 were both at 1.1.0, creating a version chain inconsistency across the document hierarchy. The Enhancement Pipeline features were added to SRS/SDS on 2026-02-07 but PRD was not updated.

## Version Alignment
| Document | Before | After |
|----------|--------|-------|
| PRD-001 | 1.0.0 | **1.1.0** |
| SRS-001 | 1.1.0 | 1.1.0 (no change) |
| SDS-001 | 1.1.0 | 1.1.0 (no change) |

## Test Plan
- [x] English PRD metadata updated (version, implementation status)
- [x] Korean PRD metadata updated (version, implementation status)
- [x] Section 1.2 agent count corrected in both versions
- [x] Version history entry added in both versions
- [x] No other files modified

Closes #426