### PR TITLE
fix(config): align Zod schemas with actual YAML config structure (#515, #516)

### DIFF
--- a/src/config/ConfigManager.ts
+++ b/src/config/ConfigManager.ts
@@ -325,17 +325,20 @@ export class ConfigManager {
   getPipelineStages(): readonly PipelineStage[] {
     const stages = this.workflowConfig.pipeline?.stages ?? [];
 
-    return stages.map((stage) => ({
-      name: stage.name,
-      agent: stage.agent,
-      description: stage.description,
-      inputs: stage.inputs,
-      outputs: stage.outputs,
-      next: stage.next ?? null,
-      approvalRequired: stage.approval_required ?? false,
-      parallel: stage.parallel ?? false,
-      maxParallel: stage.max_parallel,
-    }));
+    return stages.map((raw) => {
+      const stage = raw as Record<string, unknown>;
+      return {
+        name: stage.name as string,
+        agent: (stage.agent as string | undefined) ?? '',
+        description: stage.description as string | undefined,
+        inputs: stage.inputs as readonly string[] | undefined,
+        outputs: stage.outputs as readonly string[] | undefined,
+        next: (stage.next as string | null) ?? null,
+        approvalRequired: (stage.approval_required as boolean | undefined) ?? false,
+        parallel: (stage.parallel as boolean | undefined) ?? false,
+        maxParallel: stage.max_parallel as number | undefined,
+      };
+    });
   }
 
   /**

--- a/tests/config/validation.test.ts
+++ b/tests/config/validation.test.ts
@@ -145,14 +145,14 @@ describe('Config Validation', () => {
       expect(result.errors?.some((e) => e.path.includes('pipeline'))).toBe(true);
     });
 
-    it('should reject empty stages array', () => {
+    it('should accept empty stages array (stages can be in modes instead)', () => {
       const config = {
         version: '1.0.0',
         pipeline: { stages: [] },
       };
 
       const result = validateWorkflowConfig(config);
-      expect(result.success).toBe(false);
+      expect(result.success).toBe(true);
     });
 
     it('should reject invalid model type', () => {


### PR DESCRIPTION
## Summary
- Align workflow Zod schema with actual `workflow.yaml` pipeline modes structure (#515)
- Align agent definition Zod schema with actual `agents.yaml` categories and values (#516)
- Resolves 17 schema-config mismatches that caused `ad-sdlc validate` to fail on its own config files

## Key Changes

### Workflow Schema (#515)
- `ApprovalGatesSchema`: fixed keys → `z.record()` for dynamic stage names
- `PipelineSchema`: flat `stages[]` → `modes.{greenfield|enhancement|import}.stages[]`
- `PipelineStageSchema`: add `substages`, `on_ci_failure`, `conditional`; make `agent` optional
- Add `approval_mode` to `GlobalSettingsSchema`
- Add `TokenBudgetsSchema` for pipeline-level budget config

### Agent Schema (#516)
- `category` enum: 3 → 9 values (orchestration, infrastructure, enhancement_pipeline, etc.)
- `order`: `int.min(1)` → `number()` (supports float/negative values like -2, 3.5)
- Add `token_budget` and `model_preference` per agent
- `execution_mode`: add `on_demand` and `mixed` modes
- Add `.passthrough()` on schemas for extensibility

## Test Plan
- [x] `validateWorkflowConfig()` passes on default `workflow.yaml`
- [x] `validateAgentsConfig()` passes on default `agents.yaml`
- [x] Build succeeds without type errors

Refs: #515, #516
Part of: #511