### PR TITLE
refactor(lint): add JSDoc descriptions to SRS and SDS writer modules (#477)

### DIFF
--- a/src/sds-writer/APISpecifier.ts
+++ b/src/sds-writer/APISpecifier.ts
@@ -140,7 +140,8 @@ export class APISpecifier {
 
   /**
    * Generate a single API endpoint from a use case
-   * @param input
+   * @param input - API design input containing component, use case, and NFRs
+   * @returns Generated API endpoint or null if the use case cannot be converted
    */
   public specifyEndpoint(input: APIDesignInput): APIEndpoint | null {
     const { component, useCase, nfrs } = input;
@@ -185,8 +186,9 @@ export class APISpecifier {
 
   /**
    * Analyze use case to determine HTTP method and path
-   * @param useCase
-   * @param component
+   * @param useCase - Parsed use case to analyze
+   * @param component - Associated SDS component for resource naming
+   * @returns HTTP method, path template, and resource name
    */
   private analyzeUseCase(
     useCase: ParsedUseCase,
@@ -261,7 +263,8 @@ export class APISpecifier {
 
   /**
    * Extract resource name from component name
-   * @param componentName
+   * @param componentName - Full component name including suffix
+   * @returns Resource name with common suffixes removed
    */
   private extractResourceName(componentName: string): string {
     return componentName
@@ -274,7 +277,8 @@ export class APISpecifier {
 
   /**
    * Convert string to kebab-case
-   * @param str
+   * @param str - Input string in camelCase or PascalCase
+   * @returns Kebab-case formatted string
    */
   private toKebabCase(str: string): string {
     return str
@@ -285,8 +289,9 @@ export class APISpecifier {
 
   /**
    * Generate request and response schemas
-   * @param useCase
-   * @param resourceName
+   * @param useCase - Parsed use case for property extraction
+   * @param resourceName - Resource name for schema naming
+   * @returns Request and response data schemas
    */
   private generateSchemas(
     useCase: ParsedUseCase,
@@ -316,7 +321,8 @@ export class APISpecifier {
 
   /**
    * Extract properties from use case scenario
-   * @param useCase
+   * @param useCase - Parsed use case with scenario text to analyze
+   * @returns Array of data properties matched from scenario patterns
    */
   private extractPropertiesFromScenario(useCase: ParsedUseCase): DataProperty[] {
     const properties: DataProperty[] = [];
@@ -409,7 +415,8 @@ export class APISpecifier {
 
   /**
    * Extract path parameters from path template
-   * @param path
+   * @param path - URL path template with curly-brace placeholders
+   * @returns Array of API parameters extracted from path segments
    */
   private extractPathParameters(path: string): APIParameter[] {
     const parameters: APIParameter[] = [];
@@ -433,7 +440,8 @@ export class APISpecifier {
 
   /**
    * Convert camelCase to readable string
-   * @param str
+   * @param str - camelCase input string
+   * @returns Human-readable lowercase string with spaces
    */
   private toReadable(str: string): string {
     return str
@@ -444,8 +452,9 @@ export class APISpecifier {
 
   /**
    * Extract query parameters from use case
-   * @param useCase
-   * @param method
+   * @param useCase - Parsed use case for parameter extraction
+   * @param method - HTTP method to determine if query params apply
+   * @returns Array of query parameters for GET list/search operations
    */
   private extractQueryParameters(useCase: ParsedUseCase, method: HttpMethod): APIParameter[] {
     if (method !== 'GET') {
@@ -488,8 +497,9 @@ export class APISpecifier {
 
   /**
    * Determine security level from use case and NFRs
-   * @param useCase
-   * @param nfrs
+   * @param useCase - Parsed use case to analyze for security indicators
+   * @param nfrs - Non-functional requirements with security constraints
+   * @returns Resolved security level for the endpoint
    */
   private determineSecurityLevel(
     useCase: ParsedUseCase,
@@ -547,8 +557,9 @@ export class APISpecifier {
 
   /**
    * Generate error responses for an endpoint
-   * @param useCase
-   * @param method
+   * @param useCase - Parsed use case with alternative scenarios for error detection
+   * @param method - HTTP method for method-specific error responses
+   * @returns Deduplicated array of error responses
    */
   private generateErrorResponses(useCase: ParsedUseCase, method: HttpMethod): ErrorResponse[] {
     const errors: ErrorResponse[] = [];
@@ -624,7 +635,8 @@ export class APISpecifier {
 
   /**
    * Generate description for endpoint
-   * @param useCase
+   * @param useCase - Parsed use case to derive the endpoint description from
+   * @returns Formatted endpoint description with requirements and steps
    */
   private generateDescription(useCase: ParsedUseCase): string {
     const parts: string[] = [];

--- a/src/sds-writer/ComponentDesigner.ts
+++ b/src/sds-writer/ComponentDesigner.ts
@@ -119,7 +119,8 @@ export class ComponentDesigner {
 
   /**
    * Design a single component from a feature
-   * @param input
+   * @param input - Component design input containing feature, use cases, NFRs, and constraints
+   * @returns Designed SDS component
    */
   public designComponent(input: ComponentDesignInput): SDSComponent {
     const { feature, useCases, nfrs, constraints, componentIndex } = input;
@@ -167,7 +168,8 @@ export class ComponentDesigner {
 
   /**
    * Group use cases by their source feature ID
-   * @param useCases
+   * @param useCases - Use cases to group
+   * @returns Map of feature IDs to their associated use cases
    */
   private groupUseCasesByFeature(useCases: readonly ParsedUseCase[]): Map<string, ParsedUseCase[]> {
     const map = new Map<string, ParsedUseCase[]>();
@@ -186,7 +188,8 @@ export class ComponentDesigner {
 
   /**
    * Generate component name from feature name
-   * @param featureName
+   * @param featureName - Raw feature name to convert
+   * @returns PascalCase component name with an appropriate suffix
    */
   private generateComponentName(featureName: string): string {
     // Remove common prefixes and clean up
@@ -226,7 +229,8 @@ export class ComponentDesigner {
 
   /**
    * Generate responsibility statement from feature
-   * @param feature
+   * @param feature - Source SRS feature
+   * @returns Concise responsibility statement (max 200 characters)
    */
   private generateResponsibility(feature: ParsedSRSFeature): string {
     if (feature.description) {
@@ -243,7 +247,8 @@ export class ComponentDesigner {
 
   /**
    * Generate description from feature
-   * @param feature
+   * @param feature - Source SRS feature
+   * @returns Multi-line description including key capabilities
    */
   private generateDescription(feature: ParsedSRSFeature): string {
     const parts: string[] = [];
@@ -262,9 +267,10 @@ export class ComponentDesigner {
 
   /**
    * Generate interfaces for a component
-   * @param componentName
-   * @param feature
-   * @param useCases
+   * @param componentName - Name of the component
+   * @param feature - Source SRS feature
+   * @param useCases - Related use cases for additional interfaces
+   * @returns Generated SDS interfaces
    */
   private generateInterfaces(
     componentName: string,
@@ -293,8 +299,9 @@ export class ComponentDesigner {
 
   /**
    * Generate main interface for a component
-   * @param componentName
-   * @param feature
+   * @param componentName - Name of the component
+   * @param feature - Source SRS feature providing acceptance criteria
+   * @returns Main interface or null if no methods could be generated
    */
   private generateMainInterface(
     componentName: string,
@@ -331,8 +338,9 @@ export class ComponentDesigner {
 
   /**
    * Generate interface from a use case
-   * @param componentName
-   * @param useCase
+   * @param componentName - Name of the parent component
+   * @param useCase - Source use case with scenarios
+   * @returns Use case interface or null if no methods could be generated
    */
   private generateUseCaseInterface(
     componentName: string,
@@ -372,7 +380,8 @@ export class ComponentDesigner {
 
   /**
    * Sanitize use case name for interface naming
-   * @param name
+   * @param name - Raw use case name
+   * @returns PascalCase alphanumeric string suitable for interface naming
    */
   private sanitizeUseCaseName(name: string): string {
     return name
@@ -384,7 +393,8 @@ export class ComponentDesigner {
 
   /**
    * Generate method from acceptance criterion
-   * @param criterion
+   * @param criterion - Acceptance criterion text (e.g., "User can create...")
+   * @returns Parsed method definition or null if no action verb is detected
    */
   private generateMethodFromCriterion(criterion: string): SDSMethod | null {
     // Parse criterion for action verbs
@@ -417,8 +427,9 @@ export class ComponentDesigner {
 
   /**
    * Generate method from use case scenario
-   * @param scenarioName
-   * @param steps
+   * @param scenarioName - Name of the scenario
+   * @param steps - Ordered list of scenario steps
+   * @returns Method definition or null if scenario is empty
    */
   private generateMethodFromScenario(
     scenarioName: string,
@@ -454,7 +465,8 @@ export class ComponentDesigner {
 
   /**
    * Generate method name from action description
-   * @param action
+   * @param action - Action description text to derive the method name from
+   * @returns camelCase method name (verb + noun)
    */
   private generateMethodName(action: string): string {
     // Extract key verbs and nouns
@@ -527,7 +539,8 @@ export class ComponentDesigner {
 
   /**
    * Extract parameters from action description
-   * @param action
+   * @param action - Action description text to extract parameters from
+   * @returns Array of detected method parameters
    */
   private extractParameters(action: string): MethodParameter[] {
     const parameters: MethodParameter[] = [];
@@ -565,7 +578,8 @@ export class ComponentDesigner {
 
   /**
    * Infer return type from action description
-   * @param action
+   * @param action - Action description text to infer return type from
+   * @returns TypeScript return type string (e.g., "Promise<boolean>")
    */
   private inferReturnType(action: string): string {
     const lowerAction = action.toLowerCase();
@@ -609,7 +623,8 @@ export class ComponentDesigner {
 
   /**
    * Generate default CRUD methods for a feature
-   * @param featureName
+   * @param featureName - Feature name used to derive entity type names
+   * @returns Array of create, get, update, delete, and list methods
    */
   private generateDefaultMethods(featureName: string): SDSMethod[] {
     const entityName = featureName.replace(/\s+/g, '').replace(/^(.)/, (c) => c.toUpperCase());
@@ -653,8 +668,9 @@ export class ComponentDesigner {
 
   /**
    * Generate TypeScript interface code
-   * @param name
-   * @param methods
+   * @param name - Interface name
+   * @param methods - Methods to include in the interface
+   * @returns Raw TypeScript interface code string
    */
   private generateInterfaceCode(name: string, methods: readonly SDSMethod[]): string {
     const methodLines = methods.map((m) => `  ${m.signature};`).join('\n');
@@ -664,9 +680,10 @@ export class ComponentDesigner {
 
   /**
    * Generate implementation notes from NFRs and constraints
-   * @param feature
-   * @param nfrs
-   * @param constraints
+   * @param feature - Source feature for priority-based notes
+   * @param nfrs - Non-functional requirements to extract notes from
+   * @param constraints - Constraints to include in the notes
+   * @returns Multi-line implementation notes string
    */
   private generateImplementationNotes(
     feature: ParsedSRSFeature,
@@ -706,8 +723,9 @@ export class ComponentDesigner {
 
   /**
    * Suggest technology based on feature and NFRs
-   * @param feature
-   * @param nfrs
+   * @param feature - Feature to analyze for technology hints
+   * @param nfrs - NFRs that may influence technology choice
+   * @returns Suggested technology string or undefined if no match
    */
   private suggestTechnology(
     feature: ParsedSRSFeature,
@@ -747,8 +765,9 @@ export class ComponentDesigner {
 
   /**
    * Resolve dependencies between components
-   * @param components
-   * @param features
+   * @param components - Components to resolve cross-references for
+   * @param features - Features used to detect dependency relationships
+   * @returns Components with populated dependency arrays
    */
   private resolveDependencies(
     components: readonly SDSComponent[],

--- a/src/sds-writer/DataDesigner.ts
+++ b/src/sds-writer/DataDesigner.ts
@@ -120,7 +120,8 @@ export class DataDesigner {
 
   /**
    * Design a single data model from a component
-   * @param input
+   * @param input - Design input containing component, features, and model index
+   * @returns Designed data model or null if the component does not require one
    */
   public designModel(input: DataModelDesignInput): DataModel | null {
     const { component, features, modelIndex } = input;
@@ -167,8 +168,9 @@ export class DataDesigner {
 
   /**
    * Get related features for a component
-   * @param component
-   * @param featureById
+   * @param component - Component to find features for
+   * @param featureById - Lookup map of features keyed by ID
+   * @returns Array of features related to the component
    */
   private getRelatedFeatures(
     component: SDSComponent,
@@ -186,7 +188,8 @@ export class DataDesigner {
 
   /**
    * Check if a component needs a data model
-   * @param component
+   * @param component - Component to evaluate
+   * @returns True if the component has data-related indicators or CRUD operations
    */
   private needsDataModel(component: SDSComponent): boolean {
     const nameLower = component.name.toLowerCase();
@@ -245,7 +248,8 @@ export class DataDesigner {
 
   /**
    * Extract model name from component name
-   * @param componentName
+   * @param componentName - Component name with potential suffix
+   * @returns Clean model name with common suffixes removed
    */
   private extractModelName(componentName: string): string {
     return componentName
@@ -258,8 +262,9 @@ export class DataDesigner {
 
   /**
    * Determine data model category
-   * @param component
-   * @param features
+   * @param component - Component to categorize
+   * @param features - Related features providing additional context
+   * @returns Data type category (entity, aggregate, value_object, or enum)
    */
   private determineCategory(
     component: SDSComponent,
@@ -293,8 +298,9 @@ export class DataDesigner {
 
   /**
    * Extract properties from component and features
-   * @param component
-   * @param features
+   * @param component - Component to extract interface parameters from
+   * @param features - Related features to extract criteria-based properties from
+   * @returns Array of deduplicated data properties
    */
   private extractProperties(
     component: SDSComponent,
@@ -363,7 +369,8 @@ export class DataDesigner {
 
   /**
    * Check if parameter is a system parameter (not for data model)
-   * @param name
+   * @param name - Parameter name to check
+   * @returns True if the parameter is a system-level parameter
    */
   private isSystemParam(name: string): boolean {
     const systemParams = [
@@ -381,7 +388,8 @@ export class DataDesigner {
 
   /**
    * Map TypeScript type to data model type
-   * @param tsType
+   * @param tsType - TypeScript type string to convert
+   * @returns Corresponding data model type (e.g., "string", "number", "json")
    */
   private mapToDataType(tsType: string): string {
     const typeLower = tsType.toLowerCase();
@@ -398,7 +406,8 @@ export class DataDesigner {
 
   /**
    * Extract properties from acceptance criteria
-   * @param criteria
+   * @param criteria - Acceptance criteria strings to analyze
+   * @returns Array of data properties detected in the criteria text
    */
   private extractPropertiesFromCriteria(criteria: readonly string[]): DataProperty[] {
     const fullText = criteria.join(' ');
@@ -407,7 +416,8 @@ export class DataDesigner {
 
   /**
    * Extract properties from text
-   * @param text
+   * @param text - Free-form text to scan for property patterns
+   * @returns Array of data properties detected via pattern matching
    */
   private extractPropertiesFromText(text: string): DataProperty[] {
     const properties: DataProperty[] = [];
@@ -499,7 +509,8 @@ export class DataDesigner {
 
   /**
    * Add standard properties to model
-   * @param properties
+   * @param properties - Existing properties to extend
+   * @returns Properties array with timestamp and soft-delete fields appended
    */
   private addStandardProperties(properties: readonly DataProperty[]): DataProperty[] {
     const allProps = [...properties];
@@ -539,8 +550,9 @@ export class DataDesigner {
 
   /**
    * Generate indexes for a model
-   * @param modelName
-   * @param properties
+   * @param modelName - Model name used for index naming
+   * @param properties - Model properties to generate indexes for
+   * @returns Array of generated index definitions
    */
   private generateIndexes(modelName: string, properties: readonly DataProperty[]): DataIndex[] {
     const indexes: DataIndex[] = [];
@@ -579,7 +591,8 @@ export class DataDesigner {
 
   /**
    * Convert to snake_case
-   * @param str
+   * @param str - String to convert (PascalCase or camelCase)
+   * @returns snake_case version of the input string
    */
   private toSnakeCase(str: string): string {
     return str
@@ -590,7 +603,8 @@ export class DataDesigner {
 
   /**
    * Generate description for model
-   * @param component
+   * @param component - Source component providing name and responsibility
+   * @returns Human-readable model description
    */
   private generateDescription(component: SDSComponent): string {
     return `Data model for ${component.name}. ${component.responsibility}`;
@@ -598,7 +612,8 @@ export class DataDesigner {
 
   /**
    * Resolve relationships between models
-   * @param models
+   * @param models - Data models to analyze for cross-references
+   * @returns Models with populated relationship arrays
    */
   private resolveRelationships(models: readonly DataModel[]): readonly DataModel[] {
     // Create model name lookup

--- a/src/sds-writer/DeploymentDesigner.ts
+++ b/src/sds-writer/DeploymentDesigner.ts
@@ -136,8 +136,9 @@ export class DeploymentDesigner {
 
   /**
    * Determine deployment pattern based on components and NFRs
-   * @param components
-   * @param nfrs
+   * @param components - SDS components to evaluate for pattern selection
+   * @param nfrs - Non-functional requirements influencing deployment pattern
+   * @returns Selected deployment pattern
    */
   private determinePattern(
     components: readonly SDSComponent[],
@@ -180,7 +181,8 @@ export class DeploymentDesigner {
 
   /**
    * Generate environment specifications
-   * @param nfrs
+   * @param nfrs - Non-functional requirements for environment configuration
+   * @returns Array of environment specifications (dev, staging, production)
    */
   private generateEnvironments(nfrs: readonly ParsedNFR[]): EnvironmentSpec[] {
     const environments: EnvironmentSpec[] = [];
@@ -215,7 +217,8 @@ export class DeploymentDesigner {
 
   /**
    * Derive production infrastructure details from NFRs
-   * @param nfrText
+   * @param nfrText - Concatenated lowercase NFR descriptions
+   * @returns Infrastructure description string with detected features
    */
   private deriveProductionInfrastructure(nfrText: string): string {
     const features: string[] = [];
@@ -249,7 +252,8 @@ export class DeploymentDesigner {
 
   /**
    * Generate scaling strategy from NFRs
-   * @param nfrs
+   * @param nfrs - Non-functional requirements for scaling configuration
+   * @returns Scaling specification with type, metrics, and instance limits
    */
   private generateScalingStrategy(nfrs: readonly ParsedNFR[]): ScalingSpec {
     const nfrText = nfrs.map((n) => n.description.toLowerCase()).join(' ');
@@ -296,7 +300,8 @@ export class DeploymentDesigner {
 
   /**
    * Extract instance limits from NFR text
-   * @param nfrText
+   * @param nfrText - Concatenated lowercase NFR descriptions
+   * @returns Minimum and maximum instance counts
    */
   private extractInstanceLimits(nfrText: string): {
     minInstances: number;
@@ -323,8 +328,9 @@ export class DeploymentDesigner {
 
   /**
    * Generate configuration specifications from components and NFRs
-   * @param components
-   * @param nfrs
+   * @param components - SDS components for component-specific configs
+   * @param nfrs - Non-functional requirements for NFR-driven configs
+   * @returns Deduplicated array of configuration specifications
    */
   private generateConfigurations(
     components: readonly SDSComponent[],
@@ -388,7 +394,8 @@ export class DeploymentDesigner {
 
   /**
    * Extract configurations from NFRs
-   * @param nfrs
+   * @param nfrs - Non-functional requirements to derive config entries from
+   * @returns Configuration specifications for security, performance, and data NFRs
    */
   private extractNFRConfigurations(nfrs: readonly ParsedNFR[]): ConfigurationSpec[] {
     const configs: ConfigurationSpec[] = [];
@@ -462,7 +469,8 @@ export class DeploymentDesigner {
 
   /**
    * Extract configurations from components
-   * @param components
+   * @param components - SDS components to derive config entries from
+   * @returns Configuration specifications for component-specific integrations
    */
   private extractComponentConfigurations(components: readonly SDSComponent[]): ConfigurationSpec[] {
     const configs: ConfigurationSpec[] = [];
@@ -535,9 +543,10 @@ export class DeploymentDesigner {
 
   /**
    * Generate infrastructure diagram in mermaid format
-   * @param pattern
-   * @param components
-   * @param configurations
+   * @param pattern - Deployment pattern determining diagram layout
+   * @param components - SDS components to include as services
+   * @param configurations - Configuration specs for external service detection
+   * @returns Mermaid flowchart diagram as a string
    */
   private generateInfrastructureDiagram(
     pattern: DeploymentSpec['pattern'],
@@ -611,7 +620,8 @@ export class DeploymentDesigner {
 
   /**
    * Group components into logical services
-   * @param components
+   * @param components - SDS components to categorize into service groups
+   * @returns Array of service group names (max 5 for diagram clarity)
    */
   private groupComponentsIntoServices(components: readonly SDSComponent[]): string[] {
     const services = new Set<string>();
@@ -637,7 +647,8 @@ export class DeploymentDesigner {
 
   /**
    * Detect external services from configurations
-   * @param configurations
+   * @param configurations - Configuration specs to scan for external service indicators
+   * @returns Array of detected external services with id and display name
    */
   private detectExternalServices(
     configurations: readonly ConfigurationSpec[]
@@ -669,9 +680,9 @@ export class DeploymentDesigner {
 
   /**
    * Validate design and collect warnings
-   * @param components
-   * @param nfrs
-   * @param warnings
+   * @param components - SDS components for validation checks
+   * @param nfrs - Non-functional requirements to verify coverage
+   * @param warnings - Mutable array to append validation warnings to
    */
   private validateDesign(
     components: readonly SDSComponent[],
@@ -705,7 +716,8 @@ export class DeploymentDesigner {
 
   /**
    * Generate deployment specification as markdown
-   * @param result
+   * @param result - Deployment design result to render
+   * @returns Formatted markdown string of the deployment specification
    */
   public toMarkdown(result: DeploymentDesignResult): string {
     const lines: string[] = [];

--- a/src/sds-writer/SDSWriterAgent.ts
+++ b/src/sds-writer/SDSWriterAgent.ts
@@ -152,6 +152,7 @@ export class SDSWriterAgent implements IAgent {
 
   /**
    * Get the current session
+   * @returns Current SDS generation session or null if no session is active
    */
   public getSession(): SDSGenerationSession | null {
     return this.session;
@@ -387,7 +388,7 @@ export class SDSWriterAgent implements IAgent {
 
   /**
    * Update session with partial data
-   * @param updates
+   * @param updates - Partial session fields to merge into the current session
    */
   private updateSession(updates: Partial<SDSGenerationSession>): void {
     if (!this.session) return;
@@ -401,7 +402,8 @@ export class SDSWriterAgent implements IAgent {
 
   /**
    * Generate security specification from NFRs
-   * @param nfrs
+   * @param nfrs - Non-functional requirements to derive security settings from
+   * @returns Security specification with authentication, authorization, and data protection
    */
   private generateSecuritySpec(
     nfrs: readonly { id: string; category: string; description: string; metric?: string }[]
@@ -440,7 +442,8 @@ export class SDSWriterAgent implements IAgent {
 
   /**
    * Generate deployment specification from NFRs
-   * @param nfrs
+   * @param nfrs - Non-functional requirements to derive deployment settings from
+   * @returns Deployment specification with pattern, environments, and optional scaling
    */
   private generateDeploymentSpec(
     nfrs: readonly { id: string; category: string; description: string; metric?: string }[]
@@ -481,14 +484,15 @@ export class SDSWriterAgent implements IAgent {
 
   /**
    * Generate complete SDS document
-   * @param projectId
-   * @param srs
-   * @param components
-   * @param apis
-   * @param dataModels
-   * @param traceabilityMatrix
-   * @param security
-   * @param deployment
+   * @param projectId - Project identifier for document naming
+   * @param srs - Parsed SRS document with source metadata
+   * @param components - Designed SDS components
+   * @param apis - Generated API endpoint specifications
+   * @param dataModels - Designed data models
+   * @param traceabilityMatrix - Feature-to-component traceability matrix
+   * @param security - Optional security specification
+   * @param deployment - Optional deployment specification
+   * @returns Complete generated SDS document with metadata and content
    */
   private generateSDSDocument(
     projectId: string,
@@ -539,14 +543,15 @@ export class SDSWriterAgent implements IAgent {
 
   /**
    * Generate markdown content for SDS
-   * @param metadata
-   * @param srs
-   * @param components
-   * @param apis
-   * @param dataModels
-   * @param traceabilityMatrix
-   * @param security
-   * @param deployment
+   * @param metadata - SDS document metadata for header section
+   * @param srs - Parsed SRS for product name and description
+   * @param components - SDS components for the component design section
+   * @param apis - API endpoints for the interface design section
+   * @param dataModels - Data models for the data design section
+   * @param traceabilityMatrix - Traceability matrix for coverage section
+   * @param security - Optional security spec for the security design section
+   * @param deployment - Optional deployment spec for the deployment section
+   * @returns Formatted markdown string of the full SDS document
    */
   private generateMarkdownContent(
     metadata: SDSMetadata,
@@ -845,8 +850,9 @@ export class SDSWriterAgent implements IAgent {
 
   /**
    * Write output files
-   * @param projectId
-   * @param sds
+   * @param projectId - Project identifier for directory and file naming
+   * @param sds - Generated SDS document to write
+   * @returns Paths to the written scratchpad and public files
    */
   private async writeOutputFiles(
     projectId: string,

--- a/src/sds-writer/SRSParser.ts
+++ b/src/sds-writer/SRSParser.ts
@@ -114,7 +114,8 @@ export class SRSParser {
 
   /**
    * Parse document metadata from the header table
-   * @param lines
+   * @param lines - Document lines to scan for metadata
+   * @returns Extracted document metadata
    */
   private parseMetadata(lines: readonly string[]): SRSDocumentMetadata {
     const metadata: Record<string, string> = {};
@@ -146,7 +147,8 @@ export class SRSParser {
 
   /**
    * Extract project ID from document ID
-   * @param documentId
+   * @param documentId - SRS document identifier (e.g., "SRS-001")
+   * @returns Extracted project ID portion
    */
   private extractProjectId(documentId: string): string {
     // SRS-001 -> 001, SRS-agent-driven-sdlc -> agent-driven-sdlc
@@ -156,7 +158,8 @@ export class SRSParser {
 
   /**
    * Parse product information
-   * @param lines
+   * @param lines - Document lines to scan for product info
+   * @returns Object containing product name and description
    */
   private parseProductInfo(lines: readonly string[]): {
     productName: string;
@@ -218,7 +221,8 @@ export class SRSParser {
 
   /**
    * Parse features from the Features section
-   * @param lines
+   * @param lines - Document lines to scan for feature definitions
+   * @returns Array of parsed SRS features
    */
   private parseFeatures(lines: readonly string[]): readonly ParsedSRSFeature[] {
     const features: ParsedSRSFeature[] = [];
@@ -332,9 +336,10 @@ export class SRSParser {
 
   /**
    * Finalize a feature with all collected data
-   * @param feature
-   * @param descriptionLines
-   * @param acceptanceCriteria
+   * @param feature - Partially parsed feature object
+   * @param descriptionLines - Collected description text lines
+   * @param acceptanceCriteria - Collected acceptance criteria items
+   * @returns Complete parsed SRS feature
    */
   private finalizeFeature(
     feature: Partial<ParsedSRSFeature>,
@@ -354,7 +359,8 @@ export class SRSParser {
 
   /**
    * Parse use cases from the Use Cases section
-   * @param lines
+   * @param lines - Document lines to scan for use case definitions
+   * @returns Array of parsed use cases
    */
   private parseUseCases(lines: readonly string[]): readonly ParsedUseCase[] {
     const useCases: ParsedUseCase[] = [];
@@ -552,11 +558,12 @@ export class SRSParser {
 
   /**
    * Finalize a use case with all collected data
-   * @param useCase
-   * @param preconditions
-   * @param mainScenario
-   * @param postconditions
-   * @param alternativeScenarios
+   * @param useCase - Partially parsed use case object
+   * @param preconditions - Collected precondition items
+   * @param mainScenario - Collected main scenario steps
+   * @param postconditions - Collected postcondition items
+   * @param alternativeScenarios - Collected alternative scenario flows
+   * @returns Complete parsed use case
    */
   private finalizeUseCase(
     useCase: Partial<ParsedUseCase>,
@@ -579,7 +586,8 @@ export class SRSParser {
 
   /**
    * Parse NFRs from the Non-Functional Requirements section
-   * @param lines
+   * @param lines - Document lines to scan for NFR definitions
+   * @returns Array of parsed non-functional requirements
    */
   private parseNFRs(lines: readonly string[]): readonly ParsedNFR[] {
     const nfrs: ParsedNFR[] = [];
@@ -656,7 +664,8 @@ export class SRSParser {
 
   /**
    * Extract NFR category from name
-   * @param name
+   * @param name - NFR name to categorize
+   * @returns Category string (e.g., "Performance", "Security", "General")
    */
   private extractNFRCategory(name: string): string {
     const lowerName = name.toLowerCase();
@@ -672,8 +681,9 @@ export class SRSParser {
 
   /**
    * Finalize an NFR with collected data
-   * @param nfr
-   * @param descriptionLines
+   * @param nfr - Partially parsed NFR object
+   * @param descriptionLines - Collected description text lines
+   * @returns Complete parsed NFR
    */
   private finalizeNFR(nfr: MutableParsedNFR, descriptionLines: string[]): ParsedNFR {
     const base = {
@@ -692,7 +702,8 @@ export class SRSParser {
 
   /**
    * Parse constraints from the Constraints section
-   * @param lines
+   * @param lines - Document lines to scan for constraint definitions
+   * @returns Array of parsed constraints
    */
   private parseConstraints(lines: readonly string[]): readonly ParsedConstraint[] {
     const constraints: ParsedConstraint[] = [];
@@ -764,7 +775,8 @@ export class SRSParser {
 
   /**
    * Extract constraint type from name
-   * @param name
+   * @param name - Constraint name to classify
+   * @returns Constraint type string (e.g., "Technical", "Business", "General")
    */
   private extractConstraintType(name: string): string {
     const lowerName = name.toLowerCase();
@@ -778,8 +790,9 @@ export class SRSParser {
 
   /**
    * Finalize a constraint with collected data
-   * @param constraint
-   * @param descriptionLines
+   * @param constraint - Partially parsed constraint object
+   * @param descriptionLines - Collected description text lines
+   * @returns Complete parsed constraint
    */
   private finalizeConstraint(
     constraint: Partial<ParsedConstraint>,
@@ -794,7 +807,8 @@ export class SRSParser {
 
   /**
    * Parse assumptions from the Assumptions section
-   * @param lines
+   * @param lines - Document lines to scan for assumption items
+   * @returns Array of assumption strings
    */
   private parseAssumptions(lines: readonly string[]): readonly string[] {
     const assumptions: string[] = [];
@@ -826,7 +840,8 @@ export class SRSParser {
 
   /**
    * Parse priority value
-   * @param value
+   * @param value - Raw priority string to normalize (e.g., "P0", "p2")
+   * @returns Normalized priority value (P0-P3), defaults to P1
    */
   private parsePriority(value: string): Priority {
     const normalized = value.trim().toUpperCase();
@@ -843,7 +858,8 @@ export class SRSParser {
 
   /**
    * Validate parsed SRS structure
-   * @param srs
+   * @param srs - Parsed SRS to validate
+   * @returns Array of validation error messages (empty if valid)
    * @throws SRSParseError if validation fails in strict mode
    */
   public validate(srs: ParsedSRS): readonly string[] {

--- a/src/srs-writer/FeatureDecomposer.ts
+++ b/src/srs-writer/FeatureDecomposer.ts
@@ -134,7 +134,8 @@ export class FeatureDecomposer {
 
   /**
    * Extract actor names from user personas
-   * @param parsedPRD
+   * @param parsedPRD - The parsed PRD document containing user personas
+   * @returns Array of actor names derived from personas
    */
   private extractActors(parsedPRD: ParsedPRD): string[] {
     const actors = parsedPRD.userPersonas.map((p) => p.role || p.name);
@@ -149,8 +150,9 @@ export class FeatureDecomposer {
 
   /**
    * Decompose a single requirement into features
-   * @param requirement
-   * @param actors
+   * @param requirement - The PRD requirement to decompose
+   * @param actors - Available actor names for use case generation
+   * @returns Array of SRS features decomposed from the requirement
    */
   private decomposeRequirement(
     requirement: ParsedPRDRequirement,
@@ -176,7 +178,8 @@ export class FeatureDecomposer {
 
   /**
    * Analyze requirement complexity
-   * @param requirement
+   * @param requirement - The PRD requirement to evaluate
+   * @returns Complexity level based on description length, criteria count, and dependencies
    */
   private analyzeComplexity(requirement: ParsedPRDRequirement): 'simple' | 'moderate' | 'complex' {
     let score = 0;
@@ -205,8 +208,9 @@ export class FeatureDecomposer {
 
   /**
    * Create a single feature from a requirement
-   * @param requirement
-   * @param actors
+   * @param requirement - The PRD requirement to convert into a feature
+   * @param actors - Available actor names for use case generation
+   * @returns A single SRS feature with use cases and NFR references
    */
   private createFeature(requirement: ParsedPRDRequirement, actors: readonly string[]): SRSFeature {
     this.featureCounter++;
@@ -256,9 +260,10 @@ export class FeatureDecomposer {
 
   /**
    * Create multiple sub-features from a complex requirement
-   * @param requirement
-   * @param actors
-   * @param complexity
+   * @param requirement - The complex PRD requirement to split
+   * @param actors - Available actor names for use case generation
+   * @param complexity - Analyzed complexity level controlling segmentation granularity
+   * @returns Array of sub-features derived from the requirement
    */
   private createSubFeatures(
     requirement: ParsedPRDRequirement,
@@ -292,8 +297,9 @@ export class FeatureDecomposer {
 
   /**
    * Segment a complex requirement into smaller parts
-   * @param requirement
-   * @param complexity
+   * @param requirement - The PRD requirement to segment
+   * @param complexity - Complexity level controlling segment granularity
+   * @returns Array of named segments with descriptions and criteria
    */
   private segmentRequirement(
     requirement: ParsedPRDRequirement,
@@ -340,7 +346,8 @@ export class FeatureDecomposer {
 
   /**
    * Get a label for a part index
-   * @param index
+   * @param index - Zero-based index of the part
+   * @returns Descriptive label for the feature part
    */
   private getPartLabel(index: number): string {
     const labels = ['Core Functionality', 'Validation', 'User Feedback', 'Integration', 'Cleanup'];
@@ -349,9 +356,10 @@ export class FeatureDecomposer {
 
   /**
    * Generate use cases from a requirement
-   * @param requirement
-   * @param featureId
-   * @param actors
+   * @param requirement - The PRD requirement providing use case content
+   * @param featureId - Parent feature identifier for traceability
+   * @param actors - Available actor names for use cases
+   * @returns Array of SRS use cases for the requirement
    */
   private generateUseCases(
     requirement: ParsedPRDRequirement,
@@ -380,9 +388,10 @@ export class FeatureDecomposer {
 
   /**
    * Create primary use case for a requirement
-   * @param requirement
-   * @param _featureId
-   * @param actor
+   * @param requirement - The PRD requirement to create a primary use case from
+   * @param _featureId - Parent feature identifier (reserved for future use)
+   * @param actor - Primary actor for the use case
+   * @returns Primary SRS use case with main and alternative flows
    */
   private createPrimaryUseCase(
     requirement: ParsedPRDRequirement,
@@ -417,9 +426,10 @@ export class FeatureDecomposer {
 
   /**
    * Create use cases from acceptance criteria
-   * @param criteria
-   * @param _featureId
-   * @param actor
+   * @param criteria - Acceptance criteria strings to generate use cases from
+   * @param _featureId - Parent feature identifier (reserved for future use)
+   * @param actor - Actor name for the generated use cases
+   * @returns Array of SRS use cases derived from significant criteria
    */
   private createUseCasesFromCriteria(
     criteria: readonly string[],
@@ -454,12 +464,13 @@ export class FeatureDecomposer {
 
   /**
    * Generate use cases from a segment
-   * @param segment
-   * @param segment.name
-   * @param segment.description
-   * @param segment.criteria
-   * @param _featureId
-   * @param actors
+   * @param segment - The requirement segment containing name, description, and criteria
+   * @param segment.name - Display name for the segment
+   * @param segment.description - Detailed description of the segment scope
+   * @param segment.criteria - Acceptance criteria assigned to this segment
+   * @param _featureId - Parent feature identifier (reserved for future use)
+   * @param actors - Available actor names for use cases
+   * @returns Array of SRS use cases for the segment
    */
   private generateUseCasesFromSegment(
     segment: { name: string; description: string; criteria: string[] },
@@ -490,7 +501,8 @@ export class FeatureDecomposer {
 
   /**
    * Generate main flow steps from requirement
-   * @param requirement
+   * @param requirement - The PRD requirement to derive main flow from
+   * @returns Array of main flow step descriptions
    */
   private generateMainFlow(requirement: ParsedPRDRequirement): string[] {
     const flow: string[] = [];
@@ -514,7 +526,8 @@ export class FeatureDecomposer {
 
   /**
    * Generate preconditions from requirement
-   * @param requirement
+   * @param requirement - The PRD requirement to derive preconditions from
+   * @returns Array of precondition strings
    */
   private generatePreconditions(requirement: ParsedPRDRequirement): string[] {
     const preconditions: string[] = ['User is authenticated', 'System is available'];
@@ -529,7 +542,8 @@ export class FeatureDecomposer {
 
   /**
    * Generate postconditions from requirement
-   * @param requirement
+   * @param requirement - The PRD requirement to derive postconditions from
+   * @returns Array of postcondition strings
    */
   private generatePostconditions(requirement: ParsedPRDRequirement): string[] {
     const postconditions: string[] = [];
@@ -547,7 +561,8 @@ export class FeatureDecomposer {
 
   /**
    * Generate alternative flows from requirement
-   * @param requirement
+   * @param requirement - The PRD requirement with acceptance criteria to check
+   * @returns Array of alternative flow description strings
    */
   private generateAlternativeFlows(requirement: ParsedPRDRequirement): string[] {
     const flows: string[] = [];
@@ -564,7 +579,8 @@ export class FeatureDecomposer {
 
   /**
    * Generate use case name from requirement title
-   * @param title
+   * @param title - Raw title string to format as a use case name
+   * @returns Formatted use case name with proper capitalization
    */
   private generateUseCaseName(title: string): string {
     // Convert to action format
@@ -579,7 +595,8 @@ export class FeatureDecomposer {
 
   /**
    * Extract use case name from criterion
-   * @param criterion
+   * @param criterion - The acceptance criterion text to extract a name from
+   * @returns Extracted and formatted use case name
    */
   private extractUseCaseNameFromCriterion(criterion: string): string {
     // Extract key action from criterion
@@ -592,7 +609,8 @@ export class FeatureDecomposer {
 
   /**
    * Convert criterion to flow step
-   * @param criterion
+   * @param criterion - The acceptance criterion text to convert
+   * @returns Flow step description string prefixed with system context
    */
   private criterionToFlowStep(criterion: string): string {
     return `System ensures: ${criterion}`;
@@ -600,7 +618,8 @@ export class FeatureDecomposer {
 
   /**
    * Enhance description with additional context
-   * @param requirement
+   * @param requirement - The PRD requirement whose description is enriched
+   * @returns Enhanced description with source and priority metadata
    */
   private enhanceDescription(requirement: ParsedPRDRequirement): string {
     let description = requirement.description;
@@ -616,7 +635,8 @@ export class FeatureDecomposer {
 
   /**
    * Extract NFR references from text
-   * @param text
+   * @param text - Text content to scan for NFR-XXX identifiers
+   * @returns Deduplicated array of NFR identifiers found in the text
    */
   private extractNFRReferences(text: string): string[] {
     const refs: string[] = [];
@@ -630,8 +650,9 @@ export class FeatureDecomposer {
 
   /**
    * Chunk array into smaller arrays
-   * @param array
-   * @param size
+   * @param array - The source array to split into chunks
+   * @param size - Maximum number of elements per chunk
+   * @returns Array of chunks, each containing up to size elements
    */
   private chunkArray<T>(array: readonly T[], size: number): T[][] {
     const chunks: T[][] = [];

--- a/src/srs-writer/PRDParser.ts
+++ b/src/srs-writer/PRDParser.ts
@@ -81,8 +81,9 @@ export class PRDParser {
 
   /**
    * Parse document metadata from PRD
-   * @param content
-   * @param projectId
+   * @param content - Raw PRD markdown content
+   * @param projectId - Unique project identifier
+   * @returns Extracted document metadata
    */
   private parseMetadata(content: string, projectId: string): PRDDocumentMetadata {
     // Try to extract from metadata table
@@ -100,7 +101,8 @@ export class PRDParser {
 
   /**
    * Extract product name from PRD
-   * @param content
+   * @param content - Raw PRD markdown content
+   * @returns Product name extracted from title or metadata table
    */
   private extractProductName(content: string): string {
     // Try from title (# PRD: Product Name)
@@ -122,7 +124,8 @@ export class PRDParser {
 
   /**
    * Extract product description from PRD
-   * @param content
+   * @param content - Raw PRD markdown content
+   * @returns First paragraph of the executive summary or product overview
    */
   private extractProductDescription(content: string): string {
     // Look for Executive Summary or Product Overview section
@@ -141,7 +144,8 @@ export class PRDParser {
 
   /**
    * Parse functional requirements from PRD
-   * @param content
+   * @param content - Raw PRD markdown content
+   * @returns Array of parsed functional requirements
    */
   private parseFunctionalRequirements(content: string): ParsedPRDRequirement[] {
     const requirements: ParsedPRDRequirement[] = [];
@@ -189,9 +193,10 @@ export class PRDParser {
 
   /**
    * Parse requirement body to extract details
-   * @param id
-   * @param title
-   * @param body
+   * @param id - Requirement identifier (e.g., FR-001)
+   * @param title - Requirement title text
+   * @param body - Markdown body containing priority, description, and acceptance criteria
+   * @returns Fully parsed requirement with extracted fields
    */
   private parseRequirementBody(id: string, title: string, body: string): ParsedPRDRequirement {
     // Extract priority
@@ -234,7 +239,8 @@ export class PRDParser {
 
   /**
    * Normalize priority string to Priority type
-   * @param priority
+   * @param priority - Raw priority string (e.g., "p1", "P2")
+   * @returns Normalized priority value (P0-P3), defaults to P2
    */
   private normalizePriority(priority: string): Priority {
     const upper = priority.toUpperCase();
@@ -246,7 +252,8 @@ export class PRDParser {
 
   /**
    * Extract acceptance criteria from requirement body
-   * @param body
+   * @param body - Requirement body containing an acceptance criteria section
+   * @returns List of acceptance criteria strings
    */
   private extractAcceptanceCriteria(body: string): string[] {
     const criteria: string[] = [];
@@ -273,7 +280,8 @@ export class PRDParser {
 
   /**
    * Extract dependencies from requirement body
-   * @param body
+   * @param body - Requirement body containing dependency references
+   * @returns Deduplicated list of dependency IDs (e.g., FR-001)
    */
   private extractDependencies(body: string): string[] {
     const dependencies: string[] = [];
@@ -296,7 +304,8 @@ export class PRDParser {
 
   /**
    * Parse functional requirements using alternative format
-   * @param content
+   * @param content - Raw PRD markdown content without FR-XXX patterns
+   * @returns Array of requirements parsed from numbered or bulleted lists
    */
   private parseFunctionalRequirementsAlternative(content: string): ParsedPRDRequirement[] {
     const requirements: ParsedPRDRequirement[] = [];
@@ -338,7 +347,8 @@ export class PRDParser {
 
   /**
    * Parse non-functional requirements from PRD
-   * @param content
+   * @param content - Raw PRD markdown content
+   * @returns Array of parsed non-functional requirements
    */
   private parseNonFunctionalRequirements(content: string): ParsedNFR[] {
     const nfrs: ParsedNFR[] = [];
@@ -386,7 +396,8 @@ export class PRDParser {
 
   /**
    * Infer NFR category from title
-   * @param title
+   * @param title - NFR title text used for keyword-based classification
+   * @returns Inferred category string (e.g., "performance", "security")
    */
   private inferNFRCategory(title: string): string {
     const lower = title.toLowerCase();
@@ -401,7 +412,8 @@ export class PRDParser {
 
   /**
    * Parse NFRs using alternative format
-   * @param content
+   * @param content - Raw PRD markdown content without NFR-XXX patterns
+   * @returns Array of NFRs parsed from category subsections
    */
   private parseNFRAlternative(content: string): ParsedNFR[] {
     const nfrs: ParsedNFR[] = [];
@@ -451,7 +463,8 @@ export class PRDParser {
 
   /**
    * Parse constraints from PRD
-   * @param content
+   * @param content - Raw PRD markdown content
+   * @returns Array of parsed constraints with type classification
    */
   private parseConstraints(content: string): ParsedConstraint[] {
     const constraints: ParsedConstraint[] = [];
@@ -506,7 +519,8 @@ export class PRDParser {
 
   /**
    * Normalize constraint type
-   * @param type
+   * @param type - Raw constraint type string
+   * @returns Normalized type (technical, business, regulatory, resource, or timeline)
    */
   private normalizeConstraintType(type: string): string {
     const lower = type.toLowerCase();
@@ -520,7 +534,8 @@ export class PRDParser {
 
   /**
    * Parse assumptions from PRD
-   * @param content
+   * @param content - Raw PRD markdown content
+   * @returns List of assumption strings
    */
   private parseAssumptions(content: string): string[] {
     const assumptions: string[] = [];
@@ -546,7 +561,8 @@ export class PRDParser {
 
   /**
    * Extract list items from text
-   * @param text
+   * @param text - Markdown text containing bulleted list items
+   * @returns Array of trimmed list item strings
    */
   private extractListItems(text: string): string[] {
     const items: string[] = [];
@@ -563,7 +579,8 @@ export class PRDParser {
 
   /**
    * Parse user personas from PRD
-   * @param content
+   * @param content - Raw PRD markdown content
+   * @returns Array of user persona objects with name, role, and goals
    */
   private parseUserPersonas(content: string): UserPersona[] {
     const personas: UserPersona[] = [];
@@ -606,7 +623,8 @@ export class PRDParser {
 
   /**
    * Parse goals and metrics from PRD
-   * @param content
+   * @param content - Raw PRD markdown content
+   * @returns Array of goal objects with descriptions and optional metrics
    */
   private parseGoals(content: string): Goal[] {
     const goals: Goal[] = [];

--- a/src/srs-writer/SRSWriterAgent.ts
+++ b/src/srs-writer/SRSWriterAgent.ts
@@ -449,7 +449,8 @@ export class SRSWriterAgent implements IAgent {
 
   /**
    * Create SRS metadata
-   * @param session
+   * @param session - Active generation session containing parsed PRD data
+   * @returns SRS metadata derived from the session and PRD
    */
   private createMetadata(session: SRSGenerationSession): SRSMetadata {
     return {
@@ -463,7 +464,8 @@ export class SRSWriterAgent implements IAgent {
 
   /**
    * Convert parsed NFRs to proper format
-   * @param parsedPRD
+   * @param parsedPRD - Parsed PRD containing raw non-functional requirements
+   * @returns Array of normalized NonFunctionalRequirement objects
    */
   private convertNFRs(parsedPRD: ParsedPRD): NonFunctionalRequirement[] {
     return parsedPRD.nonFunctionalRequirements.map((nfr) => ({
@@ -477,7 +479,8 @@ export class SRSWriterAgent implements IAgent {
 
   /**
    * Normalize NFR category
-   * @param category
+   * @param category - Raw category string to classify
+   * @returns Standardized NFR category value
    */
   private normalizeNFRCategory(
     category: string
@@ -502,7 +505,8 @@ export class SRSWriterAgent implements IAgent {
 
   /**
    * Convert parsed constraints to proper format
-   * @param parsedPRD
+   * @param parsedPRD - Parsed PRD containing raw constraints
+   * @returns Array of normalized Constraint objects with architecture impact
    */
   private convertConstraints(parsedPRD: ParsedPRD): Constraint[] {
     return parsedPRD.constraints.map((con) => ({
@@ -515,7 +519,8 @@ export class SRSWriterAgent implements IAgent {
 
   /**
    * Normalize constraint type
-   * @param type
+   * @param type - Raw constraint type string
+   * @returns Standardized constraint type value
    */
   private normalizeConstraintType(
     type: string
@@ -531,7 +536,8 @@ export class SRSWriterAgent implements IAgent {
 
   /**
    * Infer architecture impact from constraint description
-   * @param description
+   * @param description - Constraint description to analyze for impact keywords
+   * @returns Human-readable architecture impact statement
    */
   private inferArchitectureImpact(description: string): string {
     const lower = description.toLowerCase();
@@ -552,12 +558,13 @@ export class SRSWriterAgent implements IAgent {
 
   /**
    * Generate SRS markdown content
-   * @param parsedPRD
-   * @param metadata
-   * @param decompositionResult
-   * @param traceabilityMatrix
-   * @param nfrs
-   * @param constraints
+   * @param parsedPRD - Parsed PRD providing source requirements and assumptions
+   * @param metadata - SRS document metadata for the header section
+   * @param decompositionResult - Feature decomposition with use cases
+   * @param traceabilityMatrix - Requirement-to-feature traceability data
+   * @param nfrs - Normalized non-functional requirements
+   * @param constraints - Normalized constraints with architecture impact
+   * @returns Complete SRS document as a markdown string
    */
   private generateContent(
     parsedPRD: ParsedPRD,
@@ -719,7 +726,8 @@ export class SRSWriterAgent implements IAgent {
 
   /**
    * Get category number for section numbering
-   * @param category
+   * @param category - NFR category name
+   * @returns Ordinal number for the category in the SRS section hierarchy
    */
   private getCategoryNumber(category: string): number {
     const order = [
@@ -737,7 +745,8 @@ export class SRSWriterAgent implements IAgent {
 
   /**
    * Capitalize first letter
-   * @param str
+   * @param str - Input string to capitalize
+   * @returns String with the first character uppercased
    */
   private capitalize(str: string): string {
     return str.charAt(0).toUpperCase() + str.slice(1);
@@ -745,9 +754,10 @@ export class SRSWriterAgent implements IAgent {
 
   /**
    * Calculate generation statistics
-   * @param session
-   * @param generatedSRS
-   * @param processingTimeMs
+   * @param session - Completed generation session with parsed PRD
+   * @param generatedSRS - Generated SRS containing features and NFRs
+   * @param processingTimeMs - Total processing time in milliseconds
+   * @returns Aggregated statistics for the generation run
    */
   private calculateStats(
     session: SRSGenerationSession,
@@ -769,7 +779,8 @@ export class SRSWriterAgent implements IAgent {
 
   /**
    * Ensure there is an active session in the expected state
-   * @param expectedStates
+   * @param expectedStates - Allowed session states for the current operation
+   * @returns The validated active session
    */
   private ensureSession(
     expectedStates: readonly ('pending' | 'parsing' | 'decomposing' | 'generating' | 'completed')[]
@@ -804,7 +815,7 @@ export class SRSWriterAgent implements IAgent {
 
   /**
    * Ensure directory exists
-   * @param dirPath
+   * @param dirPath - Absolute or relative directory path to create recursively
    */
   private async ensureDir(dirPath: string): Promise<void> {
     await fs.promises.mkdir(dirPath, { recursive: true });

--- a/src/srs-writer/TraceabilityBuilder.ts
+++ b/src/srs-writer/TraceabilityBuilder.ts
@@ -127,8 +127,9 @@ export class TraceabilityBuilder {
 
   /**
    * Find NFRs related to a requirement
-   * @param requirement
-   * @param parsedPRD
+   * @param requirement - The functional requirement to find related NFRs for
+   * @param parsedPRD - The parsed PRD containing non-functional requirements
+   * @returns Array of related NFR identifiers
    */
   private findRelatedNFRs(requirement: ParsedPRDRequirement, parsedPRD: ParsedPRD): string[] {
     const relatedNFRs: string[] = [];
@@ -164,8 +165,9 @@ export class TraceabilityBuilder {
 
   /**
    * Check if there's keyword overlap between texts
-   * @param text1
-   * @param text2
+   * @param text1 - First text to compare
+   * @param text2 - Second text to compare
+   * @returns True if at least two significant words overlap
    */
   private hasKeywordOverlap(text1: string, text2: string): boolean {
     // Extract significant words (4+ characters)
@@ -186,8 +188,9 @@ export class TraceabilityBuilder {
 
   /**
    * Check if a category is relevant to the description
-   * @param description
-   * @param category
+   * @param description - Lowercase requirement description text
+   * @param category - NFR category name to check relevance for
+   * @returns True if the description contains keywords related to the category
    */
   private isCategoryRelevant(description: string, category: string): boolean {
     const categoryKeywords: Record<string, string[]> = {
@@ -300,7 +303,8 @@ export class TraceabilityBuilder {
 
   /**
    * Generate reverse traceability (feature to requirements)
-   * @param matrix
+   * @param matrix - The forward traceability matrix to invert
+   * @returns Map from feature IDs to arrays of requirement IDs
    */
   public buildReverseTraceability(matrix: TraceabilityMatrix): Map<string, string[]> {
     const reverseMap = new Map<string, string[]>();

--- a/src/srs-writer/UseCaseGenerator.ts
+++ b/src/srs-writer/UseCaseGenerator.ts
@@ -156,9 +156,10 @@ export class UseCaseGenerator {
 
   /**
    * Generate a primary use case for the main feature flow
-   * @param feature
-   * @param requirement
-   * @param actors
+   * @param feature - The SRS feature to generate a use case for
+   * @param requirement - The parsed PRD requirement providing context
+   * @param actors - Available actor names for the use case
+   * @returns Detailed use case with flows and conditions
    */
   private generatePrimaryUseCase(
     feature: SRSFeature,
@@ -197,10 +198,11 @@ export class UseCaseGenerator {
 
   /**
    * Generate use cases from acceptance criteria
-   * @param feature
-   * @param requirement
-   * @param actors
-   * @param coveredCriteria
+   * @param feature - The SRS feature being processed
+   * @param requirement - The parsed PRD requirement with criteria
+   * @param actors - Available actor names for use cases
+   * @param coveredCriteria - Set of already-covered criteria to avoid duplicates
+   * @returns Array of detailed use cases derived from criteria
    */
   private generateFromAcceptanceCriteria(
     feature: SRSFeature,
@@ -242,7 +244,8 @@ export class UseCaseGenerator {
 
   /**
    * Check if a criterion is significant enough for a separate use case
-   * @param criterion
+   * @param criterion - The acceptance criterion text to evaluate
+   * @returns True if the criterion warrants a separate use case
    */
   private isSignificantCriterion(criterion: string): boolean {
     const significantPatterns = [
@@ -258,11 +261,12 @@ export class UseCaseGenerator {
 
   /**
    * Create a use case from a single criterion
-   * @param ucId
-   * @param criterion
-   * @param feature
-   * @param requirement
-   * @param actors
+   * @param ucId - Unique identifier for the use case
+   * @param criterion - The acceptance criterion text
+   * @param feature - The parent SRS feature
+   * @param requirement - The source PRD requirement
+   * @param actors - Available actor names
+   * @returns Detailed use case derived from the criterion
    */
   private createUseCaseFromCriterion(
     ucId: string,
@@ -296,10 +300,11 @@ export class UseCaseGenerator {
 
   /**
    * Generate a supplementary use case when minimum is not met
-   * @param feature
-   * @param requirement
-   * @param actors
-   * @param index
+   * @param feature - The parent SRS feature
+   * @param requirement - The source PRD requirement
+   * @param actors - Available actor names
+   * @param index - Current use case index for type selection
+   * @returns Supplementary use case to meet the minimum threshold
    */
   private generateSupplementaryUseCase(
     feature: SRSFeature,
@@ -339,8 +344,9 @@ export class UseCaseGenerator {
 
   /**
    * Select the primary actor based on requirement context
-   * @param requirement
-   * @param actors
+   * @param requirement - The PRD requirement to analyze for actor cues
+   * @param actors - Candidate actor names to choose from
+   * @returns Name of the most appropriate primary actor
    */
   private selectPrimaryActor(requirement: ParsedPRDRequirement, actors: readonly string[]): string {
     const text = `${requirement.title} ${requirement.description} ${requirement.userStory ?? ''}`;
@@ -366,9 +372,10 @@ export class UseCaseGenerator {
 
   /**
    * Identify secondary actors from requirement
-   * @param requirement
-   * @param actors
-   * @param primaryActor
+   * @param requirement - The PRD requirement to analyze
+   * @param actors - All available actor names
+   * @param primaryActor - The already-selected primary actor to exclude
+   * @returns Array of secondary actor names mentioned in the requirement
    */
   private identifySecondaryActors(
     requirement: ParsedPRDRequirement,
@@ -397,7 +404,8 @@ export class UseCaseGenerator {
 
   /**
    * Generate main flow steps from requirement
-   * @param requirement
+   * @param requirement - The PRD requirement to derive flow steps from
+   * @returns Array of sequential flow steps for the main scenario
    */
   private generateMainFlow(requirement: ParsedPRDRequirement): FlowStep[] {
     const steps: FlowStep[] = [];
@@ -437,7 +445,8 @@ export class UseCaseGenerator {
 
   /**
    * Parse user story into flow steps
-   * @param userStory
+   * @param userStory - User story text in "As a... I want... so that..." format
+   * @returns Array of flow steps derived from the user story
    */
   private parseUserStoryToSteps(userStory: string): FlowStep[] {
     const steps: FlowStep[] = [];
@@ -472,7 +481,8 @@ export class UseCaseGenerator {
 
   /**
    * Generate flow steps from requirement description
-   * @param requirement
+   * @param requirement - The PRD requirement whose description is parsed into steps
+   * @returns Array of flow steps extracted from the description sentences
    */
   private generateStepsFromDescription(requirement: ParsedPRDRequirement): FlowStep[] {
     const steps: FlowStep[] = [];
@@ -507,7 +517,8 @@ export class UseCaseGenerator {
 
   /**
    * Generate flow from a criterion
-   * @param criterion
+   * @param criterion - The acceptance criterion text to convert into flow steps
+   * @returns Array of flow steps representing the criterion scenario
    */
   private generateFlowFromCriterion(criterion: string): FlowStep[] {
     const steps: FlowStep[] = [];
@@ -537,8 +548,9 @@ export class UseCaseGenerator {
 
   /**
    * Generate alternative flows based on main flow
-   * @param requirement
-   * @param mainFlow
+   * @param requirement - The PRD requirement with acceptance criteria
+   * @param mainFlow - The main flow steps to branch from
+   * @returns Array of alternative flow scenarios
    */
   private generateAlternativeFlows(
     requirement: ParsedPRDRequirement,
@@ -598,8 +610,9 @@ export class UseCaseGenerator {
 
   /**
    * Determine which main flow step an alternative branches from
-   * @param condition
-   * @param mainFlow
+   * @param condition - The alternative flow condition text
+   * @param mainFlow - The main flow steps to find a branch point in
+   * @returns Step number where the alternative flow branches off
    */
   private determineBranchPoint(condition: string, mainFlow: readonly FlowStep[]): number {
     const lowerCondition = condition.toLowerCase();
@@ -626,7 +639,8 @@ export class UseCaseGenerator {
 
   /**
    * Generate exception flows for error scenarios
-   * @param requirement
+   * @param requirement - The PRD requirement to derive exception flows from
+   * @returns Array of exception flow definitions
    */
   private generateExceptionFlows(requirement: ParsedPRDRequirement): ExceptionFlow[] {
     const exceptions: ExceptionFlow[] = [];
@@ -653,6 +667,7 @@ export class UseCaseGenerator {
 
   /**
    * Generate generic exception flows
+   * @returns Array of standard exception flows for common error scenarios
    */
   private generateGenericExceptionFlows(): ExceptionFlow[] {
     return [
@@ -671,7 +686,8 @@ export class UseCaseGenerator {
 
   /**
    * Extract exception type from criterion text
-   * @param criterion
+   * @param criterion - The criterion text mentioning an error condition
+   * @returns Human-readable exception type label
    */
   private extractExceptionType(criterion: string): string {
     const patterns: Array<{ pattern: RegExp; type: string }> = [
@@ -695,8 +711,9 @@ export class UseCaseGenerator {
 
   /**
    * Infer exception handling from criterion
-   * @param criterion
-   * @param exceptionType
+   * @param criterion - The criterion text describing error behavior
+   * @param exceptionType - The classified exception type
+   * @returns Recommended handling action for the exception
    */
   private inferExceptionHandling(criterion: string, exceptionType: string): string {
     // Check if criterion specifies handling
@@ -722,7 +739,8 @@ export class UseCaseGenerator {
 
   /**
    * Generate preconditions from requirement
-   * @param requirement
+   * @param requirement - The PRD requirement to derive preconditions from
+   * @returns Array of precondition strings for the use case
    */
   private generatePreconditions(requirement: ParsedPRDRequirement): string[] {
     const preconditions: string[] = [];
@@ -750,7 +768,8 @@ export class UseCaseGenerator {
 
   /**
    * Generate postconditions from requirement
-   * @param requirement
+   * @param requirement - The PRD requirement to derive postconditions from
+   * @returns Array of postcondition strings for the use case
    */
   private generatePostconditions(requirement: ParsedPRDRequirement): string[] {
     const postconditions: string[] = [];
@@ -784,7 +803,8 @@ export class UseCaseGenerator {
 
   /**
    * Generate use case title from requirement title
-   * @param title
+   * @param title - Raw requirement title to format
+   * @returns Formatted use case title with proper capitalization
    */
   private generateTitle(title: string): string {
     let processedTitle = title.trim();
@@ -798,7 +818,8 @@ export class UseCaseGenerator {
 
   /**
    * Extract title from criterion text
-   * @param criterion
+   * @param criterion - The acceptance criterion text to extract a title from
+   * @returns Extracted and formatted title string
    */
   private extractTitleFromCriterion(criterion: string): string {
     // Try to extract action
@@ -821,9 +842,9 @@ export class UseCaseGenerator {
 
   /**
    * Track which criteria are covered by a use case
-   * @param useCase
-   * @param requirement
-   * @param coveredCriteria
+   * @param useCase - The detailed use case to check coverage for
+   * @param requirement - The PRD requirement containing acceptance criteria
+   * @param coveredCriteria - Mutable set to record covered criteria into
    */
   private trackCoveredCriteria(
     useCase: DetailedUseCase,


### PR DESCRIPTION
Closes #477
Part of #463

## Summary
- Add missing `@param` descriptions and `@returns` declarations to all methods in `src/srs-writer/` and `src/sds-writer/` modules
- Resolves ~410 ESLint JSDoc warnings (`jsdoc/require-param-description`, `jsdoc/require-returns`) across 11 files
- No code logic changes — only JSDoc comment updates

## Files Modified

### srs-writer (5 files, ~201 warnings)
| File | Warnings Fixed |
|------|---------------|
| `UseCaseGenerator.ts` | 62 |
| `FeatureDecomposer.ts` | 59 |
| `PRDParser.ts` | 39 |
| `SRSWriterAgent.ts` | 30 |
| `TraceabilityBuilder.ts` | 11 |

### sds-writer (6 files, ~209 warnings)
| File | Warnings Fixed |
|------|---------------|
| `ComponentDesigner.ts` | 48 |
| `SRSParser.ts` | 40 |
| `DataDesigner.ts` | 34 |
| `DeploymentDesigner.ts` | 31 |
| `APISpecifier.ts` | 29 |
| `SDSWriterAgent.ts` | 27 |

## Test Plan
- [x] ESLint: 0 JSDoc warnings in both modules
- [x] Prettier: All files formatted correctly
- [x] All 5052 tests pass