### PR TITLE
refactor(lint): add JSDoc descriptions to issue pipeline and collector modules

### DIFF
--- a/src/collector/CollectorAgent.ts
+++ b/src/collector/CollectorAgent.ts
@@ -482,7 +482,8 @@ export class CollectorAgent implements IAgent {
 
   /**
    * Get an answered value by searching question text
-   * @param searchText
+   * @param searchText - The text to search for in clarification questions
+   * @returns The answer if found, undefined otherwise
    */
   private getAnsweredValue(searchText: string): string | undefined {
     const answer = this.session?.answeredQuestions.find((a) => {
@@ -500,6 +501,7 @@ export class CollectorAgent implements IAgent {
    * @param session - The current session
    * @param name - Project name
    * @param description - Project description
+   * @returns CollectedInfo object formatted for YAML output
    */
   private buildCollectedInfo(
     session: CollectionSession,
@@ -591,7 +593,7 @@ export class CollectorAgent implements IAgent {
   /**
    * Ensure there is an active session in the expected state
    *
-   * @param expectedState
+   * @param expectedState - The expected state the session must be in to proceed
    * @returns The current session
    */
   private ensureSession(expectedState: 'collecting' | 'clarifying'): CollectionSession {

--- a/src/collector/InformationExtractor.ts
+++ b/src/collector/InformationExtractor.ts
@@ -206,7 +206,7 @@ export class InformationExtractor {
   }
 
   /**
-   * Reset ID counters
+   * Reset ID counters to zero before extraction
    */
   private resetCounters(): void {
     this.requirementCounter = 0;
@@ -218,6 +218,7 @@ export class InformationExtractor {
 
   /**
    * Generate next requirement ID
+   * @returns Sequentially numbered functional requirement ID (FR-001, FR-002, etc.)
    */
   private nextRequirementId(): string {
     this.requirementCounter++;
@@ -226,6 +227,7 @@ export class InformationExtractor {
 
   /**
    * Generate next NFR ID
+   * @returns Sequentially numbered non-functional requirement ID (NFR-001, NFR-002, etc.)
    */
   private nextNfrId(): string {
     this.nfrCounter++;
@@ -234,6 +236,7 @@ export class InformationExtractor {
 
   /**
    * Generate next constraint ID
+   * @returns Sequentially numbered constraint ID (CON-001, CON-002, etc.)
    */
   private nextConstraintId(): string {
     this.constraintCounter++;
@@ -242,6 +245,7 @@ export class InformationExtractor {
 
   /**
    * Generate next assumption ID
+   * @returns Sequentially numbered assumption ID (ASM-001, ASM-002, etc.)
    */
   private nextAssumptionId(): string {
     this.assumptionCounter++;
@@ -250,6 +254,7 @@ export class InformationExtractor {
 
   /**
    * Generate next question ID
+   * @returns Sequentially numbered clarification question ID (Q-001, Q-002, etc.)
    */
   private nextQuestionId(): string {
     this.questionCounter++;
@@ -258,7 +263,8 @@ export class InformationExtractor {
 
   /**
    * Extract project name and description from content
-   * @param content
+   * @param content - The text content to analyze for project information
+   * @returns Object containing optional project name and description
    */
   private extractProjectInfo(content: string): {
     name?: string | undefined;
@@ -301,8 +307,9 @@ export class InformationExtractor {
 
   /**
    * Extract requirements from content
-   * @param content
-   * @param source
+   * @param content - The text content to analyze for requirements
+   * @param source - The source reference for traceability
+   * @returns Object containing functional and non-functional requirements arrays
    */
   private extractRequirements(
     content: string,
@@ -422,8 +429,9 @@ export class InformationExtractor {
 
   /**
    * Extract constraints from content
-   * @param content
-   * @param source
+   * @param content - The text content to analyze for constraints
+   * @param source - The source reference for traceability
+   * @returns Array of extracted constraints with type classification
    */
   private extractConstraints(content: string, source: string): ExtractedConstraint[] {
     const constraints: ExtractedConstraint[] = [];
@@ -453,8 +461,9 @@ export class InformationExtractor {
 
   /**
    * Extract assumptions from content
-   * @param content
-   * @param source
+   * @param content - The text content to analyze for assumptions
+   * @param source - The source reference for traceability
+   * @returns Array of extracted assumptions identified in the content
    */
   private extractAssumptions(content: string, source: string): ExtractedAssumption[] {
     const assumptions: ExtractedAssumption[] = [];
@@ -496,8 +505,9 @@ export class InformationExtractor {
 
   /**
    * Extract dependencies from content
-   * @param content
-   * @param source
+   * @param content - The text content to analyze for dependencies
+   * @param source - The source reference for traceability
+   * @returns Array of extracted dependencies with type and requirement status
    */
   private extractDependencies(content: string, source: string): ExtractedDependency[] {
     const dependencies: ExtractedDependency[] = [];
@@ -527,14 +537,15 @@ export class InformationExtractor {
 
   /**
    * Generate clarification questions based on extracted information
-   * @param info
-   * @param info.projectName
-   * @param info.projectDescription
-   * @param info.functionalRequirements
-   * @param info.nonFunctionalRequirements
-   * @param info.constraints
-   * @param info.assumptions
-   * @param info.dependencies
+   * @param info - Extracted information object
+   * @param info.projectName - Extracted project name
+   * @param info.projectDescription - Extracted project description
+   * @param info.functionalRequirements - Array of functional requirements
+   * @param info.nonFunctionalRequirements - Array of non-functional requirements
+   * @param info.constraints - Array of constraints
+   * @param info.assumptions - Array of assumptions
+   * @param info.dependencies - Array of dependencies
+   * @returns Array of clarification questions prioritized by importance
    */
   private generateClarificationQuestions(info: {
     projectName?: string | undefined;
@@ -616,7 +627,8 @@ export class InformationExtractor {
 
   /**
    * Split content into segments (sentences, bullet points, etc.)
-   * @param content
+   * @param content - The text content to split into analyzable segments
+   * @returns Array of text segments extracted from bullets, numbered lists, and sentences
    */
   private splitIntoSegments(content: string): string[] {
     const segments: string[] = [];
@@ -654,7 +666,8 @@ export class InformationExtractor {
 
   /**
    * Check if a segment looks like a requirement
-   * @param text
+   * @param text - The normalized text segment to evaluate
+   * @returns True if the text contains requirement indicators, false otherwise
    */
   private isRequirementLike(text: string): boolean {
     const indicators = [
@@ -680,7 +693,8 @@ export class InformationExtractor {
 
   /**
    * Detect NFR category from text
-   * @param text
+   * @param text - The normalized text to analyze for NFR category keywords
+   * @returns The detected NFR category or undefined if no category matches
    */
   private detectNfrCategory(
     text: string
@@ -708,7 +722,8 @@ export class InformationExtractor {
 
   /**
    * Detect priority from text
-   * @param text
+   * @param text - The normalized text to analyze for priority keywords
+   * @returns The detected priority level (P0-P3) or default priority
    */
   private detectPriority(text: string): Priority {
     for (const [priority, keywords] of Object.entries(PRIORITY_KEYWORDS)) {
@@ -721,7 +736,8 @@ export class InformationExtractor {
 
   /**
    * Detect constraint type from text
-   * @param text
+   * @param text - The normalized text to analyze for constraint type keywords
+   * @returns The detected constraint type or undefined if no type matches
    */
   private detectConstraintType(
     text: string
@@ -736,7 +752,8 @@ export class InformationExtractor {
 
   /**
    * Detect dependency type from text
-   * @param text
+   * @param text - The normalized text to analyze for dependency type keywords
+   * @returns The detected dependency type or undefined if no type matches
    */
   private detectDependencyType(text: string): 'api' | 'library' | 'service' | 'tool' | undefined {
     for (const [type, keywords] of Object.entries(DEPENDENCY_KEYWORDS)) {
@@ -749,7 +766,8 @@ export class InformationExtractor {
 
   /**
    * Extract a title from a segment
-   * @param segment
+   * @param segment - The text segment to extract a title from
+   * @returns The extracted title, truncated to 60 characters if necessary
    */
   private extractTitle(segment: string): string {
     // Take first part up to first punctuation or 60 chars
@@ -762,8 +780,9 @@ export class InformationExtractor {
 
   /**
    * Extract dependency name from segment
-   * @param segment
-   * @param type
+   * @param segment - The text segment containing dependency information
+   * @param type - The dependency type to guide extraction pattern matching
+   * @returns The extracted dependency name or undefined if not found
    */
   private extractDependencyName(segment: string, type: string): string | undefined {
     // Look for quoted names
@@ -793,8 +812,9 @@ export class InformationExtractor {
 
   /**
    * Calculate confidence score for an extraction
-   * @param segment
-   * @param isRelevant
+   * @param segment - The text segment being evaluated
+   * @param isRelevant - Whether the segment is relevant to the extraction type
+   * @returns Confidence score between 0 and 1 based on segment characteristics
    */
   private calculateConfidence(segment: string, isRelevant: boolean): number {
     if (!isRelevant) return 0;

--- a/src/github-repo-setup/GitHubRepoSetupAgent.ts
+++ b/src/github-repo-setup/GitHubRepoSetupAgent.ts
@@ -60,7 +60,7 @@ export class GitHubRepoSetupAgent implements IAgent {
   }
 
   /**
-   *
+   * Initialize the agent and prepare for repository setup operations
    */
   public async initialize(): Promise<void> {
     if (this.initialized) return;
@@ -69,7 +69,7 @@ export class GitHubRepoSetupAgent implements IAgent {
   }
 
   /**
-   *
+   * Cleanup resources and reset agent state
    */
   public async dispose(): Promise<void> {
     await Promise.resolve();
@@ -79,8 +79,9 @@ export class GitHubRepoSetupAgent implements IAgent {
 
   /**
    * Start a new setup session
-   * @param projectName
-   * @param rootPath
+   * @param projectName - The name of the project being set up
+   * @param rootPath - The root directory path where the project will be created
+   * @returns The newly created setup session
    */
   public startSession(projectName: string, rootPath: string): RepoSetupSession {
     const now = new Date().toISOString();
@@ -101,6 +102,7 @@ export class GitHubRepoSetupAgent implements IAgent {
 
   /**
    * Get current session
+   * @returns The current setup session or null if no session is active
    */
   public getSession(): RepoSetupSession | null {
     return this.session;
@@ -111,9 +113,10 @@ export class GitHubRepoSetupAgent implements IAgent {
    *
    * Implements the IGitHubRepoSetupAgent.createRepository interface
    * from SDS-001 Section 3.27.
-   * @param projectName
-   * @param description
-   * @param options
+   * @param projectName - The name of the repository to create
+   * @param description - A brief description of the repository
+   * @param options - Configuration options for repository setup
+   * @returns The result of the repository setup operation including URL and metadata
    */
   public async createRepository(
     projectName: string,
@@ -200,9 +203,10 @@ export class GitHubRepoSetupAgent implements IAgent {
 
   /**
    * Create a GitHub repository using gh CLI
-   * @param projectName
-   * @param description
-   * @param options
+   * @param projectName - The name of the repository to create
+   * @param description - A brief description of the repository
+   * @param options - Configuration options including visibility and license
+   * @returns The full repository name in "owner/repo" format
    */
   private createGhRepo(
     projectName: string,
@@ -252,8 +256,8 @@ export class GitHubRepoSetupAgent implements IAgent {
 
   /**
    * Clone the newly created repository
-   * @param repoFullName
-   * @param targetDir
+   * @param repoFullName - The full repository name in "owner/repo" format
+   * @param targetDir - The local directory path where the repository will be cloned
    */
   private cloneRepo(repoFullName: string, targetDir: string): void {
     const result = this.runGhCommandWithArgs(process.cwd(), [
@@ -270,6 +274,7 @@ export class GitHubRepoSetupAgent implements IAgent {
 
   /**
    * Get the authenticated GitHub user
+   * @returns The GitHub username of the currently authenticated user
    */
   private getGhUser(): string {
     const result = this.runGhCommandWithArgs(process.cwd(), ['api', 'user', '--jq', '.login']);
@@ -287,9 +292,9 @@ export class GitHubRepoSetupAgent implements IAgent {
 
   /**
    * Generate README.md from project metadata
-   * @param repoDir
-   * @param projectName
-   * @param description
+   * @param repoDir - The repository directory path
+   * @param projectName - The name of the project for the README header
+   * @param description - The project description to include in the README
    */
   private generateReadme(repoDir: string, projectName: string, description: string): void {
     const readmePath = path.join(repoDir, 'README.md');
@@ -319,8 +324,8 @@ export class GitHubRepoSetupAgent implements IAgent {
 
   /**
    * Generate .gitignore based on language
-   * @param repoDir
-   * @param language
+   * @param repoDir - The repository directory path
+   * @param language - The programming language for language-specific ignore patterns
    */
   private generateGitignore(repoDir: string, language: string): void {
     const gitignorePath = path.join(repoDir, '.gitignore');
@@ -345,7 +350,8 @@ export class GitHubRepoSetupAgent implements IAgent {
 
   /**
    * Get .gitignore entries for a language
-   * @param language
+   * @param language - The programming language to generate ignore patterns for
+   * @returns Array of .gitignore patterns including base and language-specific entries
    */
   private getGitignoreEntries(language: string): string[] {
     const base = [
@@ -399,7 +405,8 @@ export class GitHubRepoSetupAgent implements IAgent {
 
   /**
    * Perform initial commit and push
-   * @param repoDir
+   * @param repoDir - The repository directory path
+   * @returns The SHA of the initial commit
    */
   private initialCommitAndPush(repoDir: string): string {
     // Stage all files
@@ -440,7 +447,8 @@ export class GitHubRepoSetupAgent implements IAgent {
 
   /**
    * Get the default branch name from the repository
-   * @param repoDir
+   * @param repoDir - The repository directory path
+   * @returns The name of the default branch (e.g., "main", "master")
    */
   private getDefaultBranch(repoDir: string): string {
     const result = this.runGitCommand(repoDir, 'rev-parse --abbrev-ref HEAD');
@@ -456,8 +464,9 @@ export class GitHubRepoSetupAgent implements IAgent {
 
   /**
    * Run a git command using CommandSanitizer
-   * @param cwd
-   * @param command
+   * @param cwd - The working directory to execute the command in
+   * @param command - The git command string to execute (without "git" prefix)
+   * @returns Object containing execution success status, stdout output, and optional error message
    */
   private runGitCommand(
     cwd: string,
@@ -481,8 +490,9 @@ export class GitHubRepoSetupAgent implements IAgent {
 
   /**
    * Run a gh command using a string
-   * @param cwd
-   * @param command
+   * @param cwd - The working directory to execute the command in
+   * @param command - The gh command string to execute (without "gh" prefix)
+   * @returns Object containing execution success status, stdout output, and optional error message
    */
   private runGhCommand(
     cwd: string,
@@ -506,8 +516,9 @@ export class GitHubRepoSetupAgent implements IAgent {
 
   /**
    * Run a gh command with pre-parsed arguments
-   * @param cwd
-   * @param args
+   * @param cwd - The working directory to execute the command in
+   * @param args - Array of command arguments to pass to gh CLI
+   * @returns Object containing execution success status, stdout output, and optional error message
    */
   private runGhCommandWithArgs(
     cwd: string,
@@ -533,9 +544,9 @@ export class GitHubRepoSetupAgent implements IAgent {
 
   /**
    * Save setup result to scratchpad
-   * @param rootPath
-   * @param projectName
-   * @param result
+   * @param rootPath - The root directory path containing the scratchpad
+   * @param projectName - The name of the project for organizing scratchpad files
+   * @param result - The repository setup result to persist
    */
   private saveResult(rootPath: string, projectName: string, result: RepoSetupResult): void {
     const scratchpadPath = path.join(rootPath, this.config.scratchpadBasePath, 'repo', projectName);
@@ -572,7 +583,8 @@ let instance: GitHubRepoSetupAgent | null = null;
 
 /**
  * Get the singleton GitHub Repo Setup Agent instance
- * @param config
+ * @param config - Optional configuration for the agent
+ * @returns The singleton GitHubRepoSetupAgent instance
  */
 export function getGitHubRepoSetupAgent(config?: RepoSetupConfig): GitHubRepoSetupAgent {
   if (instance === null) {

--- a/src/issue-generator/DependencyGraph.ts
+++ b/src/issue-generator/DependencyGraph.ts
@@ -124,8 +124,8 @@ export class DependencyGraphBuilder {
 
   /**
    * DFS helper for cycle detection
-   * @param node
-   * @param path
+   * @param node - The current node being visited in the DFS traversal
+   * @param path - The current path of node IDs from the DFS root to this node
    */
   private dfsDetectCycle(node: InternalNode, path: string[]): void {
     node.visited = true;
@@ -184,6 +184,7 @@ export class DependencyGraphBuilder {
 
   /**
    * Build the output dependency graph structure
+   * @returns Complete dependency graph with nodes, edges, and execution order
    */
   private buildOutput(): DependencyGraphType {
     const nodes: DependencyNode[] = [];
@@ -219,7 +220,8 @@ export class DependencyGraphBuilder {
 
   /**
    * Calculate priority based on number of dependents
-   * @param node
+   * @param node - The internal node to calculate priority for
+   * @returns Priority score based on the number of dependents
    */
   private calculatePriority(node: InternalNode): number {
     // Higher priority for nodes with more dependents
@@ -273,6 +275,7 @@ export class DependencyGraphBuilder {
 
   /**
    * Build groups of issues that can be executed in parallel
+   * @returns Array of parallel groups organized by depth level
    */
   private buildParallelGroups(): readonly ParallelGroup[] {
     const groups: ParallelGroup[] = [];
@@ -297,7 +300,8 @@ export class DependencyGraphBuilder {
 
   /**
    * Get direct dependencies for an issue
-   * @param issueId
+   * @param issueId - The issue ID to get dependencies for
+   * @returns Array of issue IDs that this issue depends on
    */
   public getDependencies(issueId: string): readonly string[] {
     const node = this.nodes.get(issueId);
@@ -306,7 +310,8 @@ export class DependencyGraphBuilder {
 
   /**
    * Get direct dependents for an issue
-   * @param issueId
+   * @param issueId - The issue ID to get dependents for
+   * @returns Array of issue IDs that depend on this issue
    */
   public getDependents(issueId: string): readonly string[] {
     const node = this.nodes.get(issueId);
@@ -315,8 +320,9 @@ export class DependencyGraphBuilder {
 
   /**
    * Check if issue A depends on issue B (directly or transitively)
-   * @param issueA
-   * @param issueB
+   * @param issueA - The dependent issue ID
+   * @param issueB - The dependency issue ID to check for
+   * @returns True if issueA depends on issueB, false otherwise
    */
   public dependsOn(issueA: string, issueB: string): boolean {
     const visited = new Set<string>();
@@ -347,7 +353,8 @@ export class DependencyGraphBuilder {
 
   /**
    * Get all transitive dependencies for an issue
-   * @param issueId
+   * @param issueId - The issue ID to get transitive dependencies for
+   * @returns Sorted array of all issue IDs that this issue transitively depends on
    */
   public getTransitiveDependencies(issueId: string): readonly string[] {
     const result = new Set<string>();
@@ -373,6 +380,7 @@ export class DependencyGraphBuilder {
 
   /**
    * Get statistics about the graph
+   * @returns Graph statistics including node count, edge count, and depth metrics
    */
   public getStatistics(): {
     totalNodes: number;

--- a/src/issue-generator/EffortEstimator.ts
+++ b/src/issue-generator/EffortEstimator.ts
@@ -144,7 +144,8 @@ export class EffortEstimator {
 
   /**
    * Calculate estimation factors for a component
-   * @param component
+   * @param component - The SDS component to analyze
+   * @returns Estimation factors including complexity, interface count, dependency count, and method count
    */
   private calculateFactors(component: SDSComponent): EstimationFactors {
     const complexity = this.analyzeComplexity(component);
@@ -162,7 +163,8 @@ export class EffortEstimator {
 
   /**
    * Analyze component complexity based on various factors
-   * @param component
+   * @param component - The SDS component to analyze
+   * @returns Complexity score from minComplexity to maxComplexity
    */
   private analyzeComplexity(component: SDSComponent): number {
     let score = this.minComplexity;
@@ -208,7 +210,8 @@ export class EffortEstimator {
 
   /**
    * Count total methods across all interfaces
-   * @param component
+   * @param component - The SDS component to count methods from
+   * @returns Total number of methods across all component interfaces
    */
   private countMethods(component: SDSComponent): number {
     return component.interfaces.reduce((sum, iface) => sum + iface.methods.length, 0);
@@ -216,7 +219,8 @@ export class EffortEstimator {
 
   /**
    * Calculate weighted score from factors
-   * @param factors
+   * @param factors - The estimation factors to combine
+   * @returns Weighted effort score on a 0-10 scale
    */
   private calculateScore(factors: EstimationFactors): number {
     // Normalize each factor to 0-10 scale
@@ -237,7 +241,8 @@ export class EffortEstimator {
 
   /**
    * Convert score to effort size
-   * @param score
+   * @param score - The effort score to convert
+   * @returns Effort size category (XS, S, M, L, or XL)
    */
   private scoreToSize(score: number): EffortSize {
     if (score < this.thresholds.xs) return 'XS';
@@ -249,7 +254,8 @@ export class EffortEstimator {
 
   /**
    * Get effort size description
-   * @param size
+   * @param size - The effort size category
+   * @returns Human-readable description of the effort size and time estimate
    */
   public static getSizeDescription(size: EffortSize): string {
     const descriptions: Record<EffortSize, string> = {
@@ -264,8 +270,9 @@ export class EffortEstimator {
 
   /**
    * Check if a component should be decomposed based on size
-   * @param component
-   * @param maxSize
+   * @param component - The SDS component to check for decomposition
+   * @param maxSize - Maximum acceptable effort size (default: 'L')
+   * @returns True if the component exceeds the maximum size threshold
    */
   public shouldDecompose(component: SDSComponent, maxSize: EffortSize = 'L'): boolean {
     const estimation = this.estimate(component);

--- a/src/issue-generator/IssueGenerator.ts
+++ b/src/issue-generator/IssueGenerator.ts
@@ -196,8 +196,9 @@ export class IssueGenerator {
 
   /**
    * Resolve component dependencies to issue IDs
-   * @param issues
-   * @param componentToIssue
+   * @param issues - Array of generated issues with component IDs as dependencies
+   * @param componentToIssue - Map from component IDs to issue IDs
+   * @returns Array of issues with resolved issue ID dependencies
    */
   private resolveDependencies(
     issues: readonly GeneratedIssue[],
@@ -225,8 +226,9 @@ export class IssueGenerator {
 
   /**
    * Build generation summary
-   * @param issues
-   * @param sds
+   * @param issues - Array of generated issues
+   * @param sds - Parsed SDS document
+   * @returns Summary statistics including counts by priority, type, size, and total hours
    */
   private buildSummary(issues: readonly GeneratedIssue[], sds: ParsedSDS): GenerationSummary {
     const byPriority: Record<Priority, number> = {
@@ -286,8 +288,8 @@ export class IssueGenerator {
 
   /**
    * Save results to output files
-   * @param result
-   * @param projectId
+   * @param result - The issue generation result to save
+   * @param projectId - Project identifier for the output directory name
    */
   private async saveResults(result: IssueGenerationResult, projectId: string): Promise<void> {
     const outputDir = path.join(this.config.outputPath, projectId);
@@ -344,7 +346,8 @@ export class IssueGenerator {
 
   /**
    * Get graph statistics
-   * @param result
+   * @param result - The issue generation result containing the dependency graph
+   * @returns Statistics including total nodes, edges, depth, and root/leaf node counts
    */
   public getGraphStatistics(result: IssueGenerationResult): {
     totalNodes: number;
@@ -367,7 +370,8 @@ export class IssueGenerator {
 /**
  * Get the global IssueGenerator instance
  * Creates a new instance with default config if none exists
- * @param config
+ * @param config - Optional configuration for the IssueGenerator
+ * @returns The global IssueGenerator singleton instance
  */
 export function getIssueGenerator(config?: IssueGeneratorConfig): IssueGenerator {
   if (!globalInstance) {

--- a/src/issue-generator/IssueTransformer.ts
+++ b/src/issue-generator/IssueTransformer.ts
@@ -75,9 +75,10 @@ export class IssueTransformer {
 
   /**
    * Transform a single component to an issue
-   * @param component
-   * @param traceabilityMatrix
-   * @param estimation
+   * @param component - The SDS component to transform
+   * @param traceabilityMatrix - Traceability entries linking components to SRS and PRD
+   * @param estimation - Optional pre-calculated effort estimation
+   * @returns Generated GitHub issue
    */
   public transformComponent(
     component: SDSComponent,
@@ -115,8 +116,9 @@ export class IssueTransformer {
 
   /**
    * Decompose a large component into multiple issues
-   * @param component
-   * @param traceabilityMatrix
+   * @param component - The large component to decompose into sub-tasks
+   * @param traceabilityMatrix - Traceability entries for source references
+   * @returns Array of issues including parent epic and sub-tasks
    */
   private decomposeComponent(
     component: SDSComponent,
@@ -213,6 +215,7 @@ export class IssueTransformer {
 
   /**
    * Generate a unique issue ID
+   * @returns A unique issue ID in the format ISS-XXX
    */
   private generateIssueId(): string {
     this.issueCounter++;
@@ -221,7 +224,8 @@ export class IssueTransformer {
 
   /**
    * Generate issue title from component
-   * @param component
+   * @param component - The SDS component to generate a title for
+   * @returns A descriptive issue title
    */
   private generateTitle(component: SDSComponent): string {
     if (component.name) {
@@ -232,8 +236,9 @@ export class IssueTransformer {
 
   /**
    * Build traceability links
-   * @param component
-   * @param matrix
+   * @param component - The SDS component to build traceability for
+   * @param matrix - Traceability matrix entries from the SDS document
+   * @returns Traceability object with links to SDS, SRS, and PRD
    */
   private buildTraceability(
     component: SDSComponent,
@@ -260,8 +265,9 @@ export class IssueTransformer {
 
   /**
    * Build issue labels
-   * @param component
-   * @param estimation
+   * @param component - The SDS component to generate labels for
+   * @param estimation - Effort estimation containing the size category
+   * @returns Issue labels with type, priority, component, size, and phase
    */
   private buildLabels(component: SDSComponent, estimation: IssueEstimation): IssueLabels {
     return {
@@ -276,7 +282,8 @@ export class IssueTransformer {
 
   /**
    * Build technical guidance
-   * @param component
+   * @param component - The SDS component to extract technical details from
+   * @returns Technical guidance including suggested approach and implementation notes
    */
   private buildTechnical(component: SDSComponent): IssueTechnical {
     const suggestedApproach: string[] = [];
@@ -305,7 +312,8 @@ export class IssueTransformer {
 
   /**
    * Build dependency relationships
-   * @param component
+   * @param component - The SDS component with dependency information
+   * @returns Dependency structure with blockedBy and blocks relationships
    */
   private buildDependencies(component: SDSComponent): IssueDependencies {
     // Note: Actual issue IDs will be resolved later by IssueGenerator
@@ -317,10 +325,11 @@ export class IssueTransformer {
 
   /**
    * Generate the issue body in markdown
-   * @param component
-   * @param traceability
-   * @param technical
-   * @param estimation
+   * @param component - The SDS component to generate the body for
+   * @param traceability - Traceability links to source documents
+   * @param technical - Technical guidance and implementation notes
+   * @param estimation - Effort estimation with size and hours
+   * @returns Formatted markdown issue body
    */
   private generateBody(
     component: SDSComponent,
@@ -419,7 +428,8 @@ export class IssueTransformer {
 
   /**
    * Generate acceptance criteria from component
-   * @param component
+   * @param component - The SDS component to generate criteria for
+   * @returns Formatted markdown checklist of acceptance criteria
    */
   private generateAcceptanceCriteria(component: SDSComponent): string {
     const criteria: string[] = [];
@@ -444,9 +454,10 @@ export class IssueTransformer {
 
   /**
    * Generate body for epic (parent) issue
-   * @param component
-   * @param subTasks
-   * @param traceability
+   * @param component - The SDS component representing the epic
+   * @param subTasks - Array of sub-task descriptions
+   * @param traceability - Traceability links to source documents
+   * @returns Formatted markdown for the epic issue body
    */
   private generateEpicBody(
     component: SDSComponent,
@@ -483,10 +494,11 @@ export class IssueTransformer {
 
   /**
    * Generate body for sub-task issue
-   * @param component
-   * @param task
-   * @param parentId
-   * @param traceability
+   * @param component - The parent SDS component
+   * @param task - The specific sub-task description
+   * @param parentId - The parent epic issue ID
+   * @param traceability - Traceability links to source documents
+   * @returns Formatted markdown for the sub-task issue body
    */
   private generateSubTaskBody(
     component: SDSComponent,

--- a/src/issue-generator/SDSParser.ts
+++ b/src/issue-generator/SDSParser.ts
@@ -96,7 +96,8 @@ export class SDSParser {
 
   /**
    * Parse document metadata from the header table
-   * @param lines
+   * @param lines - The markdown content split into lines
+   * @returns Parsed metadata including document ID, source references, version, and dates
    */
   private parseMetadata(lines: readonly string[]): SDSMetadata {
     const metadata: Record<string, string> = {};
@@ -128,6 +129,7 @@ export class SDSParser {
 
   /**
    * Mutable parsing state for a component
+   * @returns Empty parsing state object with default values
    */
   private createEmptyParsingState(): {
     id: string;
@@ -145,7 +147,8 @@ export class SDSParser {
 
   /**
    * Parse components from the Component Design section
-   * @param lines
+   * @param lines - The markdown content split into lines
+   * @returns Array of parsed SDS components with interfaces and dependencies
    */
   private parseComponents(lines: readonly string[]): readonly SDSComponent[] {
     const components: SDSComponent[] = [];
@@ -298,15 +301,16 @@ export class SDSParser {
 
   /**
    * Finalize a component with all its collected data
-   * @param state
-   * @param state.id
-   * @param state.name
-   * @param state.sourceFeature
-   * @param state.priority
-   * @param descriptionLines
-   * @param implNotesLines
-   * @param dependencies
-   * @param interfaceBuffer
+   * @param state - The current parsing state containing component ID, name, source feature, and priority
+   * @param state.id - Component ID (e.g., CMP-001)
+   * @param state.name - Component name
+   * @param state.sourceFeature - Source SRS feature reference
+   * @param state.priority - Component priority (P0-P3)
+   * @param descriptionLines - Collected description text lines
+   * @param implNotesLines - Collected implementation notes lines
+   * @param dependencies - Component dependency IDs
+   * @param interfaceBuffer - Collected interface code lines
+   * @returns Complete SDS component with all properties
    */
   private finalizeComponent(
     state: { id: string; name: string; sourceFeature: string | null; priority: Priority },
@@ -332,7 +336,8 @@ export class SDSParser {
 
   /**
    * Parse interface definitions from TypeScript code
-   * @param lines
+   * @param lines - TypeScript code lines containing interface definitions
+   * @returns Array of parsed interfaces with methods
    */
   private parseInterfaces(lines: readonly string[]): readonly SDSInterface[] {
     const interfaces: SDSInterface[] = [];
@@ -359,7 +364,8 @@ export class SDSParser {
 
   /**
    * Parse method signatures from interface code
-   * @param lines
+   * @param lines - TypeScript code lines containing method signatures
+   * @returns Array of parsed methods with names, signatures, and return types
    */
   private parseMethods(lines: readonly string[]): readonly SDSMethod[] {
     const methods: SDSMethod[] = [];
@@ -385,7 +391,8 @@ export class SDSParser {
 
   /**
    * Extract component IDs from dependency list
-   * @param dependencies
+   * @param dependencies - Raw dependency strings that may contain component IDs
+   * @returns Array of extracted component IDs in CMP-XXX format
    */
   private extractComponentDependencies(dependencies: readonly string[]): readonly string[] {
     return dependencies
@@ -398,7 +405,8 @@ export class SDSParser {
 
   /**
    * Parse priority value
-   * @param value
+   * @param value - Priority string (e.g., "P0", "P1", or "P0 / P1 / P2 / P3")
+   * @returns Parsed priority value (P0, P1, P2, or P3)
    */
   private parsePriority(value: string): Priority {
     const normalized = value.trim().toUpperCase();
@@ -415,7 +423,8 @@ export class SDSParser {
 
   /**
    * Parse technology stack from Section 2.3
-   * @param lines
+   * @param lines - The markdown content split into lines
+   * @returns Array of technology stack entries with layer, technology, version, and rationale
    */
   private parseTechnologyStack(lines: readonly string[]): readonly TechnologyEntry[] {
     const stack: TechnologyEntry[] = [];
@@ -472,7 +481,8 @@ export class SDSParser {
 
   /**
    * Parse traceability matrix from Section 9
-   * @param lines
+   * @param lines - The markdown content split into lines
+   * @returns Array of traceability entries linking components to SRS features and PRD requirements
    */
   private parseTraceabilityMatrix(lines: readonly string[]): readonly TraceabilityEntry[] {
     const matrix: TraceabilityEntry[] = [];
@@ -529,7 +539,8 @@ export class SDSParser {
 
   /**
    * Parse use case references from a cell value
-   * @param value
+   * @param value - Comma-separated or space-separated use case IDs
+   * @returns Array of use case IDs in UC-XXX format
    */
   private parseUseCases(value: string): readonly string[] {
     const matches = value.match(/UC-\d{3}/g);
@@ -538,7 +549,8 @@ export class SDSParser {
 
   /**
    * Validate parsed SDS structure
-   * @param sds
+   * @param sds - The parsed SDS document to validate
+   * @returns Array of validation error messages (empty if valid)
    * @throws SDSParseError if validation fails in strict mode
    */
   public validate(sds: ParsedSDS): readonly string[] {

--- a/src/issue-reader/IssueReaderAgent.ts
+++ b/src/issue-reader/IssueReaderAgent.ts
@@ -99,7 +99,8 @@ export class IssueReaderAgent implements IAgent {
   }
 
   /**
-   *
+   * Initialize the agent
+   * @returns Promise that resolves when initialization is complete
    */
   public async initialize(): Promise<void> {
     if (this.initialized) return;
@@ -108,7 +109,8 @@ export class IssueReaderAgent implements IAgent {
   }
 
   /**
-   *
+   * Dispose of the agent and clean up resources
+   * @returns Promise that resolves when cleanup is complete
    */
   public async dispose(): Promise<void> {
     await Promise.resolve();
@@ -122,7 +124,8 @@ export class IssueReaderAgent implements IAgent {
 
   /**
    * Start a new import session
-   * @param repository
+   * @param repository - The GitHub repository identifier (owner/repo format)
+   * @returns Newly created session object
    */
   public startSession(repository: string): IssueReaderSession {
     const now = new Date().toISOString();
@@ -142,6 +145,7 @@ export class IssueReaderAgent implements IAgent {
 
   /**
    * Get the current session
+   * @returns Current session object or null if no session exists
    */
   public getSession(): IssueReaderSession | null {
     return this.session;
@@ -155,8 +159,9 @@ export class IssueReaderAgent implements IAgent {
    * Import issues from a GitHub repository
    *
    * Implements the IIssueReaderAgent.importIssues interface from SDS-001 Section 3.28.
-   * @param repoUrl
-   * @param options
+   * @param repoUrl - GitHub repository URL or owner/repo identifier
+   * @param options - Filtering and pagination options for issue import
+   * @returns Import result containing issues, dependency graph, and statistics
    */
   public async importIssues(
     repoUrl: string,
@@ -228,6 +233,7 @@ export class IssueReaderAgent implements IAgent {
 
   /**
    * Verify gh CLI authentication
+   * @returns void, throws GhAuthError if authentication fails
    */
   private verifyGhAuth(): void {
     const result = this.runGhCommand(['auth', 'status']);
@@ -238,8 +244,9 @@ export class IssueReaderAgent implements IAgent {
 
   /**
    * Fetch issues from GitHub using gh CLI
-   * @param repository
-   * @param options
+   * @param repository - The GitHub repository identifier (owner/repo format)
+   * @param options - Filtering and pagination options for issue fetching
+   * @returns Array of raw GitHub issues from gh CLI
    */
   private fetchIssues(repository: string, options: IssueImportOptions): readonly GhIssueRaw[] {
     const args = [
@@ -290,8 +297,9 @@ export class IssueReaderAgent implements IAgent {
 
   /**
    * Convert raw GitHub issues to AD-SDLC internal format
-   * @param rawIssues
-   * @param repository
+   * @param rawIssues - Array of raw GitHub issues from gh CLI
+   * @param repository - The GitHub repository identifier (owner/repo format)
+   * @returns Array of issues converted to AD-SDLC internal format
    */
   private convertIssues(
     rawIssues: readonly GhIssueRaw[],
@@ -331,7 +339,8 @@ export class IssueReaderAgent implements IAgent {
 
   /**
    * Map raw GitHub labels to structured AD-SDLC labels
-   * @param labelNames
+   * @param labelNames - Array of raw GitHub label names
+   * @returns Structured label object with priority, type, and size
    */
   private mapLabels(labelNames: readonly string[]): ImportedIssueLabels {
     let priority: Priority = DEFAULT_PRIORITY;
@@ -365,8 +374,9 @@ export class IssueReaderAgent implements IAgent {
 
   /**
    * Extract dependency relationships from issue body text
-   * @param body
-   * @param validNumbers
+   * @param body - The issue body text containing dependency references
+   * @param validNumbers - Set of valid issue numbers for reference validation
+   * @returns Object containing arrays of dependency and blocking issue numbers
    */
   private extractDependencies(
     body: string,
@@ -410,7 +420,8 @@ export class IssueReaderAgent implements IAgent {
 
   /**
    * Estimate issue complexity from effort size
-   * @param size
+   * @param size - The effort size label (XS, S, M, L, XL)
+   * @returns Complexity category (small, medium, or large)
    */
   private estimateComplexity(size: EffortSize): 'small' | 'medium' | 'large' {
     if (size === 'XS' || size === 'S') return 'small';
@@ -424,7 +435,8 @@ export class IssueReaderAgent implements IAgent {
 
   /**
    * Build a dependency graph from imported issues
-   * @param issues
+   * @param issues - Array of imported issues with dependency information
+   * @returns Complete dependency graph with nodes, edges, and topological analysis
    */
   private buildDependencyGraph(issues: readonly ImportedIssue[]): ImportDependencyGraph {
     const numberToId = new Map<number, ImportedIssue>();
@@ -514,8 +526,9 @@ export class IssueReaderAgent implements IAgent {
 
   /**
    * Perform topological sort using Kahn's algorithm on depends_on edges
-   * @param issues
-   * @param numberToId
+   * @param issues - Array of imported issues to sort
+   * @param numberToId - Map from GitHub issue number to issue object
+   * @returns Object containing cycle detection and topological order results
    */
   private topologicalSort(
     issues: readonly ImportedIssue[],
@@ -578,8 +591,9 @@ export class IssueReaderAgent implements IAgent {
 
   /**
    * Find nodes that are blocked (have unresolved dependencies)
-   * @param issues
-   * @param numberToId
+   * @param issues - Array of imported issues to analyze
+   * @param numberToId - Map from GitHub issue number to issue object
+   * @returns Set of issue IDs that are blocked by unresolved dependencies
    */
   private findBlockedNodes(
     issues: readonly ImportedIssue[],
@@ -604,7 +618,8 @@ export class IssueReaderAgent implements IAgent {
 
   /**
    * Compute import statistics
-   * @param issues
+   * @param issues - Array of imported issues to analyze
+   * @returns Statistics object with counts, priorities, and effort estimates
    */
   private computeStats(issues: readonly ImportedIssue[]): ImportStats {
     const byPriority: Record<Priority, number> = { P0: 0, P1: 0, P2: 0, P3: 0 };
@@ -635,7 +650,8 @@ export class IssueReaderAgent implements IAgent {
 
   /**
    * Run a gh command via CommandSanitizer
-   * @param args
+   * @param args - Array of command-line arguments for gh CLI
+   * @returns Execution result with success status, output, and optional error
    */
   private runGhCommand(args: readonly string[]): {
     success: boolean;
@@ -662,7 +678,8 @@ export class IssueReaderAgent implements IAgent {
 
   /**
    * Normalize a repository URL to owner/repo format
-   * @param repoUrl
+   * @param repoUrl - GitHub repository URL or owner/repo identifier
+   * @returns Normalized repository identifier in owner/repo format
    */
   private normalizeRepoUrl(repoUrl: string): string {
     // Already in owner/repo format
@@ -685,8 +702,9 @@ export class IssueReaderAgent implements IAgent {
 
   /**
    * Save import results to scratchpad
-   * @param repository
-   * @param result
+   * @param repository - The GitHub repository identifier (owner/repo format)
+   * @param result - Import result containing issues and dependency graph
+   * @returns void, throws OutputWriteError if file operations fail
    */
   private saveOutput(repository: string, result: IssueImportResult): void {
     const projectId = repository.replace('/', '_');
@@ -735,7 +753,8 @@ let instance: IssueReaderAgent | null = null;
 
 /**
  * Get the singleton Issue Reader Agent instance
- * @param config
+ * @param config - Optional configuration to initialize the agent with
+ * @returns Singleton instance of IssueReaderAgent
  */
 export function getIssueReaderAgent(config?: IssueReaderConfig): IssueReaderAgent {
   if (instance === null) {

--- a/src/project-initializer/InteractiveWizard.ts
+++ b/src/project-initializer/InteractiveWizard.ts
@@ -41,6 +41,7 @@ export class InteractiveWizard {
 
   /**
    * Run the interactive wizard to gather project configuration
+   * @returns Project initialization options gathered from user input
    */
   async run(): Promise<InitOptions> {
     const answers = await inquirer.prompt<WizardAnswers>([
@@ -125,7 +126,8 @@ export class InteractiveWizard {
 
   /**
    * Prompt for confirmation before proceeding
-   * @param message
+   * @param message - The confirmation message to display to the user
+   * @returns True if the user confirms, false otherwise
    */
   async confirm(message: string): Promise<boolean> {
     const answer = await inquirer.prompt<ConfirmAnswer>([
@@ -141,7 +143,8 @@ export class InteractiveWizard {
 
   /**
    * Display a summary of the configuration and ask for confirmation
-   * @param options
+   * @param options - The initialization options to display for confirmation
+   * @returns True if the user confirms the configuration, false otherwise
    */
   async confirmConfiguration(options: InitOptions): Promise<boolean> {
     const summaryData: Record<string, string> = {
@@ -165,6 +168,7 @@ export class InteractiveWizard {
 
 /**
  * Create and return an InteractiveWizard instance
+ * @returns New instance of InteractiveWizard
  */
 export function createInteractiveWizard(): InteractiveWizard {
   return new InteractiveWizard();

--- a/src/project-initializer/PrerequisiteValidator.ts
+++ b/src/project-initializer/PrerequisiteValidator.ts
@@ -48,6 +48,7 @@ export class PrerequisiteValidator {
 
   /**
    * Run all prerequisite checks
+   * @returns Validation result containing check statuses and overall validity
    */
   async validate(): Promise<PrerequisiteValidationResult> {
     const results: PrerequisiteResult[] = [];
@@ -91,6 +92,7 @@ export class PrerequisiteValidator {
 
   /**
    * Check if Node.js version is 18 or higher
+   * @returns True if Node.js version is 18 or higher, false otherwise
    */
   private checkNodeVersion(): Promise<boolean> {
     const version = process.version;
@@ -100,6 +102,7 @@ export class PrerequisiteValidator {
 
   /**
    * Check if Claude API key is set
+   * @returns True if CLAUDE_API_KEY or ANTHROPIC_API_KEY is set, false otherwise
    */
   private checkClaudeApiKey(): Promise<boolean> {
     const claudeKey = process.env['CLAUDE_API_KEY'];
@@ -112,6 +115,7 @@ export class PrerequisiteValidator {
 
   /**
    * Check if GitHub CLI is installed and authenticated
+   * @returns True if GitHub CLI is installed and user is logged in, false otherwise
    */
   private async checkGitHubCli(): Promise<boolean> {
     const sanitizer = getCommandSanitizer();
@@ -125,6 +129,7 @@ export class PrerequisiteValidator {
 
   /**
    * Check if Git is installed
+   * @returns True if Git is installed and executable, false otherwise
    */
   private async checkGit(): Promise<boolean> {
     const sanitizer = getCommandSanitizer();
@@ -138,7 +143,7 @@ export class PrerequisiteValidator {
 
   /**
    * Add a custom prerequisite check
-   * @param check
+   * @param check - The prerequisite check to add to the validation list
    */
   addCheck(check: PrerequisiteCheck): void {
     this.checks.push(check);
@@ -146,6 +151,7 @@ export class PrerequisiteValidator {
 
   /**
    * Get all registered checks
+   * @returns Read-only array of all registered prerequisite checks
    */
   getChecks(): readonly PrerequisiteCheck[] {
     return this.checks;
@@ -157,6 +163,7 @@ let validatorInstance: PrerequisiteValidator | null = null;
 
 /**
  * Get the singleton PrerequisiteValidator instance
+ * @returns The singleton PrerequisiteValidator instance
  */
 export function getPrerequisiteValidator(): PrerequisiteValidator {
   if (!validatorInstance) {

--- a/src/project-initializer/ProjectInitializer.ts
+++ b/src/project-initializer/ProjectInitializer.ts
@@ -33,7 +33,8 @@ import { QUALITY_GATE_CONFIGS, TEMPLATE_CONFIGS } from './types.js';
  * 1. Explicitly provided targetDir
  * 2. Initialized project root from ProjectContext
  * 3. Current working directory (fallback)
- * @param targetDir
+ * @param targetDir - Optional target directory path to use
+ * @returns Resolved target directory path
  */
 function resolveTargetDir(targetDir?: string): string {
   if (targetDir !== undefined && targetDir !== '') {
@@ -57,6 +58,7 @@ export class ProjectInitializer {
 
   /**
    * Initialize a new AD-SDLC project
+   * @returns Initialization result containing success status and created files
    */
   async initialize(): Promise<InitResult> {
     const createdFiles: string[] = [];
@@ -157,7 +159,8 @@ export class ProjectInitializer {
 
   /**
    * Get the directory structure to create
-   * @param projectPath
+   * @param projectPath - The root path of the project
+   * @returns Array of directory paths to create
    */
   private getDirectoryStructure(projectPath: string): string[] {
     return [
@@ -189,7 +192,8 @@ export class ProjectInitializer {
 
   /**
    * Create a directory if it doesn't exist
-   * @param dirPath
+   * @param dirPath - The directory path to create
+   * @returns Promise that resolves when directory is created
    */
   private createDirectory(dirPath: string): Promise<void> {
     try {
@@ -204,7 +208,8 @@ export class ProjectInitializer {
 
   /**
    * Generate configuration files
-   * @param projectPath
+   * @param projectPath - The root path of the project
+   * @returns Array of created configuration file paths
    */
   private async generateConfigFiles(projectPath: string): Promise<string[]> {
     const createdFiles: string[] = [];
@@ -228,8 +233,9 @@ export class ProjectInitializer {
 
   /**
    * Generate workflow configuration
-   * @param templateConfig
-   * @param qualityGates
+   * @param templateConfig - The template configuration to use
+   * @param qualityGates - The quality gate configuration to apply
+   * @returns Generated workflow configuration object
    */
   private generateWorkflowConfig(
     templateConfig: TemplateConfig,
@@ -259,6 +265,7 @@ export class ProjectInitializer {
 
   /**
    * Generate agents configuration
+   * @returns Agent configuration object with definitions
    */
   private generateAgentsConfig(): Record<string, unknown> {
     return {
@@ -310,7 +317,8 @@ export class ProjectInitializer {
 
   /**
    * Generate template files
-   * @param projectPath
+   * @param projectPath - The root path of the project
+   * @returns Array of created template file paths
    */
   private async generateTemplateFiles(projectPath: string): Promise<string[]> {
     const createdFiles: string[] = [];
@@ -345,7 +353,8 @@ export class ProjectInitializer {
 
   /**
    * Generate agent definition files
-   * @param projectPath
+   * @param projectPath - The root path of the project
+   * @returns Array of created agent definition file paths
    */
   private async generateAgentDefinitions(projectPath: string): Promise<string[]> {
     const createdFiles: string[] = [];
@@ -373,8 +382,9 @@ export class ProjectInitializer {
 
   /**
    * Write content to a file
-   * @param filePath
-   * @param content
+   * @param filePath - The path where the file should be written
+   * @param content - The content to write to the file
+   * @returns Promise that resolves when file is written
    */
   private writeFile(filePath: string, content: string): Promise<void> {
     try {
@@ -387,7 +397,8 @@ export class ProjectInitializer {
 
   /**
    * Update .gitignore with AD-SDLC entries
-   * @param projectPath
+   * @param projectPath - The root path of the project
+   * @returns True if .gitignore was updated, false if already contained entries
    */
   private async updateGitignore(projectPath: string): Promise<boolean> {
     const gitignorePath = path.join(projectPath, '.gitignore');
@@ -408,7 +419,8 @@ export class ProjectInitializer {
 
   /**
    * Create a basic README file
-   * @param projectPath
+   * @param projectPath - The root path of the project
+   * @returns Promise that resolves when README is created
    */
   private async createReadme(projectPath: string): Promise<void> {
     const content = `# ${this.options.projectName}
@@ -848,7 +860,8 @@ You are the PR Reviewer agent responsible for reviewing pull requests.
 
   /**
    * Get template configuration
-   * @param template
+   * @param template - The template type to retrieve configuration for
+   * @returns Template configuration object
    */
   getTemplateConfig(template: TemplateType): TemplateConfig {
     return TEMPLATE_CONFIGS[template];
@@ -860,7 +873,8 @@ let initializerInstance: ProjectInitializer | null = null;
 
 /**
  * Create a new ProjectInitializer with given options
- * @param options
+ * @param options - The initialization options for the project
+ * @returns New instance of ProjectInitializer
  */
 export function createProjectInitializer(options: InitOptions): ProjectInitializer {
   initializerInstance = new ProjectInitializer(options);

--- a/src/project-initializer/TemplateVersioning.ts
+++ b/src/project-initializer/TemplateVersioning.ts
@@ -35,8 +35,9 @@ export function compareVersions(a: TemplateVersion, b: TemplateVersion): -1 | 0 
 
 /**
  * Check if two versions are equal
- * @param a
- * @param b
+ * @param a - First version to compare
+ * @param b - Second version to compare
+ * @returns True if versions are equal, false otherwise
  */
 export function versionsEqual(a: TemplateVersion, b: TemplateVersion): boolean {
   return compareVersions(a, b) === 0;
@@ -44,7 +45,8 @@ export function versionsEqual(a: TemplateVersion, b: TemplateVersion): boolean {
 
 /**
  * Format a version as a string (e.g., "1.0.0")
- * @param version
+ * @param version - The version to format
+ * @returns Formatted version string
  */
 export function formatVersion(version: TemplateVersion): string {
   return `${String(version.major)}.${String(version.minor)}.${String(version.patch)}`;
@@ -77,8 +79,9 @@ export function parseVersion(versionString: string): TemplateVersion | null {
  * Versions are compatible if:
  * - Major versions match (breaking changes require migration)
  * - Source minor version <= target minor version
- * @param source
- * @param target
+ * @param source - The source version to check
+ * @param target - The target version to check against
+ * @returns True if versions are compatible, false otherwise
  */
 export function isVersionCompatible(source: TemplateVersion, target: TemplateVersion): boolean {
   // Major version must match for compatibility
@@ -96,7 +99,7 @@ const migrationRegistry: TemplateMigrationStep[] = [];
 
 /**
  * Register a migration step
- * @param step
+ * @param step - The migration step to register
  */
 export function registerMigration(step: TemplateMigrationStep): void {
   migrationRegistry.push(step);
@@ -111,6 +114,7 @@ export function clearMigrations(): void {
 
 /**
  * Get all registered migrations
+ * @returns Read-only array of all registered migration steps
  */
 export function getMigrations(): readonly TemplateMigrationStep[] {
   return [...migrationRegistry];
@@ -332,7 +336,8 @@ export function migrateTemplate(config: TemplateConfig): TemplateMigrationResult
 
 /**
  * Check if a template configuration needs migration
- * @param config
+ * @param config - The template configuration to check
+ * @returns True if the configuration needs migration, false otherwise
  */
 export function needsMigration(config: TemplateConfig): boolean {
   return compareVersions(config.version, CURRENT_TEMPLATE_VERSION) < 0;
@@ -340,6 +345,7 @@ export function needsMigration(config: TemplateConfig): boolean {
 
 /**
  * Get the current template version
+ * @returns The current template version
  */
 export function getCurrentVersion(): TemplateVersion {
   return CURRENT_TEMPLATE_VERSION;

--- a/src/repo-detector/RepoDetector.ts
+++ b/src/repo-detector/RepoDetector.ts
@@ -79,7 +79,8 @@ export class RepoDetector implements IAgent {
   }
 
   /**
-   *
+   * Initialize the repository detector agent
+   * @returns Promise that resolves when initialization is complete
    */
   public async initialize(): Promise<void> {
     if (this.initialized) return;
@@ -88,7 +89,8 @@ export class RepoDetector implements IAgent {
   }
 
   /**
-   *
+   * Dispose of the repository detector agent and cleanup resources
+   * @returns Promise that resolves when disposal is complete
    */
   public async dispose(): Promise<void> {
     await Promise.resolve();
@@ -98,8 +100,9 @@ export class RepoDetector implements IAgent {
 
   /**
    * Start a new detection session
-   * @param projectId
-   * @param rootPath
+   * @param projectId - The unique identifier for the project
+   * @param rootPath - The absolute path to the project root directory
+   * @returns The newly created detection session
    */
   public startSession(projectId: string, rootPath: string): RepoDetectionSession {
     const now = new Date().toISOString();
@@ -120,6 +123,7 @@ export class RepoDetector implements IAgent {
 
   /**
    * Get current session
+   * @returns The current detection session or null if no session is active
    */
   public getSession(): RepoDetectionSession | null {
     return this.session;
@@ -127,6 +131,7 @@ export class RepoDetector implements IAgent {
 
   /**
    * Detect repository mode for the current session
+   * @returns Promise resolving to the detection result with repository mode and status
    */
   public detect(): Promise<RepoDetectionResult> {
     try {
@@ -213,7 +218,8 @@ export class RepoDetector implements IAgent {
 
   /**
    * Check Git initialization status
-   * @param rootPath
+   * @param rootPath - The absolute path to the project root directory
+   * @returns Git status information including initialization state, commits, and branch
    */
   private checkGitStatus(rootPath: string): GitStatus {
     const gitDir = path.join(rootPath, '.git');
@@ -270,8 +276,9 @@ export class RepoDetector implements IAgent {
 
   /**
    * Check remote repository configuration
-   * @param rootPath
-   * @param gitInitialized
+   * @param rootPath - The absolute path to the project root directory
+   * @param gitInitialized - Whether Git is initialized in the project
+   * @returns Remote status information including origin URL and remote type
    */
   private checkRemoteStatus(rootPath: string, gitInitialized: boolean): RemoteStatus {
     if (!gitInitialized) {
@@ -304,7 +311,8 @@ export class RepoDetector implements IAgent {
 
   /**
    * Detect remote type from URL
-   * @param url
+   * @param url - The remote repository URL
+   * @returns The detected remote type (github, gitlab, bitbucket, or other)
    */
   private detectRemoteType(url: string): RemoteType {
     const lowerUrl = url.toLowerCase();
@@ -324,8 +332,9 @@ export class RepoDetector implements IAgent {
 
   /**
    * Check GitHub repository status
-   * @param rootPath
-   * @param remoteStatus
+   * @param rootPath - The absolute path to the project root directory
+   * @param remoteStatus - The remote repository status information
+   * @returns GitHub status information including existence, accessibility, and repository details
    */
   private checkGitHubStatus(rootPath: string, remoteStatus: RemoteStatus): GitHubStatus {
     // If not GitHub, return empty status
@@ -402,7 +411,8 @@ export class RepoDetector implements IAgent {
 
   /**
    * Parse GitHub URL to extract owner and name
-   * @param url
+   * @param url - The GitHub repository URL (HTTPS or SSH format)
+   * @returns Object containing owner and repository name, or null if parsing fails
    */
   private parseGitHubUrl(url: string): { owner: string; name: string } | null {
     // Handle HTTPS URLs
@@ -440,9 +450,10 @@ export class RepoDetector implements IAgent {
 
   /**
    * Determine repository mode and recommendation
-   * @param gitStatus
-   * @param remoteStatus
-   * @param githubStatus
+   * @param gitStatus - The Git initialization and commit status
+   * @param remoteStatus - The remote repository configuration status
+   * @param githubStatus - The GitHub repository existence and accessibility status
+   * @returns Object containing repository mode, confidence level, and setup recommendation
    */
   private determineMode(
     gitStatus: GitStatus,
@@ -526,8 +537,9 @@ export class RepoDetector implements IAgent {
   /**
    * Run a Git command with timeout using safe execution
    * Uses execFileSync to bypass shell and prevent command injection
-   * @param rootPath
-   * @param command
+   * @param rootPath - The absolute path to the project root directory
+   * @param command - The git command arguments (without 'git' prefix)
+   * @returns Object containing execution success status, stdout output, and optional stderr error
    */
   private runGitCommand(
     rootPath: string,
@@ -554,8 +566,9 @@ export class RepoDetector implements IAgent {
   /**
    * Run a gh CLI command with timeout using safe execution
    * Uses execFileSync to bypass shell and prevent command injection
-   * @param rootPath
-   * @param command
+   * @param rootPath - The absolute path to the project root directory
+   * @param command - The gh CLI command arguments (without 'gh' prefix)
+   * @returns Object containing execution success status, stdout output, and optional stderr error
    */
   private runGhCommand(
     rootPath: string,
@@ -581,9 +594,9 @@ export class RepoDetector implements IAgent {
 
   /**
    * Save detection result to scratchpad
-   * @param rootPath
-   * @param projectId
-   * @param result
+   * @param rootPath - The absolute path to the project root directory
+   * @param projectId - The unique identifier for the project
+   * @param result - The detection result to save
    */
   private saveResult(rootPath: string, projectId: string, result: RepoDetectionResult): void {
     const scratchpadPath = path.join(rootPath, this.config.scratchpadBasePath, 'repo', projectId);
@@ -637,6 +650,8 @@ export class RepoDetector implements IAgent {
 
   /**
    * Ensure session exists
+   * @returns The current active detection session
+   * @throws NoActiveSessionError if no session is active
    */
   private ensureSession(): RepoDetectionSession {
     if (!this.session) {
@@ -651,7 +666,8 @@ let instance: RepoDetector | null = null;
 
 /**
  * Get the singleton Repository Detector instance
- * @param config
+ * @param config - Optional configuration for the repository detector
+ * @returns The singleton RepoDetector instance
  */
 export function getRepoDetector(config?: RepoDetectorConfig): RepoDetector {
   if (instance === null) {


### PR DESCRIPTION
Closes #479

## Summary
- Add missing `@param` descriptions and `@returns` declarations across 6 modules
- Resolve ~332 ESLint JSDoc warnings to achieve 0 warnings in target modules
- Follow existing JSDoc description patterns established in PRs #483-#487

## Changes by Module

| Module | Files | Warnings Fixed |
|--------|-------|----------------|
| `src/collector/` | 2 | ~52 |
| `src/issue-generator/` | 5 | ~110 |
| `src/issue-reader/` | 1 | ~37 |
| `src/project-initializer/` | 4 | ~54 |
| `src/repo-detector/` | 1 | ~33 |
| `src/github-repo-setup/` | 1 | ~40 |
| **Total** | **14** | **~326** |

## What Changed
- Added meaningful `@param` descriptions explaining each parameter's role
- Added `@returns` declarations describing return values
- No code logic changes - only JSDoc comment modifications

## Test Plan
- [x] `npx eslint src/collector --ext .ts` produces 0 warnings
- [x] `npx eslint src/issue-generator --ext .ts` produces 0 warnings
- [x] `npx eslint src/issue-reader --ext .ts` produces 0 warnings
- [x] `npx eslint src/project-initializer --ext .ts` produces 0 warnings
- [x] `npx eslint src/repo-detector --ext .ts` produces 0 warnings
- [x] `npx eslint src/github-repo-setup --ext .ts` produces 0 warnings
- [x] CI pipeline passes