### PR TITLE
fix(config): align workflow and agent Zod schemas with actual YAML config (#515, #516)

### DIFF
--- a/src/config/ConfigManager.ts
+++ b/src/config/ConfigManager.ts
@@ -325,17 +325,20 @@ export class ConfigManager {
   getPipelineStages(): readonly PipelineStage[] {
     const stages = this.workflowConfig.pipeline?.stages ?? [];
 
-    return stages.map((stage) => ({
-      name: stage.name,
-      agent: stage.agent,
-      description: stage.description,
-      inputs: stage.inputs,
-      outputs: stage.outputs,
-      next: stage.next ?? null,
-      approvalRequired: stage.approval_required ?? false,
-      parallel: stage.parallel ?? false,
-      maxParallel: stage.max_parallel,
-    }));
+    return stages.map((raw) => {
+      const stage = raw as Record<string, unknown>;
+      return {
+        name: stage.name as string,
+        agent: (stage.agent as string | undefined) ?? '',
+        description: stage.description as string | undefined,
+        inputs: stage.inputs as readonly string[] | undefined,
+        outputs: stage.outputs as readonly string[] | undefined,
+        next: (stage.next as string | null) ?? null,
+        approvalRequired: (stage.approval_required as boolean | undefined) ?? false,
+        parallel: (stage.parallel as boolean | undefined) ?? false,
+        maxParallel: stage.max_parallel as number | undefined,
+      };
+    });
   }
 
   /**

--- a/tests/config/validation.test.ts
+++ b/tests/config/validation.test.ts
@@ -145,14 +145,14 @@ describe('Config Validation', () => {
       expect(result.errors?.some((e) => e.path.includes('pipeline'))).toBe(true);
     });
 
-    it('should reject empty stages array', () => {
+    it('should accept empty stages array (stages can be in modes instead)', () => {
       const config = {
         version: '1.0.0',
         pipeline: { stages: [] },
       };
 
       const result = validateWorkflowConfig(config);
-      expect(result.success).toBe(false);
+      expect(result.success).toBe(true);
     });
 
     it('should reject invalid model type', () => {


### PR DESCRIPTION
Closes #515
Closes #516
Part of #511

## Summary
- Aligned Zod schemas in `src/config/schemas.ts` with actual `workflow.yaml` and `agents.yaml` structure
- 12 schema mismatches fixed across workflow and agent schemas:
  1. `ApprovalGatesSchema`: fixed keys replaced with `z.record()` for dynamic stage names
  2. `GlobalSettingsSchema`: added `approval_mode` enum field
  3. `StageIOSchema`: supports union of string and object types
  4. `PipelineStageSchema`: recursive with `z.lazy()`, added `substages`, `on_ci_failure`, `conditional`; made `agent` optional
  5. `PipelineSchema`: supports `modes.{greenfield|enhancement|import}` structure
  6. `WorkflowAgentConfigSchema`: added `.passthrough()` for extension fields
  7. `TokenBudgetsSchema`: new schema for pipeline-level budget config
  8. `WorkflowConfigSchema`: added `token_budgets` field
  9. `AgentDefinitionSchema`: expanded `category` enum (3 to 9 values), relaxed `order` type, added `token_budget` and `model_preference`, added `.passthrough()`
  10. `AgentCategorySchema`: expanded `execution_mode` with `on_demand` and `mixed`
  11. `AgentDependencySchema`: added `blocks`, `alternative_to`, `alternative_inputs`, `orchestrates`
  12. `DataFlowSchema`: added optional `mode` field
- Updated `ConfigManager.ts` to handle `z.lazy()` type inference for pipeline stages
- Updated validation test to accept empty stages array (stages can now live in `modes`)

## Test plan
- [x] `npm run build` passes (only pre-existing security module errors)
- [x] `npm test -- tests/config/` passes (99/99 tests)
- [ ] `ad-sdlc validate` passes on default configs