### PR TITLE
docs(sds): add CMP-033~CMP-036 component definitions and update traceability matrix

### DIFF
--- a/docs/SDS-001-agent-driven-sdlc.kr.md
+++ b/docs/SDS-001-agent-driven-sdlc.kr.md
@@ -3310,7 +3310,7 @@ interface TelemetryEvent {
 
 #### 3.14.6 CMP-034: Security Module
 
-**Source Features**: Cross-cutting (NFR — 보안 요구사항)
+**Applicability**: Cross-cutting (NFR — 보안 요구사항)
 **Responsibility**: AD-SDLC 시스템을 위한 종합적 보안 인프라를 제공합니다. 입력 검증, 경로 새니타이즈, 심볼릭 링크 해석, 화이트리스트 기반 명령어 새니타이즈, 속도 제한, 감사 로깅, 보안 파일 작업, 시크릿 관리를 포함합니다. 상태를 유지하지 않는 라이브러리 컬렉션입니다(IAgent 구현이 아님).
 
 ```typescript
@@ -3495,7 +3495,7 @@ interface PipelineStage {
 
 #### 3.14.8 CMP-036: Completion Generator
 
-**Source Features**: CLI Tooling (독립 유틸리티)
+**Applicability**: CLI Tooling (독립 유틸리티)
 **Responsibility**: AD-SDLC CLI를 위한 쉘별 자동완성 스크립트를 생성합니다. bash, zsh, fish 쉘을 지원합니다. 등록된 CLI 명령어 정의(서브커맨드, 옵션, 값 열거 포함)를 기반으로 완성 스크립트를 생성합니다. 각 쉘 유형에 대한 설치 지침을 제공합니다. 독립 싱글톤입니다(IAgent 구현이 아님).
 
 ```typescript

--- a/docs/SDS-001-agent-driven-sdlc.md
+++ b/docs/SDS-001-agent-driven-sdlc.md
@@ -3313,7 +3313,7 @@ interface TelemetryEvent {
 
 #### 3.14.6 CMP-034: Security Module
 
-**Source Features**: Cross-cutting (NFR — security requirements)
+**Applicability**: Cross-cutting (NFR — security requirements)
 **Responsibility**: Provides comprehensive security infrastructure for the AD-SDLC system including input validation, path sanitization, symlink resolution, command sanitization with whitelist enforcement, rate limiting, audit logging, secure file operations, and secret management. This is a stateless library collection (not an IAgent implementation) exposing multiple focused classes.
 
 ```typescript
@@ -3498,7 +3498,7 @@ interface PipelineStage {
 
 #### 3.14.8 CMP-036: Completion Generator
 
-**Source Features**: CLI Tooling (standalone utility)
+**Applicability**: CLI Tooling (standalone utility)
 **Responsibility**: Generates shell-specific autocompletion scripts for the AD-SDLC CLI. Supports bash, zsh, and fish shells. Produces completion scripts based on registered CLI command definitions including subcommands, options, and value enumerations. Provides installation instructions for each shell type. This is a standalone singleton (not an IAgent implementation).
 
 ```typescript


### PR DESCRIPTION
## Summary
- Add four support module component definitions to SDS-001 (English and Korean): Telemetry Service (CMP-033), Security Module (CMP-034), Configuration Manager (CMP-035), Completion Generator (CMP-036)
- Re-apply corrections from PR #456 squash merge that missed fix commit: CMP-029 UC reference (UC-038→UC-039), CMP-032 UC reference (UC-025→UC-022/UC-023), component count (28→36), CMP-029 stateless library description
- Update SRS→SDS traceability matrix (Section 9.1) with all 8 new CMP entries
- Update Component→API mapping (Section 9.2) with CMP-029~CMP-036 interfaces
- Bump SDS version to 1.2.0

Closes #455

## Test Plan
- [x] Verify Component Overview table has 36 entries (CMP-001~CMP-036) — EN: 36 rows (line 357~392), KR: 36 rows (line 356~391)
- [x] Verify Section 3.14.5~3.14.8 definitions match actual source interfaces — All 4 sections verified against src/telemetry/, src/security/, src/config/, src/completion/
- [x] Verify traceability matrix SF→CMP mappings are consistent — CI validation: 6/6 PASS, FR:33 SF:31 CMP:36, 100% coverage
- [x] Verify English and Korean SDS are synchronized — Both files have identical structure, 36 CMP entries, 4 new sections, matching Component→API mappings