### PR TITLE
fix(sds-writer): fix SRSParser regex to match "System Features" heading (#513)

### DIFF
--- a/src/sds-writer/SRSParser.ts
+++ b/src/sds-writer/SRSParser.ts
@@ -236,7 +236,7 @@ export class SRSParser {
       const line = lines[i] ?? '';
 
       // Check for Features section
-      if (line.match(/^##\s+\d*\.?\s*(Software\s+)?Features/i)) {
+      if (line.match(/^##\s+\d*\.?\s*(Software\s+|System\s+)?Features/i)) {
         inFeaturesSection = true;
         continue;
       }

--- a/tests/sds-writer/SRSParser.test.ts
+++ b/tests/sds-writer/SRSParser.test.ts
@@ -305,6 +305,45 @@ A simple feature.
       expect(result.features[0]?.useCaseIds).toHaveLength(0);
     });
 
+    it('should parse features section with "System Features" heading', () => {
+      const parser = new SRSParser();
+      const result = parser.parse(`
+## 2. System Features
+
+### SF-001: Feature One
+
+| **Priority** | P0 |
+| **Source** | FR-001 |
+
+**Description:**
+
+A feature under System Features heading.
+
+**Acceptance Criteria:**
+
+- Criterion one
+- Criterion two
+
+### SF-002: Feature Two
+
+| **Priority** | P1 |
+| **Source** | FR-002 |
+
+**Description:**
+
+Another feature.
+      `);
+
+      expect(result.features).toHaveLength(2);
+      expect(result.features[0]?.id).toBe('SF-001');
+      expect(result.features[0]?.name).toBe('Feature One');
+      expect(result.features[0]?.priority).toBe('P0');
+      expect(result.features[0]?.sourceRequirements).toContain('FR-001');
+      expect(result.features[0]?.acceptanceCriteria).toHaveLength(2);
+      expect(result.features[1]?.id).toBe('SF-002');
+      expect(result.features[1]?.name).toBe('Feature Two');
+    });
+
     it('should handle priority extraction from complex strings', () => {
       const parser = new SRSParser();
       const result = parser.parse(`


### PR DESCRIPTION
## Summary
- Fixed the `parseFeatures` regex in `SRSParser.ts` to match both "Software Features" and "System Features" section headings
- Added test case verifying features are correctly parsed under a "System Features" heading
- The original regex `(Software\s+)?Features` only matched "Software Features" or plain "Features", missing the "System Features" variant used in some SRS documents

## Changes
- `src/sds-writer/SRSParser.ts` (line 239): Updated regex from `(Software\s+)?` to `(Software\s+|System\s+)?`
- `tests/sds-writer/SRSParser.test.ts`: Added edge case test for "System Features" heading

## Test plan
- [x] New test `should parse features section with "System Features" heading` passes
- [x] All 18 existing SRSParser tests continue to pass
- [x] Lint passes on changed source file

Closes #513
Part of #511