### PR TITLE
refactor(lint): add JSDoc descriptions to monitoring budget, token and metrics modules

### DIFF
--- a/src/monitoring/AgentBudgetRegistry.ts
+++ b/src/monitoring/AgentBudgetRegistry.ts
@@ -119,8 +119,9 @@ export class AgentBudgetRegistry {
 
   /**
    * Get or create a budget manager for an agent
-   * @param agentName
-   * @param config
+   * @param agentName - Name of the agent to get budget manager for
+   * @param config - Optional partial configuration for agent budget
+   * @returns TokenBudgetManager instance for the specified agent
    */
   public getAgentBudget(
     agentName: string,
@@ -136,8 +137,9 @@ export class AgentBudgetRegistry {
 
   /**
    * Create a new budget manager for an agent
-   * @param agentName
-   * @param config
+   * @param agentName - Name of the agent to create budget manager for
+   * @param config - Optional partial configuration for the new agent budget
+   * @returns Newly created TokenBudgetManager instance
    */
   private createAgentBudget(
     agentName: string,
@@ -202,10 +204,11 @@ export class AgentBudgetRegistry {
 
   /**
    * Record usage for an agent and check budgets
-   * @param agentName
-   * @param inputTokens
-   * @param outputTokens
-   * @param costUsd
+   * @param agentName - Name of the agent that consumed resources
+   * @param inputTokens - Number of input tokens consumed
+   * @param outputTokens - Number of output tokens generated
+   * @param costUsd - Cost of the operation in US dollars
+   * @returns Budget status for the agent after recording usage
    */
   public recordAgentUsage(
     agentName: string,
@@ -245,6 +248,7 @@ export class AgentBudgetRegistry {
 
   /**
    * Get all agent budgets
+   * @returns Map of agent names to their current budget status
    */
   public getAllBudgets(): Map<string, BudgetStatus> {
     const budgets = new Map<string, BudgetStatus>();
@@ -258,6 +262,7 @@ export class AgentBudgetRegistry {
 
   /**
    * Get list of registered agent names
+   * @returns Array of all registered agent names
    */
   public getRegisteredAgents(): readonly string[] {
     return Array.from(this.agentBudgets.keys());
@@ -265,7 +270,8 @@ export class AgentBudgetRegistry {
 
   /**
    * Get agent budget configuration
-   * @param agentName
+   * @param agentName - Name of the agent to get configuration for
+   * @returns Agent budget configuration or undefined if not found
    */
   public getAgentConfig(agentName: string): AgentTokenBudgetConfig | undefined {
     return this.agentBudgets.get(agentName)?.config;
@@ -273,6 +279,7 @@ export class AgentBudgetRegistry {
 
   /**
    * Get aggregated pipeline status
+   * @returns Aggregated budget status across all agents in the pipeline
    */
   public getPipelineStatus(): PipelineBudgetStatus {
     let totalTokens = 0;
@@ -327,6 +334,7 @@ export class AgentBudgetRegistry {
 
   /**
    * Check if any agent exceeded budget
+   * @returns True if at least one agent has exceeded their budget limit
    */
   public hasExceededBudgets(): boolean {
     for (const entry of this.agentBudgets.values()) {
@@ -339,6 +347,7 @@ export class AgentBudgetRegistry {
 
   /**
    * Check if pipeline budget is exceeded
+   * @returns True if the total pipeline budget limit has been exceeded
    */
   public isPipelineBudgetExceeded(): boolean {
     return this.getPipelineStatus().limitExceeded;
@@ -346,7 +355,7 @@ export class AgentBudgetRegistry {
 
   /**
    * Reset specific agent budget
-   * @param agentName
+   * @param agentName - Name of the agent whose budget should be reset
    */
   public resetAgent(agentName: string): void {
     const entry = this.agentBudgets.get(agentName);
@@ -366,7 +375,8 @@ export class AgentBudgetRegistry {
 
   /**
    * Remove an agent from the registry
-   * @param agentName
+   * @param agentName - Name of the agent to remove
+   * @returns True if agent was found and removed, false if not found
    */
   public removeAgent(agentName: string): boolean {
     return this.agentBudgets.delete(agentName);
@@ -381,6 +391,7 @@ export class AgentBudgetRegistry {
 
   /**
    * Get total number of registered agents
+   * @returns Total count of agents currently registered
    */
   public get size(): number {
     return this.agentBudgets.size;
@@ -388,9 +399,10 @@ export class AgentBudgetRegistry {
 
   /**
    * Estimate if a request will exceed agent or pipeline budget
-   * @param agentName
-   * @param estimatedInputTokens
-   * @param estimatedOutputTokens
+   * @param agentName - Name of the agent that would perform the operation
+   * @param estimatedInputTokens - Expected number of input tokens for the operation
+   * @param estimatedOutputTokens - Expected number of output tokens for the operation
+   * @returns Object indicating if operation is allowed and reason if not
    */
   public estimateUsage(
     agentName: string,
@@ -423,6 +435,7 @@ export class AgentBudgetRegistry {
 
   /**
    * Get a summary report of all agent budgets
+   * @returns Formatted text report of pipeline and per-agent budget status
    */
   public getSummaryReport(): string {
     const status = this.getPipelineStatus();
@@ -625,6 +638,7 @@ export class AgentBudgetRegistry {
 
   /**
    * Get the history of budget transfers
+   * @returns Array of all budget transfer records between agents
    */
   public getTransferHistory(): readonly BudgetTransferRecord[] {
     return this.transferHistory;
@@ -639,9 +653,10 @@ export class AgentBudgetRegistry {
 
   /**
    * Helper to create transfer result for failed transfers
-   * @param success
-   * @param error
-   * @param timestamp
+   * @param success - Always false for this helper (failed transfers)
+   * @param error - Error message describing why the transfer failed
+   * @param timestamp - ISO timestamp of the failed transfer attempt
+   * @returns Budget transfer result object indicating failure
    */
   private createTransferResult(
     success: false,
@@ -663,7 +678,8 @@ let globalAgentBudgetRegistry: AgentBudgetRegistry | null = null;
 
 /**
  * Get or create the global AgentBudgetRegistry instance
- * @param config
+ * @param config - Optional configuration for the registry
+ * @returns Global singleton instance of AgentBudgetRegistry
  */
 export function getAgentBudgetRegistry(config?: AgentBudgetRegistryConfig): AgentBudgetRegistry {
   if (globalAgentBudgetRegistry === null) {

--- a/src/monitoring/BudgetAggregator.ts
+++ b/src/monitoring/BudgetAggregator.ts
@@ -117,8 +117,8 @@ export class BudgetAggregator {
 
   /**
    * Register agent category mapping
-   * @param agentName
-   * @param category
+   * @param agentName - Name of the agent to register
+   * @param category - Agent category for aggregation grouping
    */
   public registerAgentCategory(agentName: string, category: AgentCategory): void {
     this.categoryMappings.set(agentName, category);
@@ -126,7 +126,7 @@ export class BudgetAggregator {
 
   /**
    * Register multiple agent category mappings
-   * @param mappings
+   * @param mappings - Array of agent-to-category mapping objects
    */
   public registerCategoryMappings(mappings: readonly AgentCategoryMapping[]): void {
     for (const mapping of mappings) {
@@ -136,7 +136,7 @@ export class BudgetAggregator {
 
   /**
    * Record a usage trend point
-   * @param status
+   * @param status - Current pipeline budget status snapshot
    */
   public recordTrendPoint(status: PipelineBudgetStatus): void {
     const point: UsageTrendPoint = {
@@ -155,6 +155,7 @@ export class BudgetAggregator {
 
   /**
    * Get usage trends
+   * @returns Recorded usage trend points in chronological order
    */
   public getUsageTrends(): readonly UsageTrendPoint[] {
     return this.usageTrends;
@@ -169,7 +170,8 @@ export class BudgetAggregator {
 
   /**
    * Generate agent usage summaries from pipeline status
-   * @param status
+   * @param status - Current pipeline budget status to analyze
+   * @returns Array of agent usage summaries sorted by cost (descending)
    */
   public generateAgentSummaries(status: PipelineBudgetStatus): AgentUsageSummary[] {
     const summaries: AgentUsageSummary[] = [];
@@ -197,7 +199,8 @@ export class BudgetAggregator {
 
   /**
    * Generate category usage summaries
-   * @param status
+   * @param status - Current pipeline budget status to aggregate by category
+   * @returns Array of category usage summaries sorted by cost (descending)
    */
   public generateCategorySummaries(status: PipelineBudgetStatus): CategoryUsageSummary[] {
     const categoryData: Map<AgentCategory, { tokens: number; cost: number; count: number }> =
@@ -237,8 +240,9 @@ export class BudgetAggregator {
 
   /**
    * Generate optimization suggestions
-   * @param status
-   * @param agentSummaries
+   * @param status - Current pipeline budget status for analysis
+   * @param agentSummaries - Pre-computed agent usage summaries
+   * @returns Array of actionable budget optimization suggestions
    */
   public generateSuggestions(
     status: PipelineBudgetStatus,
@@ -309,7 +313,8 @@ export class BudgetAggregator {
 
   /**
    * Generate a comprehensive budget report
-   * @param status
+   * @param status - Current pipeline budget status to report
+   * @returns Complete budget report with summaries and suggestions
    */
   public generateReport(status: PipelineBudgetStatus): BudgetReport {
     const agentSummaries = this.generateAgentSummaries(status);
@@ -328,7 +333,8 @@ export class BudgetAggregator {
 
   /**
    * Format report as a readable string
-   * @param report
+   * @param report - Budget report to format
+   * @returns Human-readable formatted report with ASCII borders and tables
    */
   public formatReportAsString(report: BudgetReport): string {
     const lines: string[] = [
@@ -401,8 +407,9 @@ let globalBudgetAggregator: BudgetAggregator | null = null;
 
 /**
  * Get or create the global BudgetAggregator instance
- * @param options
- * @param options.maxTrendPoints
+ * @param options - Configuration options for the aggregator
+ * @param options.maxTrendPoints - Maximum number of trend points to retain
+ * @returns The global BudgetAggregator singleton instance
  */
 export function getBudgetAggregator(options?: { maxTrendPoints?: number }): BudgetAggregator {
   if (globalBudgetAggregator === null) {

--- a/src/monitoring/MetricsCollector.ts
+++ b/src/monitoring/MetricsCollector.ts
@@ -112,7 +112,7 @@ export class MetricsCollector {
 
   /**
    * Set session ID
-   * @param sessionId
+   * @param sessionId - Unique identifier for the current session
    */
   public setSessionId(sessionId: string): void {
     this.sessionId = sessionId;
@@ -120,6 +120,7 @@ export class MetricsCollector {
 
   /**
    * Get session ID
+   * @returns The current session identifier
    */
   public getSessionId(): string {
     return this.sessionId;
@@ -127,7 +128,7 @@ export class MetricsCollector {
 
   /**
    * Set the model for cost calculation
-   * @param model
+   * @param model - Model name (sonnet, opus, haiku) for token cost estimation
    */
   public setModel(model: string): void {
     this.model = model;
@@ -135,7 +136,8 @@ export class MetricsCollector {
 
   /**
    * Get labels key for map storage
-   * @param labels
+   * @param labels - Optional key-value pairs to identify metric variants
+   * @returns Sorted comma-separated string representation of labels
    */
   private getLabelsKey(labels?: Record<string, string>): string {
     if (labels === undefined) return '';
@@ -147,7 +149,8 @@ export class MetricsCollector {
 
   /**
    * Record agent invocation start
-   * @param _agent
+   * @param _agent - Agent name (unused, reserved for future use)
+   * @returns Timestamp in milliseconds marking the start of agent execution
    */
   public recordAgentStart(_agent: string): number {
     return Date.now();
@@ -155,9 +158,9 @@ export class MetricsCollector {
 
   /**
    * Record agent invocation completion
-   * @param agent
-   * @param startTime
-   * @param success
+   * @param agent - Name of the agent that completed execution
+   * @param startTime - Timestamp from recordAgentStart() call
+   * @param success - Whether the agent execution succeeded
    */
   public recordAgentEnd(agent: string, startTime: number, success: boolean): void {
     const duration = Date.now() - startTime;
@@ -186,9 +189,9 @@ export class MetricsCollector {
 
   /**
    * Record token usage
-   * @param agent
-   * @param inputTokens
-   * @param outputTokens
+   * @param agent - Name of the agent consuming tokens
+   * @param inputTokens - Number of input tokens consumed
+   * @param outputTokens - Number of output tokens generated
    */
   public recordTokenUsage(agent: string, inputTokens: number, outputTokens: number): void {
     const usage = this.tokenUsage.get(agent) ?? { input: 0, output: 0 };
@@ -202,7 +205,7 @@ export class MetricsCollector {
 
   /**
    * Record pipeline stage start
-   * @param stage
+   * @param stage - Name of the pipeline stage being started
    */
   public recordStageStart(stage: string): void {
     this.stageDurations.set(stage, {
@@ -214,8 +217,8 @@ export class MetricsCollector {
 
   /**
    * Record pipeline stage completion
-   * @param stage
-   * @param success
+   * @param stage - Name of the pipeline stage being completed
+   * @param success - Whether the stage completed successfully
    */
   public recordStageEnd(stage: string, success: boolean): void {
     const stageData = this.stageDurations.get(stage);
@@ -241,9 +244,9 @@ export class MetricsCollector {
 
   /**
    * Increment a counter metric
-   * @param name
-   * @param value
-   * @param labels
+   * @param name - Metric name identifier
+   * @param value - Amount to increment the counter by
+   * @param labels - Optional labels to differentiate metric instances
    */
   public incrementCounter(name: string, value: number, labels?: Record<string, string>): void {
     const key = this.getLabelsKey(labels);
@@ -255,9 +258,9 @@ export class MetricsCollector {
 
   /**
    * Set a gauge metric
-   * @param name
-   * @param value
-   * @param labels
+   * @param name - Metric name identifier
+   * @param value - Current value to set the gauge to
+   * @param labels - Optional labels to differentiate metric instances
    */
   public setGauge(name: string, value: number, labels?: Record<string, string>): void {
     const key = this.getLabelsKey(labels);
@@ -268,10 +271,10 @@ export class MetricsCollector {
 
   /**
    * Record a histogram observation
-   * @param name
-   * @param value
-   * @param labels
-   * @param buckets
+   * @param name - Metric name identifier
+   * @param value - Observed value to record in the histogram
+   * @param labels - Optional labels to differentiate metric instances
+   * @param buckets - Bucket boundaries for histogram distribution
    */
   public recordHistogram(
     name: string,
@@ -290,7 +293,8 @@ export class MetricsCollector {
 
   /**
    * Get agent metrics
-   * @param agent
+   * @param agent - Name of the agent to retrieve metrics for
+   * @returns Aggregated metrics for the agent, or null if no data exists
    */
   public getAgentMetrics(agent: string): AgentMetrics | null {
     const counts = this.agentInvocations.get(agent);
@@ -319,6 +323,7 @@ export class MetricsCollector {
 
   /**
    * Get all agent metrics
+   * @returns Array of metrics for all agents that have been tracked
    */
   public getAllAgentMetrics(): AgentMetrics[] {
     const metrics: AgentMetrics[] = [];
@@ -333,6 +338,7 @@ export class MetricsCollector {
 
   /**
    * Get token usage metrics
+   * @returns Aggregated token usage and estimated cost across all agents
    */
   public getTokenUsageMetrics(): TokenUsageMetrics {
     let totalInput = 0;
@@ -361,6 +367,7 @@ export class MetricsCollector {
 
   /**
    * Get pipeline stage durations
+   * @returns Array of duration data for all recorded pipeline stages
    */
   public getStageDurations(): StageDuration[] {
     return Array.from(this.stageDurations.values());
@@ -368,8 +375,9 @@ export class MetricsCollector {
 
   /**
    * Get counter value
-   * @param name
-   * @param labels
+   * @param name - Metric name identifier
+   * @param labels - Optional labels to identify specific counter instance
+   * @returns Current counter value, or 0 if not found
    */
   public getCounter(name: string, labels?: Record<string, string>): number {
     const key = this.getLabelsKey(labels);
@@ -378,8 +386,9 @@ export class MetricsCollector {
 
   /**
    * Get gauge value
-   * @param name
-   * @param labels
+   * @param name - Metric name identifier
+   * @param labels - Optional labels to identify specific gauge instance
+   * @returns Current gauge value, or 0 if not found
    */
   public getGauge(name: string, labels?: Record<string, string>): number {
     const key = this.getLabelsKey(labels);
@@ -388,8 +397,9 @@ export class MetricsCollector {
 
   /**
    * Get histogram data
-   * @param name
-   * @param labels
+   * @param name - Metric name identifier
+   * @param labels - Optional labels to identify specific histogram instance
+   * @returns Histogram data with bucket counts and statistics, or null if not found
    */
   public getHistogram(name: string, labels?: Record<string, string>): HistogramData | null {
     const key = this.getLabelsKey(labels);
@@ -421,6 +431,7 @@ export class MetricsCollector {
 
   /**
    * Get all metric values
+   * @returns Array of all counter and gauge metrics with their current values
    */
   public getAllMetrics(): MetricValue[] {
     const metrics: MetricValue[] = [];
@@ -455,7 +466,8 @@ export class MetricsCollector {
 
   /**
    * Parse labels key back to record
-   * @param key
+   * @param key - Serialized labels string from getLabelsKey()
+   * @returns Parsed labels object, or null for empty key
    */
   private parseLabelsKey(key: string): Record<string, string> | null {
     if (key === '') return null;
@@ -499,6 +511,7 @@ export class MetricsCollector {
 
   /**
    * Export metrics in Prometheus format
+   * @returns Metrics formatted as Prometheus exposition format
    */
   public exportPrometheus(): string {
     const lines: string[] = [];
@@ -568,6 +581,7 @@ export class MetricsCollector {
 
   /**
    * Get the metrics directory
+   * @returns Path to the directory where metrics are stored
    */
   public getMetricsDir(): string {
     return this.metricsDir;
@@ -581,7 +595,8 @@ let globalMetricsCollector: MetricsCollector | null = null;
 
 /**
  * Get or create the global MetricsCollector instance
- * @param options
+ * @param options - Configuration options for the metrics collector
+ * @returns The global singleton MetricsCollector instance
  */
 export function getMetricsCollector(options?: MetricsCollectorOptions): MetricsCollector {
   if (globalMetricsCollector === null) {

--- a/src/monitoring/ModelSelector.ts
+++ b/src/monitoring/ModelSelector.ts
@@ -174,7 +174,8 @@ export class ModelSelector {
 
   /**
    * Select optimal model for a task
-   * @param task
+   * @param task - Task analysis containing complexity, token estimates, and requirements
+   * @returns Model selection result with chosen model, reasoning, and alternatives
    */
   public selectModel(task: TaskAnalysis): ModelSelectionResult {
     // Check for agent override
@@ -229,7 +230,8 @@ export class ModelSelector {
 
   /**
    * Get model profile
-   * @param model
+   * @param model - Model type to retrieve profile for
+   * @returns Model profile with pricing, capabilities, and characteristics
    */
   public getModelProfile(model: ModelType): ModelProfile {
     return MODEL_PROFILES[model];
@@ -237,8 +239,9 @@ export class ModelSelector {
 
   /**
    * Estimate cost for a task with a specific model
-   * @param model
-   * @param task
+   * @param model - Model type to calculate cost for
+   * @param task - Task analysis with token estimates
+   * @returns Estimated cost in USD rounded to 4 decimal places
    */
   public estimateCost(model: ModelType, task: TaskAnalysis): number {
     const profile = MODEL_PROFILES[model];
@@ -249,11 +252,12 @@ export class ModelSelector {
 
   /**
    * Analyze task complexity from content
-   * @param content
-   * @param options
-   * @param options.hasCodeGeneration
-   * @param options.hasReasoning
-   * @param options.requiresAccuracy
+   * @param content - Task content to analyze for complexity signals
+   * @param options - Additional complexity indicators
+   * @param options.hasCodeGeneration - Whether task involves code generation
+   * @param options.hasReasoning - Whether task requires complex reasoning
+   * @param options.requiresAccuracy - Whether high accuracy is critical
+   * @returns Complexity level: 'simple', 'moderate', 'complex', or 'critical'
    */
   public analyzeComplexity(
     content: string,
@@ -293,7 +297,8 @@ export class ModelSelector {
 
   /**
    * Get recommended model for an agent type
-   * @param agentType
+   * @param agentType - Type of agent (e.g., 'collector', 'worker', 'validator')
+   * @returns Recommended model type based on agent capabilities needed
    */
   public getAgentRecommendation(agentType: string): ModelType {
     const recommendations: Record<string, ModelType> = {
@@ -314,8 +319,9 @@ export class ModelSelector {
 
   /**
    * Calculate model scores based on task requirements
-   * @param task
-   * @param minModel
+   * @param task - Task analysis with requirements and constraints
+   * @param minModel - Minimum model capability required for the task
+   * @returns Scores for each model type (higher is better, -1 if below minimum)
    */
   private calculateModelScores(task: TaskAnalysis, minModel: ModelType): Record<ModelType, number> {
     const scores: Record<ModelType, number> = {
@@ -370,8 +376,9 @@ export class ModelSelector {
 
   /**
    * Get selection reason
-   * @param model
-   * @param task
+   * @param model - Selected model type
+   * @param task - Task analysis that informed the selection
+   * @returns Human-readable explanation of why this model was selected
    */
   private getSelectionReason(model: ModelType, task: TaskAnalysis): string {
     const profile = MODEL_PROFILES[model];
@@ -397,10 +404,11 @@ export class ModelSelector {
 
   /**
    * Create selection result
-   * @param model
-   * @param reason
-   * @param task
-   * @param confidence
+   * @param model - Selected model type
+   * @param reason - Explanation for selection
+   * @param task - Task analysis used for selection
+   * @param confidence - Confidence score (0-1) in the selection
+   * @returns Complete model selection result with alternatives
    */
   private createResult(
     model: ModelType,
@@ -433,9 +441,10 @@ export class ModelSelector {
 
   /**
    * Get reason why alternative was not selected
-   * @param alt
-   * @param selected
-   * @param task
+   * @param alt - Alternative model being compared
+   * @param selected - The model that was selected
+   * @param task - Task analysis context
+   * @returns Explanation of why the alternative was not chosen
    */
   private getAlternativeReason(alt: ModelType, selected: ModelType, task: TaskAnalysis): string {
     const altProfile = MODEL_PROFILES[alt];
@@ -466,7 +475,8 @@ let globalModelSelector: ModelSelector | null = null;
 
 /**
  * Get or create the global ModelSelector instance
- * @param config
+ * @param config - Optional configuration for model selection
+ * @returns Global ModelSelector singleton instance
  */
 export function getModelSelector(config?: ModelSelectorConfig): ModelSelector {
   if (globalModelSelector === null) {
@@ -477,6 +487,7 @@ export function getModelSelector(config?: ModelSelectorConfig): ModelSelector {
 
 /**
  * Reset the global ModelSelector instance
+ * @returns void
  */
 export function resetModelSelector(): void {
   globalModelSelector = null;

--- a/src/monitoring/ResponseTimeBenchmarks.ts
+++ b/src/monitoring/ResponseTimeBenchmarks.ts
@@ -206,8 +206,9 @@ export class ResponseTimeBenchmarks {
 
   /**
    * Deep merge benchmark configurations
-   * @param defaults
-   * @param custom
+   * @param defaults - Default benchmark values to use as base
+   * @param custom - Custom benchmark values to override defaults
+   * @returns Merged benchmark configuration
    */
   private mergeBenchmarks(defaults: AllBenchmarks, custom: Partial<AllBenchmarks>): AllBenchmarks {
     return {
@@ -224,6 +225,7 @@ export class ResponseTimeBenchmarks {
 
   /**
    * Get all benchmark definitions
+   * @returns Complete benchmark configuration including pipeline, stages, latency, and E2E
    */
   public getBenchmarks(): AllBenchmarks {
     return this.benchmarks;
@@ -231,7 +233,8 @@ export class ResponseTimeBenchmarks {
 
   /**
    * Get pipeline benchmarks for a complexity level
-   * @param complexity
+   * @param complexity - Feature complexity level (simple, medium, complex)
+   * @returns Pipeline benchmark targets for the specified complexity
    */
   public getPipelineBenchmarks(complexity: FeatureComplexity): PipelineBenchmarks {
     return this.benchmarks.pipeline[complexity];
@@ -239,6 +242,7 @@ export class ResponseTimeBenchmarks {
 
   /**
    * Get stage benchmarks
+   * @returns Benchmark targets for individual pipeline stages
    */
   public getStageBenchmarks(): StageBenchmarks {
     return this.benchmarks.stages;
@@ -246,6 +250,7 @@ export class ResponseTimeBenchmarks {
 
   /**
    * Get latency benchmarks
+   * @returns Benchmark targets for system latency metrics
    */
   public getLatencyBenchmarks(): LatencyBenchmarks {
     return this.benchmarks.latency;
@@ -253,9 +258,10 @@ export class ResponseTimeBenchmarks {
 
   /**
    * Create a benchmark target
-   * @param name
-   * @param targetMs
-   * @param description
+   * @param name - Unique identifier for the benchmark
+   * @param targetMs - Target time in milliseconds
+   * @param description - Human-readable description of what is being benchmarked
+   * @returns Complete benchmark target with warning and critical thresholds
    */
   public createTarget(name: string, targetMs: number, description: string): BenchmarkTarget {
     return {
@@ -269,9 +275,10 @@ export class ResponseTimeBenchmarks {
 
   /**
    * Validate a timing against a benchmark
-   * @param name
-   * @param actualMs
-   * @param target
+   * @param name - Unique identifier for the benchmark being validated
+   * @param actualMs - Actual measured time in milliseconds
+   * @param target - Benchmark target to validate against
+   * @returns Validation result with status and deviation percentage
    */
   public validateTiming(name: string, actualMs: number, target: BenchmarkTarget): BenchmarkResult {
     let status: 'pass' | 'warning' | 'fail';
@@ -299,11 +306,12 @@ export class ResponseTimeBenchmarks {
 
   /**
    * Validate pipeline timing
-   * @param complexity
-   * @param timings
-   * @param timings.documentGenerationMs
-   * @param timings.issueGenerationMs
-   * @param timings.totalMs
+   * @param complexity - Feature complexity level being validated
+   * @param timings - Measured timing values for pipeline phases
+   * @param timings.documentGenerationMs - Time spent generating documentation
+   * @param timings.issueGenerationMs - Time spent generating issues
+   * @param timings.totalMs - Total pipeline execution time
+   * @returns Validation result with pass/fail status and detailed breakdown
    */
   public validatePipeline(
     complexity: FeatureComplexity,
@@ -350,7 +358,8 @@ export class ResponseTimeBenchmarks {
 
   /**
    * Validate stage timings
-   * @param stageTimes
+   * @param stageTimes - Measured execution times for individual pipeline stages
+   * @returns Validation result comparing each stage against its target
    */
   public validateStages(
     stageTimes: Partial<Record<keyof StageBenchmarks, number>>
@@ -371,7 +380,8 @@ export class ResponseTimeBenchmarks {
 
   /**
    * Validate latency metrics
-   * @param latencies
+   * @param latencies - Measured latency values for system operations
+   * @returns Validation result comparing each latency metric against its target
    */
   public validateLatency(
     latencies: Partial<Record<keyof LatencyBenchmarks, number>>
@@ -392,7 +402,8 @@ export class ResponseTimeBenchmarks {
 
   /**
    * Summarize validation results
-   * @param results
+   * @param results - Array of individual benchmark validation results
+   * @returns Overall validation summary with pass/warning/fail counts
    */
   private summarizeResults(results: BenchmarkResult[]): ValidationResult {
     const passed = results.filter((r) => r.status === 'pass').length;
@@ -415,10 +426,11 @@ export class ResponseTimeBenchmarks {
 
   /**
    * Record a benchmark run
-   * @param sessionId
-   * @param complexity
-   * @param stageTimes
-   * @param totalTimeMs
+   * @param sessionId - Unique identifier for the session
+   * @param complexity - Feature complexity level of the run
+   * @param stageTimes - Execution times for each stage in the run
+   * @param totalTimeMs - Total execution time for the entire run
+   * @returns History entry that was recorded
    */
   public recordRun(
     sessionId: string,
@@ -449,6 +461,7 @@ export class ResponseTimeBenchmarks {
 
   /**
    * Get benchmark history
+   * @returns All recorded benchmark history entries
    */
   public getHistory(): readonly BenchmarkHistoryEntry[] {
     return [...this.history];
@@ -456,7 +469,8 @@ export class ResponseTimeBenchmarks {
 
   /**
    * Get history for a specific complexity
-   * @param complexity
+   * @param complexity - Feature complexity level to filter by
+   * @returns History entries matching the specified complexity
    */
   public getHistoryByComplexity(complexity: FeatureComplexity): readonly BenchmarkHistoryEntry[] {
     return this.history.filter((h) => h.complexity === complexity);
@@ -464,7 +478,8 @@ export class ResponseTimeBenchmarks {
 
   /**
    * Get performance trend
-   * @param complexity
+   * @param complexity - Optional complexity level to analyze (if omitted, analyzes all)
+   * @returns Performance statistics and trend direction
    */
   public getPerformanceTrend(complexity?: FeatureComplexity): {
     readonly avgTotalMs: number;
@@ -521,6 +536,7 @@ export class ResponseTimeBenchmarks {
 
   /**
    * Generate a performance report
+   * @returns Comprehensive report with benchmarks, history, and trend analysis
    */
   public generateReport(): {
     readonly benchmarks: AllBenchmarks;
@@ -579,8 +595,9 @@ export class ResponseTimeBenchmarks {
 
   /**
    * Check if E2E target is met
-   * @param complexity
-   * @param totalTimeMs
+   * @param complexity - Feature complexity level being validated
+   * @param totalTimeMs - Total measured execution time in milliseconds
+   * @returns Comparison of actual time against E2E target
    */
   public checkE2ETarget(
     complexity: FeatureComplexity,
@@ -619,7 +636,8 @@ let globalResponseTimeBenchmarks: ResponseTimeBenchmarks | null = null;
 
 /**
  * Get or create the global ResponseTimeBenchmarks instance
- * @param customBenchmarks
+ * @param customBenchmarks - Optional custom benchmark values to override defaults
+ * @returns The global singleton ResponseTimeBenchmarks instance
  */
 export function getResponseTimeBenchmarks(
   customBenchmarks?: Partial<AllBenchmarks>

--- a/src/monitoring/TokenBudgetManager.ts
+++ b/src/monitoring/TokenBudgetManager.ts
@@ -200,9 +200,10 @@ export class TokenBudgetManager {
 
   /**
    * Record token usage and check budget
-   * @param inputTokens
-   * @param outputTokens
-   * @param costUsd
+   * @param inputTokens - Number of input tokens consumed in the operation
+   * @param outputTokens - Number of output tokens generated in the operation
+   * @param costUsd - Cost of the operation in US dollars
+   * @returns Budget check result indicating if operation is allowed and any warnings
    */
   public recordUsage(
     inputTokens: number,
@@ -230,9 +231,9 @@ export class TokenBudgetManager {
 
   /**
    * Add a usage record to history
-   * @param inputTokens
-   * @param outputTokens
-   * @param costUsd
+   * @param inputTokens - Number of input tokens to record
+   * @param outputTokens - Number of output tokens to record
+   * @param costUsd - Cost to record in US dollars
    */
   private addUsageRecord(inputTokens: number, outputTokens: number, costUsd: number): void {
     const record: UsageRecord = {
@@ -253,6 +254,7 @@ export class TokenBudgetManager {
 
   /**
    * Check current budget status
+   * @returns Budget check result with current status and warnings
    */
   public checkBudget(): BudgetCheckResult {
     const warnings: BudgetWarning[] = [];
@@ -338,6 +340,7 @@ export class TokenBudgetManager {
 
   /**
    * Get current budget status
+   * @returns Detailed budget status including usage, limits, and warnings
    */
   public getStatus(): BudgetStatus {
     const tokenLimit = this.config.sessionTokenLimit;
@@ -401,6 +404,7 @@ export class TokenBudgetManager {
 
   /**
    * Check if override is active
+   * @returns True if budget override is currently enabled
    */
   public isOverrideActive(): boolean {
     return this.overrideActive;
@@ -422,6 +426,7 @@ export class TokenBudgetManager {
 
   /**
    * Get warning history
+   * @returns Array of all budget warnings that have been triggered
    */
   public getWarningHistory(): readonly BudgetWarning[] {
     return this.warningHistory;
@@ -465,6 +470,7 @@ export class TokenBudgetManager {
 
   /**
    * Get current token limit
+   * @returns Current session token limit or undefined if no limit is set
    */
   public getTokenLimit(): number | undefined {
     return this.config.sessionTokenLimit;
@@ -472,6 +478,7 @@ export class TokenBudgetManager {
 
   /**
    * Get current cost limit
+   * @returns Current session cost limit in USD or undefined if no limit is set
    */
   public getCostLimit(): number | undefined {
     return this.config.sessionCostLimitUsd;
@@ -479,8 +486,9 @@ export class TokenBudgetManager {
 
   /**
    * Estimate if a request will exceed budget
-   * @param estimatedInputTokens
-   * @param estimatedOutputTokens
+   * @param estimatedInputTokens - Expected number of input tokens for the operation
+   * @param estimatedOutputTokens - Expected number of output tokens for the operation
+   * @returns Budget check result indicating if estimated operation would be allowed
    */
   public estimateUsage(
     estimatedInputTokens: number,
@@ -506,6 +514,7 @@ export class TokenBudgetManager {
 
   /**
    * Get budget forecast based on historical usage patterns
+   * @returns Budget forecast with projected usage trends and estimated time to exhaustion
    */
   public getForecast(): BudgetForecast {
     // Check if we have enough data for forecasting
@@ -603,6 +612,7 @@ export class TokenBudgetManager {
 
   /**
    * Get usage history records
+   * @returns Array of historical usage records for forecasting and analysis
    */
   public getUsageHistory(): readonly UsageRecord[] {
     return this.usageHistory;
@@ -610,6 +620,7 @@ export class TokenBudgetManager {
 
   /**
    * Get projected overage alerts
+   * @returns Array of alerts for projected budget overages based on usage trends
    */
   public getProjectedOverageAlerts(): readonly ProjectedOverageAlert[] {
     return this.projectedOverageAlerts;
@@ -617,7 +628,8 @@ export class TokenBudgetManager {
 
   /**
    * Calculate exponentially smoothed averages
-   * @param records
+   * @param records - Array of usage records to analyze
+   * @returns Object containing smoothed average tokens and cost per operation
    */
   private calculateSmoothedAverages(records: UsageRecord[]): {
     avgTokens: number;
@@ -648,7 +660,8 @@ export class TokenBudgetManager {
 
   /**
    * Calculate operation rate (operations per millisecond)
-   * @param records
+   * @param records - Array of usage records with timestamps
+   * @returns Operations per millisecond or undefined if insufficient data
    */
   private calculateOperationRate(records: UsageRecord[]): number | undefined {
     const firstRecord = records[0];
@@ -671,7 +684,8 @@ export class TokenBudgetManager {
 
   /**
    * Calculate usage trend
-   * @param records
+   * @param records - Array of usage records to analyze for trend
+   * @returns Usage trend classification (increasing, stable, or decreasing)
    */
   private calculateUsageTrend(records: UsageRecord[]): 'increasing' | 'stable' | 'decreasing' {
     if (records.length < 3) {
@@ -699,7 +713,8 @@ export class TokenBudgetManager {
 
   /**
    * Calculate forecast confidence based on data consistency
-   * @param records
+   * @param records - Array of usage records to calculate confidence from
+   * @returns Confidence score between 0.25 and 1.0 based on data consistency
    */
   private calculateForecastConfidence(records: UsageRecord[]): number {
     if (records.length < 2) {
@@ -791,9 +806,10 @@ export class TokenBudgetManager {
 
   /**
    * Create a warning object
-   * @param type
-   * @param thresholdPercent
-   * @param currentPercent
+   * @param type - Type of budget warning (token or cost)
+   * @param thresholdPercent - Threshold percentage that was exceeded
+   * @param currentPercent - Current usage percentage
+   * @returns Formatted budget warning object
    */
   private createWarning(
     type: 'token' | 'cost',
@@ -814,7 +830,8 @@ export class TokenBudgetManager {
 
   /**
    * Get severity level for a threshold
-   * @param threshold
+   * @param threshold - Threshold percentage to evaluate
+   * @returns Alert severity level (critical, warning, or info)
    */
   private getSeverityForThreshold(threshold: number): AlertSeverity {
     if (threshold >= 90) return 'critical';
@@ -824,6 +841,7 @@ export class TokenBudgetManager {
 
   /**
    * Get reason message for limit exceeded
+   * @returns Detailed message explaining which limits were exceeded
    */
   private getLimitExceededReason(): string {
     const status = this.getStatus();
@@ -863,6 +881,7 @@ export class TokenBudgetManager {
 
   /**
    * Get the persistence file path for the current session
+   * @returns Full file path for the current session's budget state
    */
   private getPersistenceFilePath(): string {
     return path.join(this.persistenceDir, `budget-${this.sessionId}.json`);
@@ -870,6 +889,7 @@ export class TokenBudgetManager {
 
   /**
    * Save current budget state to persistence
+   * @returns True if save was successful, false otherwise
    */
   public saveToPersistence(): boolean {
     if (!this.persistenceEnabled) {
@@ -912,6 +932,7 @@ export class TokenBudgetManager {
 
   /**
    * Load budget state from persistence
+   * @returns True if state was successfully loaded, false otherwise
    */
   public loadFromPersistence(): boolean {
     if (!this.persistenceEnabled) {
@@ -963,6 +984,7 @@ export class TokenBudgetManager {
 
   /**
    * Delete persisted budget state
+   * @returns True if deletion was successful, false otherwise
    */
   public deletePersistence(): boolean {
     if (!this.persistenceEnabled) {
@@ -982,6 +1004,7 @@ export class TokenBudgetManager {
 
   /**
    * Get the session ID
+   * @returns Unique identifier for the current budget session
    */
   public getSessionId(): string {
     return this.sessionId;
@@ -989,6 +1012,7 @@ export class TokenBudgetManager {
 
   /**
    * Check if persistence is enabled
+   * @returns True if budget persistence is enabled for this session
    */
   public isPersistenceEnabled(): boolean {
     return this.persistenceEnabled;
@@ -996,7 +1020,8 @@ export class TokenBudgetManager {
 
   /**
    * List all persisted budget sessions
-   * @param persistenceDir
+   * @param persistenceDir - Directory to search for persisted sessions (defaults to configured path)
+   * @returns Array of session IDs that have persisted budget data
    */
   public static listPersistedSessions(persistenceDir?: string): string[] {
     const dir = persistenceDir ?? DEFAULT_PERSISTENCE_DIR;
@@ -1018,8 +1043,9 @@ export class TokenBudgetManager {
 
   /**
    * Load a specific persisted session
-   * @param sessionId
-   * @param persistenceDir
+   * @param sessionId - Session ID to load
+   * @param persistenceDir - Directory containing persisted sessions (defaults to configured path)
+   * @returns Budget persistence state or null if not found
    */
   public static loadSession(
     sessionId: string,
@@ -1042,8 +1068,9 @@ export class TokenBudgetManager {
 
   /**
    * Delete a specific persisted session
-   * @param sessionId
-   * @param persistenceDir
+   * @param sessionId - Session ID to delete
+   * @param persistenceDir - Directory containing persisted sessions (defaults to configured path)
+   * @returns True if deletion was successful, false otherwise
    */
   public static deleteSession(sessionId: string, persistenceDir?: string): boolean {
     const dir = persistenceDir ?? DEFAULT_PERSISTENCE_DIR;
@@ -1063,8 +1090,9 @@ export class TokenBudgetManager {
    * Clean up old persisted sessions
    *
    * Removes sessions older than the specified age (in milliseconds)
-   * @param olderThanMs
-   * @param persistenceDir
+   * @param olderThanMs - Age threshold in milliseconds for session deletion
+   * @param persistenceDir - Directory containing persisted sessions (defaults to configured path)
+   * @returns Number of sessions deleted
    */
   public static cleanupOldSessions(olderThanMs: number, persistenceDir?: string): number {
     const dir = persistenceDir ?? DEFAULT_PERSISTENCE_DIR;
@@ -1104,7 +1132,8 @@ let globalBudgetManager: TokenBudgetManager | null = null;
 
 /**
  * Get or create the global TokenBudgetManager instance
- * @param config
+ * @param config - Optional configuration for the budget manager
+ * @returns Global singleton instance of TokenBudgetManager
  */
 export function getTokenBudgetManager(config?: TokenBudgetConfig): TokenBudgetManager {
   if (globalBudgetManager === null) {

--- a/src/monitoring/TokenUsageReport.ts
+++ b/src/monitoring/TokenUsageReport.ts
@@ -196,10 +196,11 @@ export class TokenUsageReport {
 
   /**
    * Generate a full report
-   * @param tokenUsage
-   * @param agentMetrics
-   * @param stageDurations
-   * @param model
+   * @param tokenUsage - Token usage metrics to analyze
+   * @param agentMetrics - Performance metrics for each agent
+   * @param stageDurations - Duration data for each pipeline stage
+   * @param model - Model name for cost calculation (default: 'sonnet')
+   * @returns Complete token usage report with summary, breakdowns, and recommendations
    */
   public generate(
     tokenUsage: TokenUsageMetrics,
@@ -237,8 +238,8 @@ export class TokenUsageReport {
 
   /**
    * Record a trend data point
-   * @param tokens
-   * @param costUsd
+   * @param tokens - Number of tokens used in this data point
+   * @param costUsd - Cost in USD for this data point
    */
   public recordTrendPoint(tokens: number, costUsd: number): void {
     if (!this.config.includeTrends) return;
@@ -258,7 +259,8 @@ export class TokenUsageReport {
 
   /**
    * Export report to JSON
-   * @param report
+   * @param report - Token usage report to serialize
+   * @returns JSON string representation of the report
    */
   public toJSON(report: TokenUsageReportData): string {
     return JSON.stringify(report, null, 2);
@@ -266,7 +268,8 @@ export class TokenUsageReport {
 
   /**
    * Export report to Markdown
-   * @param report
+   * @param report - Token usage report to format
+   * @returns Markdown-formatted report string
    */
   public toMarkdown(report: TokenUsageReportData): string {
     const lines: string[] = [];
@@ -333,10 +336,11 @@ export class TokenUsageReport {
 
   /**
    * Generate summary
-   * @param tokenUsage
-   * @param _agentMetrics
-   * @param stageDurations
-   * @param sessionDurationMs
+   * @param tokenUsage - Token usage metrics to summarize
+   * @param _agentMetrics - Agent metrics (currently unused)
+   * @param stageDurations - Duration data for each pipeline stage
+   * @param sessionDurationMs - Total session duration in milliseconds
+   * @returns Summary of token usage including totals and key metrics
    */
   private generateSummary(
     tokenUsage: TokenUsageMetrics,
@@ -393,8 +397,9 @@ export class TokenUsageReport {
 
   /**
    * Calculate usage by model
-   * @param tokenUsage
-   * @param model
+   * @param tokenUsage - Token usage metrics containing input/output token counts
+   * @param model - Model name for cost calculation
+   * @returns Array of model usage details with tokens and cost
    */
   private calculateModelUsage(tokenUsage: TokenUsageMetrics, model: string): ModelUsage[] {
     const totalTokens = tokenUsage.totalInputTokens + tokenUsage.totalOutputTokens;
@@ -418,8 +423,9 @@ export class TokenUsageReport {
 
   /**
    * Calculate usage by agent
-   * @param tokenUsage
-   * @param agentMetrics
+   * @param tokenUsage - Token usage metrics containing per-agent breakdowns
+   * @param agentMetrics - Performance metrics including invocation counts
+   * @returns Array of agent usage details sorted by token consumption
    */
   private calculateAgentUsage(
     tokenUsage: TokenUsageMetrics,
@@ -453,8 +459,9 @@ export class TokenUsageReport {
 
   /**
    * Calculate usage by stage
-   * @param stageDurations
-   * @param tokenUsage
+   * @param stageDurations - Duration data for each pipeline stage
+   * @param tokenUsage - Token usage metrics to distribute across stages
+   * @returns Array of stage usage details with proportional token estimates
    */
   private calculateStageUsage(
     stageDurations: readonly StageDuration[],
@@ -484,9 +491,10 @@ export class TokenUsageReport {
 
   /**
    * Generate optimization recommendations
-   * @param tokenUsage
-   * @param agentMetrics
-   * @param byAgent
+   * @param tokenUsage - Token usage metrics to analyze for optimization
+   * @param agentMetrics - Agent performance metrics including invocation patterns
+   * @param byAgent - Per-agent usage details sorted by consumption
+   * @returns Array of optimization recommendations sorted by priority
    */
   private generateRecommendations(
     tokenUsage: TokenUsageMetrics,
@@ -562,9 +570,10 @@ export class TokenUsageReport {
 
   /**
    * Calculate cost for given tokens
-   * @param inputTokens
-   * @param outputTokens
-   * @param model
+   * @param inputTokens - Number of input tokens consumed
+   * @param outputTokens - Number of output tokens generated
+   * @param model - Model name for pricing lookup (default: 'sonnet')
+   * @returns Total cost in USD rounded to 4 decimal places
    */
   private calculateCost(inputTokens: number, outputTokens: number, model = 'sonnet'): number {
     const pricing = TOKEN_PRICING[model] ?? TOKEN_PRICING['sonnet'];
@@ -580,8 +589,9 @@ export class TokenUsageReport {
 
 /**
  * Create a new TokenUsageReport instance
- * @param sessionId
- * @param config
+ * @param sessionId - Unique identifier for the session
+ * @param config - Optional configuration for report generation
+ * @returns Configured TokenUsageReport instance
  */
 export function createTokenUsageReport(
   sessionId: string,


### PR DESCRIPTION
## Summary
- Add meaningful `@param` descriptions and `@returns` tags to all public and internal APIs across 7 files in `src/monitoring/`
- Resolves ~265 ESLint JSDoc warnings (`jsdoc/require-param-description`, `jsdoc/require-returns`)
- Zero JSDoc warnings remaining in these modules after changes

## Files Modified
| File | Warnings Fixed |
|------|---------------|
| `TokenBudgetManager.ts` | ~53 |
| `MetricsCollector.ts` | ~47 |
| `ResponseTimeBenchmarks.ts` | ~44 |
| `TokenUsageReport.ts` | ~36 |
| `AgentBudgetRegistry.ts` | ~34 |
| `ModelSelector.ts` | ~32 |
| `BudgetAggregator.ts` | ~19 |

## Test Plan
- [x] ESLint passes with 0 JSDoc warnings in modified files
- [x] All 5052 existing tests pass (180 test files)
- [x] No functional code changes, documentation-only

Part of #460
Closes #469