### PR TITLE
refactor(agent): add missing agent exports to agents/index.ts

### DIFF
--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -739,3 +739,13 @@ export * as GitHubRepoSetup from '../github-repo-setup/index.js';
 // Project Initializer - already exported individually via control-plane,
 // so use namespace to avoid duplicate export conflicts in src/index.ts
 export * as ProjectInit from '../project-initializer/index.js';
+
+// Controller - has conflicts with many modules (Priority, CircularDependencyError, DependencyEdge, etc.)
+export * as Controller from '../controller/index.js';
+
+// Mode Detector - has conflicts with repo-detector (DetectionStatus, DetectionStats, ProjectNotFoundError)
+// and control-plane exports ModeDetector class individually, so use short namespace
+export * as ModeDetect from '../mode-detector/index.js';
+
+// Analysis Orchestrator - has conflicts with mode-detector, impact-analyzer (NoActiveSessionError, etc.)
+export * as AnalysisOrchestrator from '../analysis-orchestrator/index.js';


### PR DESCRIPTION
## Summary
- Add namespace exports for three implemented agent modules missing from the central agent registry
- **Controller** (CMP-006): worker pool management, priority analysis, progress monitoring
- **ModeDetect** (CMP-024): pipeline mode detection (Greenfield vs Enhancement)
- **AnalysisOrchestrator** (CMP-026): analysis pipeline coordination
- Uses short namespace `ModeDetect` to avoid TS2308 conflict with `ModeDetector` class exported via control-plane

Closes #427

## Test Plan
- [x] Build succeeds with `npm run build`
- [x] All 4989 tests pass with `npm test`
- [x] Lint shows 0 errors
- [x] No naming conflicts with existing exports