### PR TITLE
refactor(lint): add JSDoc descriptions to CLI and error modules

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -188,7 +188,7 @@ program
 
 /**
  * Format validation result for CLI output
- * @param result
+ * @param result - The file validation result to display
  */
 function formatFileResult(result: FileValidationResult): void {
   const statusIcon = result.valid ? chalk.green('✓') : chalk.red('✗');
@@ -206,7 +206,7 @@ function formatFileResult(result: FileValidationResult): void {
 
 /**
  * Format validation report as JSON
- * @param report
+ * @param report - The validation report to serialize as JSON
  */
 function formatReportAsJson(report: ValidationReport): void {
   console.log(JSON.stringify(report, null, 2));
@@ -644,7 +644,8 @@ program
 
 /**
  * Helper functions for status display
- * @param status
+ * @param status - The pipeline stage status string
+ * @returns A chalk-colored icon representing the status
  */
 function getStatusIcon(status: string): string {
   switch (status) {
@@ -852,7 +853,8 @@ telemetryCommand
 
 /**
  * Format consent status for display
- * @param status
+ * @param status - The telemetry consent status string
+ * @returns A chalk-colored consent status label
  */
 function formatConsentStatus(status: string): string {
   switch (status) {

--- a/src/config/errors.ts
+++ b/src/config/errors.ts
@@ -38,6 +38,7 @@ export class ConfigValidationError extends Error {
 
   /**
    * Format errors as a readable string
+   * @returns A formatted multi-line string describing all validation errors
    */
   public formatErrors(): string {
     if (this.errors.length === 0) {

--- a/src/error-handler/BackoffStrategies.ts
+++ b/src/error-handler/BackoffStrategies.ts
@@ -143,7 +143,8 @@ export class FibonacciBackoff implements BackoffStrategy {
   /**
    * Calculate fibonacci number iteratively (efficient for small n)
    * fib(1)=1, fib(2)=1, fib(3)=2, fib(4)=3, fib(5)=5, fib(6)=8, fib(7)=13...
-   * @param n
+   * @param n - The position in the fibonacci sequence (1-based)
+   * @returns The fibonacci number at the given position
    */
   private fibonacci(n: number): number {
     if (n <= 2) return 1;

--- a/src/error-handler/CircuitBreaker.ts
+++ b/src/error-handler/CircuitBreaker.ts
@@ -31,7 +31,7 @@ import { getLogger } from '../logging/Logger.js';
 
 /**
  * Validates circuit breaker configuration
- * @param config
+ * @param config - The circuit breaker configuration to validate
  * @throws InvalidCircuitBreakerConfigError if config is invalid
  */
 function validateConfig(config: CircuitBreakerConfig): void {
@@ -60,7 +60,8 @@ function validateConfig(config: CircuitBreakerConfig): void {
 
 /**
  * Merges partial config with defaults
- * @param partial
+ * @param partial - Optional partial configuration to merge with defaults
+ * @returns The fully resolved circuit breaker configuration
  */
 function mergeConfig(partial?: Partial<CircuitBreakerConfig>): CircuitBreakerConfig {
   const config: CircuitBreakerConfig = {
@@ -112,6 +113,7 @@ export class CircuitBreaker {
 
   /**
    * Get the circuit breaker configuration
+   * @returns The current circuit breaker configuration
    */
   public getConfig(): CircuitBreakerConfig {
     return this.config;
@@ -119,6 +121,7 @@ export class CircuitBreaker {
 
   /**
    * Get current circuit breaker status for monitoring
+   * @returns The current status including state, failure count, and timing details
    */
   public getStatus(): CircuitBreakerStatus {
     const now = Date.now();
@@ -143,6 +146,7 @@ export class CircuitBreaker {
 
   /**
    * Get current circuit state
+   * @returns The current circuit state (CLOSED, OPEN, or HALF_OPEN)
    */
   public getState(): CircuitState {
     return this.state;
@@ -150,6 +154,7 @@ export class CircuitBreaker {
 
   /**
    * Get current failure count
+   * @returns The number of consecutive failures recorded
    */
   public getFailureCount(): number {
     return this.failureCount;
@@ -157,6 +162,7 @@ export class CircuitBreaker {
 
   /**
    * Check if circuit is accepting requests
+   * @returns True if the circuit is currently allowing operations
    */
   public isAcceptingRequests(): boolean {
     if (this.state === 'CLOSED') {
@@ -177,6 +183,7 @@ export class CircuitBreaker {
 
   /**
    * Check if circuit should transition from OPEN to HALF_OPEN
+   * @returns True if the reset timeout has elapsed
    */
   private shouldAttemptReset(): boolean {
     if (this.state !== 'OPEN' || this.lastFailureTime === undefined) {
@@ -189,6 +196,7 @@ export class CircuitBreaker {
 
   /**
    * Get remaining time until circuit can attempt reset
+   * @returns Remaining time in milliseconds until reset is possible
    */
   public getRemainingTimeout(): number {
     if (this.state !== 'OPEN' || this.lastFailureTime === undefined) {
@@ -305,7 +313,7 @@ export class CircuitBreaker {
 
   /**
    * Handle failed operation
-   * @param error
+   * @param error - The error that caused the operation to fail
    */
   private onFailure(error: Error): void {
     const logger = getLogger();
@@ -340,7 +348,7 @@ export class CircuitBreaker {
 
   /**
    * Transition to a new state
-   * @param newState
+   * @param newState - The target circuit state to transition to
    */
   private transitionTo(newState: CircuitState): void {
     const logger = getLogger();
@@ -418,7 +426,7 @@ export class CircuitBreaker {
 
   /**
    * Emit an event to all registered callbacks
-   * @param event
+   * @param event - The circuit breaker event to emit
    */
   private emitEvent(event: CircuitBreakerEvent): void {
     for (const callback of this.eventCallbacks) {
@@ -441,7 +449,7 @@ export class CircuitBreaker {
   /**
    * Record a failed operation result (for external integration)
    * Use this when the operation is managed externally (e.g., by RetryHandler)
-   * @param error
+   * @param error - The error that caused the failure
    */
   public recordFailure(error: Error): void {
     this.onFailure(error);
@@ -449,6 +457,7 @@ export class CircuitBreaker {
 
   /**
    * Check if the circuit is currently healthy (CLOSED state with no recent failures)
+   * @returns True if the circuit is closed with zero failures
    */
   public isHealthy(): boolean {
     return this.state === 'CLOSED' && this.failureCount === 0;
@@ -456,6 +465,7 @@ export class CircuitBreaker {
 
   /**
    * Get a health check result for monitoring systems
+   * @returns An object containing the health status and detailed circuit breaker status
    */
   public getHealthCheck(): { healthy: boolean; details: CircuitBreakerStatus } {
     return {

--- a/src/error-handler/RetryExecutor.ts
+++ b/src/error-handler/RetryExecutor.ts
@@ -173,7 +173,8 @@ export const RETRY_POLICIES = {
 
 /**
  * Default error classifier using pattern matching
- * @param error
+ * @param error - The error to classify
+ * @returns The error category indicating retryability
  */
 export function defaultErrorClassifier(error: Error): ErrorCategory {
   const message = error.message.toLowerCase();
@@ -202,8 +203,9 @@ export function defaultErrorClassifier(error: Error): ErrorCategory {
 
 /**
  * Sleep for a specified duration with abort signal support
- * @param ms
- * @param signal
+ * @param ms - Duration to sleep in milliseconds
+ * @param signal - Optional abort signal to cancel the sleep
+ * @returns A promise that resolves after the specified duration
  */
 async function sleep(ms: number, signal?: AbortSignal): Promise<void> {
   if (ms <= 0) return;
@@ -230,9 +232,10 @@ async function sleep(ms: number, signal?: AbortSignal): Promise<void> {
 
 /**
  * Wrap an operation with a timeout
- * @param operation
- * @param timeoutMs
- * @param operationName
+ * @param operation - The async operation to execute with a timeout
+ * @param timeoutMs - Timeout duration in milliseconds
+ * @param operationName - Optional name of the operation for error messages
+ * @returns A promise resolving to the operation result
  */
 async function withTimeout<T>(
   operation: () => Promise<T>,
@@ -322,6 +325,7 @@ export class RetryExecutor {
 
   /**
    * Get the configured policy
+   * @returns The current unified retry policy configuration
    */
   public getPolicy(): UnifiedRetryPolicy {
     return this.policy;

--- a/src/error-handler/RetryHandler.ts
+++ b/src/error-handler/RetryHandler.ts
@@ -44,7 +44,7 @@ import { CircuitBreaker } from './CircuitBreaker.js';
 
 /**
  * Validates a retry policy configuration
- * @param policy
+ * @param policy - The retry policy configuration to validate
  * @throws InvalidRetryPolicyError if policy is invalid
  */
 function validatePolicy(policy: RetryPolicy): void {
@@ -79,7 +79,8 @@ function validatePolicy(policy: RetryPolicy): void {
 
 /**
  * Merges partial policy with defaults
- * @param partial
+ * @param partial - Optional partial retry policy to merge with defaults
+ * @returns The fully resolved retry policy
  */
 function mergePolicy(partial?: Partial<RetryPolicy>): RetryPolicy {
   const policy: RetryPolicy = {
@@ -97,7 +98,8 @@ function mergePolicy(partial?: Partial<RetryPolicy>): RetryPolicy {
 
 /**
  * Default error classifier using pattern matching
- * @param error
+ * @param error - The error to classify
+ * @returns The error category indicating retryability
  */
 export function defaultErrorClassifier(error: Error): ErrorCategory {
   const message = error.message.toLowerCase();
@@ -129,8 +131,9 @@ export function defaultErrorClassifier(error: Error): ErrorCategory {
  *
  * Supports all backoff strategies: fixed, linear, exponential, and fibonacci.
  * Delegates to unified backoff calculation for consistency across the codebase.
- * @param attempt
- * @param policy
+ * @param attempt - The current retry attempt number (1-based)
+ * @param policy - The retry policy containing backoff configuration
+ * @returns The calculated delay in milliseconds
  */
 export function calculateDelay(attempt: number, policy: RetryPolicy): number {
   const jitterRatio = policy.enableJitter ? policy.jitterFactor : 0;
@@ -178,8 +181,9 @@ export function calculateDelay(attempt: number, policy: RetryPolicy): number {
 
 /**
  * Sleep for a specified duration with abort signal support
- * @param ms
- * @param signal
+ * @param ms - Duration to sleep in milliseconds
+ * @param signal - Optional abort signal to cancel the sleep
+ * @returns A promise that resolves after the specified duration
  */
 async function sleep(ms: number, signal?: AbortSignal): Promise<void> {
   if (ms <= 0) return;
@@ -213,9 +217,10 @@ async function sleep(ms: number, signal?: AbortSignal): Promise<void> {
 
 /**
  * Wrap an operation with a timeout
- * @param operation
- * @param config
- * @param operationName
+ * @param operation - The async operation to execute with a timeout
+ * @param config - Timeout configuration containing the timeout duration
+ * @param operationName - Optional name of the operation for error messages
+ * @returns A promise resolving to the operation result
  */
 async function withTimeout<T>(
   operation: () => Promise<T>,
@@ -577,6 +582,7 @@ export class RetryHandler {
 
   /**
    * Get the configured retry policy
+   * @returns The current retry policy configuration
    */
   public getPolicy(): RetryPolicy {
     return this.policy;
@@ -584,8 +590,9 @@ export class RetryHandler {
 
   /**
    * Execute an operation with this handler's retry policy
-   * @param operation
-   * @param options
+   * @param operation - The async operation to execute
+   * @param options - Additional retry options excluding policy and classifier
+   * @returns A promise resolving to the operation result
    */
   public async execute<T>(
     operation: () => Promise<T>,
@@ -600,8 +607,9 @@ export class RetryHandler {
 
   /**
    * Execute an operation and return detailed result
-   * @param operation
-   * @param options
+   * @param operation - The async operation to execute
+   * @param options - Additional retry options excluding policy and classifier
+   * @returns A promise resolving to a detailed retry result
    */
   public async executeWithResult<T>(
     operation: () => Promise<T>,
@@ -616,7 +624,8 @@ export class RetryHandler {
 
   /**
    * Classify an error using this handler's classifier
-   * @param error
+   * @param error - The error to classify
+   * @returns The error category indicating retryability
    */
   public classifyError(error: Error): ErrorCategory {
     return this.errorClassifier(error);
@@ -624,7 +633,8 @@ export class RetryHandler {
 
   /**
    * Calculate delay for a specific attempt
-   * @param attempt
+   * @param attempt - The retry attempt number (1-based)
+   * @returns The calculated delay in milliseconds
    */
   public calculateDelayForAttempt(attempt: number): number {
     return calculateDelay(attempt, this.policy);

--- a/src/error-handler/RetryMetrics.ts
+++ b/src/error-handler/RetryMetrics.ts
@@ -214,6 +214,7 @@ export class RetryMetrics {
 
   /**
    * Get total number of records
+   * @returns The total number of recorded retry operations
    */
   public get recordCount(): number {
     return this.records.length;

--- a/src/errors/factories.ts
+++ b/src/errors/factories.ts
@@ -18,9 +18,10 @@ import type { ErrorContext, AppErrorOptions } from './types.js';
 
 /**
  * Create error for document not found
- * @param documentType
- * @param path
- * @param context
+ * @param documentType - The type of document that was not found
+ * @param path - The file path where the document was expected
+ * @param context - Additional error context information
+ * @returns The constructed document-not-found AppError
  */
 export function documentNotFoundError(
   documentType: string,
@@ -36,10 +37,11 @@ export function documentNotFoundError(
 
 /**
  * Create error for document parse failure
- * @param documentType
- * @param path
- * @param reason
- * @param context
+ * @param documentType - The type of document that failed to parse
+ * @param path - The file path of the document
+ * @param reason - The reason parsing failed
+ * @param context - Additional error context information
+ * @returns The constructed document-parse-error AppError
  */
 export function documentParseError(
   documentType: string,
@@ -60,9 +62,10 @@ export function documentParseError(
 
 /**
  * Create error for document validation failure
- * @param documentType
- * @param errors
- * @param context
+ * @param documentType - The type of document that failed validation
+ * @param errors - The list of validation error messages
+ * @param context - Additional error context information
+ * @returns The constructed document-validation-error AppError
  */
 export function documentValidationError(
   documentType: string,
@@ -82,10 +85,11 @@ export function documentValidationError(
 
 /**
  * Create error for document write failure
- * @param documentType
- * @param path
- * @param reason
- * @param context
+ * @param documentType - The type of document that failed to write
+ * @param path - The target file path for the write operation
+ * @param reason - The reason the write failed
+ * @param context - Additional error context information
+ * @returns The constructed document-write-error AppError
  */
 export function documentWriteError(
   documentType: string,
@@ -110,9 +114,10 @@ export function documentWriteError(
 
 /**
  * Create error for agent initialization failure
- * @param agentType
- * @param reason
- * @param context
+ * @param agentType - The type of agent that failed to initialize
+ * @param reason - The reason initialization failed
+ * @param context - Additional error context information
+ * @returns The constructed agent-init-error AppError
  */
 export function agentInitError(
   agentType: string,
@@ -132,10 +137,11 @@ export function agentInitError(
 
 /**
  * Create error for agent execution failure
- * @param agentType
- * @param operation
- * @param reason
- * @param context
+ * @param agentType - The type of agent that failed
+ * @param operation - The operation that was being executed
+ * @param reason - The reason execution failed
+ * @param context - Additional error context information
+ * @returns The constructed agent-execution-error AppError
  */
 export function agentExecutionError(
   agentType: string,
@@ -156,10 +162,11 @@ export function agentExecutionError(
 
 /**
  * Create error for agent timeout
- * @param agentType
- * @param operation
- * @param timeoutMs
- * @param context
+ * @param agentType - The type of agent that timed out
+ * @param operation - The operation that timed out
+ * @param timeoutMs - The timeout threshold in milliseconds
+ * @param context - Additional error context information
+ * @returns The constructed agent-timeout-error AppError
  */
 export function agentTimeoutError(
   agentType: string,
@@ -180,8 +187,9 @@ export function agentTimeoutError(
 
 /**
  * Create error for agent not found
- * @param agentType
- * @param context
+ * @param agentType - The type of agent that was not found
+ * @param context - Additional error context information
+ * @returns The constructed agent-not-found AppError
  */
 export function agentNotFoundError(agentType: string, context?: ErrorContext): AppError {
   return new AppError(
@@ -201,10 +209,11 @@ export function agentNotFoundError(agentType: string, context?: ErrorContext): A
 
 /**
  * Create error for file access failure
- * @param operation
- * @param path
- * @param reason
- * @param context
+ * @param operation - The file operation that failed
+ * @param path - The file path that could not be accessed
+ * @param reason - The reason the file access failed
+ * @param context - Additional error context information
+ * @returns The constructed file-access-error AppError
  */
 export function fileAccessError(
   operation: 'read' | 'write' | 'delete',
@@ -225,9 +234,10 @@ export function fileAccessError(
 
 /**
  * Create error for lock acquisition failure
- * @param resource
- * @param timeoutMs
- * @param context
+ * @param resource - The resource that could not be locked
+ * @param timeoutMs - The lock acquisition timeout in milliseconds
+ * @param context - Additional error context information
+ * @returns The constructed lock-acquisition-error AppError
  */
 export function lockAcquisitionError(
   resource: string,
@@ -247,9 +257,10 @@ export function lockAcquisitionError(
 
 /**
  * Create error for lock timeout
- * @param resource
- * @param holderId
- * @param context
+ * @param resource - The resource whose lock timed out
+ * @param holderId - The identifier of the current lock holder
+ * @param context - Additional error context information
+ * @returns The constructed lock-timeout-error AppError
  */
 export function lockTimeoutError(
   resource: string,
@@ -269,9 +280,10 @@ export function lockTimeoutError(
 
 /**
  * Create error for configuration load failure
- * @param configPath
- * @param reason
- * @param context
+ * @param configPath - The path to the configuration file that failed to load
+ * @param reason - The reason the configuration load failed
+ * @param context - Additional error context information
+ * @returns The constructed config-load-error AppError
  */
 export function configLoadError(
   configPath: string,
@@ -295,9 +307,10 @@ export function configLoadError(
 
 /**
  * Create error for path traversal attempt
- * @param path
- * @param baseDir
- * @param context
+ * @param path - The path that triggered the traversal detection
+ * @param baseDir - The base directory that the path must not escape
+ * @param context - Additional error context information
+ * @returns The constructed path-traversal-error AppError
  */
 export function pathTraversalError(
   path: string,
@@ -317,9 +330,10 @@ export function pathTraversalError(
 
 /**
  * Create error for command injection attempt
- * @param command
- * @param pattern
- * @param context
+ * @param command - The command string that triggered the injection detection
+ * @param pattern - The matched injection pattern
+ * @param context - Additional error context information
+ * @returns The constructed command-injection-error AppError
  */
 export function commandInjectionError(
   command: string,
@@ -339,9 +353,10 @@ export function commandInjectionError(
 
 /**
  * Create error for permission denied
- * @param resource
- * @param action
- * @param context
+ * @param resource - The resource that access was denied for
+ * @param action - The action that was denied
+ * @param context - Additional error context information
+ * @returns The constructed permission-denied AppError
  */
 export function permissionDeniedError(
   resource: string,
@@ -361,10 +376,11 @@ export function permissionDeniedError(
 
 /**
  * Create error for rate limit exceeded
- * @param resource
- * @param limit
- * @param windowMs
- * @param context
+ * @param resource - The resource that exceeded the rate limit
+ * @param limit - The maximum number of allowed requests
+ * @param windowMs - The rate limit window in milliseconds
+ * @param context - Additional error context information
+ * @returns The constructed rate-limit-exceeded AppError
  */
 export function rateLimitExceededError(
   resource: string,
@@ -389,10 +405,11 @@ export function rateLimitExceededError(
 
 /**
  * Create error for GitHub API failure
- * @param operation
- * @param statusCode
- * @param message
- * @param context
+ * @param operation - The GitHub API operation that failed
+ * @param statusCode - The HTTP status code returned, if available
+ * @param message - The error message from the API
+ * @param context - Additional error context information
+ * @returns The constructed GitHub-API-error AppError
  */
 export function githubApiError(
   operation: string,
@@ -413,10 +430,11 @@ export function githubApiError(
 
 /**
  * Create error for CI execution failure
- * @param pipeline
- * @param stage
- * @param reason
- * @param context
+ * @param pipeline - The CI pipeline that failed
+ * @param stage - The pipeline stage where the failure occurred
+ * @param reason - The reason the CI execution failed
+ * @param context - Additional error context information
+ * @returns The constructed CI-execution-error AppError
  */
 export function ciExecutionError(
   pipeline: string,
@@ -437,10 +455,11 @@ export function ciExecutionError(
 
 /**
  * Create error for network failure
- * @param operation
- * @param endpoint
- * @param reason
- * @param context
+ * @param operation - The network operation that failed
+ * @param endpoint - The target endpoint URL or address
+ * @param reason - The reason the network request failed
+ * @param context - Additional error context information
+ * @returns The constructed network-error AppError
  */
 export function networkError(
   operation: string,
@@ -465,10 +484,11 @@ export function networkError(
 
 /**
  * Create generic validation error
- * @param field
- * @param expected
- * @param received
- * @param context
+ * @param field - The name of the field that failed validation
+ * @param expected - The expected type or format description
+ * @param received - The actual value that was received
+ * @param context - Additional error context information
+ * @returns The constructed validation-error AppError
  */
 export function validationError(
   field: string,
@@ -489,8 +509,9 @@ export function validationError(
 
 /**
  * Create not implemented error
- * @param feature
- * @param context
+ * @param feature - The name of the unimplemented feature
+ * @param context - Additional error context information
+ * @returns The constructed not-implemented AppError
  */
 export function notImplementedError(feature: string, context?: ErrorContext): AppError {
   return new AppError(ErrorCodes.GEN_NOT_IMPLEMENTED, `Feature not implemented: ${feature}`, {
@@ -502,9 +523,10 @@ export function notImplementedError(feature: string, context?: ErrorContext): Ap
 
 /**
  * Create operation timeout error
- * @param operation
- * @param timeoutMs
- * @param context
+ * @param operation - The name of the operation that timed out
+ * @param timeoutMs - The timeout threshold in milliseconds
+ * @param context - Additional error context information
+ * @returns The constructed operation-timeout AppError
  */
 export function operationTimeoutError(
   operation: string,
@@ -529,9 +551,10 @@ export function operationTimeoutError(
 /**
  * Create a module-specific error factory
  *
- * @param moduleName
- * @param defaultCode
- * @param defaultOptions
+ * @param moduleName - The name of the module to scope errors to
+ * @param defaultCode - The default error code for this module
+ * @param defaultOptions - Default options applied to all errors from this factory
+ * @returns A factory function that creates module-scoped AppError instances
  * @example
  * ```typescript
  * const createPRDError = createModuleErrorFactory('PRD Writer', ErrorCodes.DOC_PARSE_ERROR);
@@ -554,7 +577,8 @@ export function createModuleErrorFactory(
 /**
  * Create an error factory bound to specific error codes
  *
- * @param codeMap
+ * @param codeMap - A mapping of factory names to their error codes
+ * @returns An object of named factory functions for creating AppError instances
  * @example
  * ```typescript
  * const errors = createBoundErrorFactories({

--- a/src/errors/handler.ts
+++ b/src/errors/handler.ts
@@ -59,8 +59,9 @@ const ERROR_CATEGORY_MAP: Record<string, ErrorCategory> = {
 export class ErrorHandler {
   /**
    * Handle an error with logging and optional output
-   * @param error
-   * @param options
+   * @param error - The error to handle
+   * @param options - Options controlling logging, output, and formatting
+   * @returns The normalized AppError instance
    */
   static handle(error: unknown, options: ErrorHandleOptions = {}): AppError {
     const appError = AppError.normalize(error);
@@ -88,7 +89,8 @@ export class ErrorHandler {
 
   /**
    * Normalize any error to AppError
-   * @param error
+   * @param error - The unknown error value to normalize
+   * @returns The normalized AppError instance
    */
   static normalize(error: unknown): AppError {
     return AppError.normalize(error);
@@ -96,7 +98,8 @@ export class ErrorHandler {
 
   /**
    * Categorize an error for retry decision
-   * @param error
+   * @param error - The error to categorize
+   * @returns The determined error category
    */
   static categorize(error: Error): ErrorCategory {
     if (error instanceof AppError) {
@@ -150,7 +153,8 @@ export class ErrorHandler {
 
   /**
    * Get suggested action based on error
-   * @param error
+   * @param error - The error to get a suggestion for
+   * @returns A human-readable suggested action string
    */
   static getSuggestedAction(error: Error): string {
     const appError = error instanceof AppError ? error : AppError.normalize(error);
@@ -170,8 +174,9 @@ export class ErrorHandler {
 
   /**
    * Create extended error information
-   * @param error
-   * @param additionalContext
+   * @param error - The source error to extract information from
+   * @param additionalContext - Extra context to merge into the error info
+   * @returns An ErrorInfo object with category, code, and suggested action
    */
   static createErrorInfo(error: Error, additionalContext: ErrorContext = {}): ErrorInfo {
     const appError = error instanceof AppError ? error : AppError.normalize(error);
@@ -194,7 +199,8 @@ export class ErrorHandler {
 
   /**
    * Check if error is retryable
-   * @param error
+   * @param error - The error to check for retryability
+   * @returns True if the error can be retried
    */
   static isRetryable(error: Error): boolean {
     if (error instanceof AppError) {
@@ -205,7 +211,8 @@ export class ErrorHandler {
 
   /**
    * Check if error requires escalation
-   * @param error
+   * @param error - The error to check for escalation requirement
+   * @returns True if the error requires immediate escalation
    */
   static requiresEscalation(error: Error): boolean {
     if (error instanceof AppError) {
@@ -216,8 +223,8 @@ export class ErrorHandler {
 
   /**
    * Log error to console with appropriate level
-   * @param error
-   * @param level
+   * @param error - The AppError to log
+   * @param level - The console log level to use
    */
   private static log(error: AppError, level: 'debug' | 'info' | 'warn' | 'error' = 'error'): void {
     const formatted = error.format('log');
@@ -240,7 +247,7 @@ export class ErrorHandler {
 
   /**
    * Report critical errors
-   * @param error
+   * @param error - The critical AppError to report
    */
   private static report(error: AppError): void {
     // Log critical error details
@@ -252,8 +259,9 @@ export class ErrorHandler {
 
   /**
    * Create a function that wraps errors with a specific code
-   * @param code
-   * @param defaultContext
+   * @param code - The error code to assign to wrapped errors
+   * @param defaultContext - Default context to attach to wrapped errors
+   * @returns A function that wraps unknown errors into AppError instances
    */
   static createWrapper(
     code: string,
@@ -264,10 +272,10 @@ export class ErrorHandler {
 
   /**
    * Assert condition and throw AppError if false
-   * @param condition
-   * @param code
-   * @param message
-   * @param context
+   * @param condition - The condition to assert as truthy
+   * @param code - The error code to use if assertion fails
+   * @param message - The error message if assertion fails
+   * @param context - Additional context for the assertion error
    */
   static assert(
     condition: boolean,
@@ -286,9 +294,10 @@ export class ErrorHandler {
 
   /**
    * Execute a function and wrap any thrown error
-   * @param fn
-   * @param code
-   * @param context
+   * @param fn - The async function to execute
+   * @param code - The error code to assign if the function throws
+   * @param context - Additional context for the wrapped error
+   * @returns The result of the executed function
    */
   static async wrapAsync<T>(
     fn: () => Promise<T>,
@@ -304,9 +313,10 @@ export class ErrorHandler {
 
   /**
    * Execute a function and wrap any thrown error (sync version)
-   * @param fn
-   * @param code
-   * @param context
+   * @param fn - The synchronous function to execute
+   * @param code - The error code to assign if the function throws
+   * @param context - Additional context for the wrapped error
+   * @returns The result of the executed function
    */
   static wrapSync<T>(fn: () => T, code: string, context: ErrorContext = {}): T {
     try {


### PR DESCRIPTION
Closes #459
Part of #432

## Summary
- Add missing `@param` descriptions and `@returns` declarations to 9 files in CLI and error infrastructure modules
- Resolves all JSDoc-related ESLint warnings in the targeted files (remaining warnings are expected `no-console` in CLI/error handler)

## Files Modified

| File | JSDoc Warnings Fixed |
|------|---------------------|
| `src/cli.ts` | 6 |
| `src/errors/factories.ts` | 102 |
| `src/errors/handler.ts` | 39 |
| `src/error-handler/RetryHandler.ts` | 25 |
| `src/error-handler/CircuitBreaker.ts` | 16 |
| `src/error-handler/RetryExecutor.ts` | 9 |
| `src/error-handler/BackoffStrategies.ts` | 2 |
| `src/error-handler/RetryMetrics.ts` | 1 |
| `src/config/errors.ts` | 1 |
| **Total** | **201** |

## Test Plan
- [x] `npx eslint <files>` produces 0 JSDoc warnings
- [x] 307 related tests pass (errors, error-handler, config modules)
- [x] No code logic changes - only JSDoc comments updated