### PR TITLE
fix(config): correct test_framework from jest to vitest in workflow.yaml

### DIFF
--- a/.ad-sdlc/config/workflow.yaml
+++ b/.ad-sdlc/config/workflow.yaml
@@ -582,7 +582,7 @@ agents:
       - Grep
     coding:
       language: "typescript"  # Adjust per project
-      test_framework: "jest"
+      test_framework: "vitest"
       lint_command: "npm run lint"
       test_command: "npm test"
       build_command: "npm run build"


### PR DESCRIPTION
## Summary
- Fix `test_framework` configuration from `"jest"` to `"vitest"` in `.ad-sdlc/config/workflow.yaml` (line 585)
- Verified no other jest references exist in `.ad-sdlc/` configuration directory

## Motivation
The worker agent (CMP-007) uses `coding.test_framework` to determine which test framework syntax to generate. With the incorrect `jest` value, the agent would produce `jest.fn()`, `jest.spyOn()`, and jest-style imports instead of the correct `vi.fn()`, `vi.spyOn()`, and vitest patterns used by the project.

## Configuration Change
| Setting | Before | After |
|---------|--------|-------|
| `agents.worker.coding.test_framework` | `jest` | `vitest` |

## Test Plan
- [x] Verified `test_framework` changed to `"vitest"` at line 585
- [x] Searched `.ad-sdlc/` directory for remaining jest references (none found)
- [x] Confirmed project uses vitest (`vitest.config.ts`, `vi.fn()`, `vi.spyOn()`)

Closes #428