### PR TITLE
refactor(security): convert secrets module export to lazy-load (#518)

### DIFF
--- a/src/security/index.ts
+++ b/src/security/index.ts
@@ -130,5 +130,32 @@ export type {
   MkdirOptions,
 } from './SecureFileOps.js';
 
-// Secret Providers - Pluggable secret management with multiple backends
-export * from './secrets/index.js';
+// Secret Providers - Type-only re-exports (safe for sandboxed environments)
+export type { ISecretProvider } from './secrets/ISecretProvider.js';
+export type {
+  Secret,
+  CachedSecret,
+  ProviderState,
+  ProviderHealth,
+  BaseSecretProviderConfig,
+  LocalProviderConfig,
+  AWSSecretsManagerConfig,
+  VaultProviderConfig,
+  AzureKeyVaultConfig,
+  SecretProviderConfig,
+  SecretManagerConfig,
+  CircuitBreakerState,
+  CircuitBreakerConfig,
+  CircuitBreakerStatus,
+} from './secrets/types.js';
+
+/**
+ * Lazy-load the secrets module. Only call when secret management is needed.
+ *
+ * This avoids eagerly importing the secrets submodule at startup, which
+ * can trigger EPERM errors in sandboxed environments where the `secrets`
+ * path pattern is blocked.
+ *
+ * @returns A promise resolving to the full secrets module exports
+ */
+export const getSecretsModule = () => import('./secrets/index.js');


### PR DESCRIPTION
Closes #518
Part of #511

## Summary
- Replaced static `export * from './secrets/index.js'` with a lazy-load accessor `getSecretsModule()`
- Type exports (interfaces, type aliases) remain statically available via `export type` re-exports
- Prevents EPERM errors in sandboxed environments where the `**/secrets` path pattern is blocked at CLI startup

## Changes
- `src/security/index.ts`: Removed eager `export *` of secrets module, added type-only re-exports for all interfaces/types, added `getSecretsModule()` dynamic import accessor

## Test plan
- [x] `npm run build` passes (no new errors; pre-existing unrelated errors in ConfigManager.ts/schemas.ts unchanged)
- [x] All 350 security tests pass
- [x] All 49 secrets-specific tests pass
- [x] No consumers in `src/` import secrets value exports through the security barrel (verified via grep)