### PR TITLE
feat(agents): create AgentTypeMapping and AgentRegistry bootstrap

### DIFF
--- a/src/agents/AgentTypeMapping.ts
+++ b/src/agents/AgentTypeMapping.ts
@@ -1,0 +1,269 @@
+/**
+ * AgentTypeMapping - Maps pipeline agentType strings to registry metadata
+ *
+ * Bridges the gap between pipeline stage definitions (which use short
+ * agentType strings like 'collector') and the AgentRegistry (which uses
+ * agentId strings like 'collector-agent').
+ *
+ * Each entry describes:
+ * - The registry key (agentId) for the agent
+ * - Human-readable name
+ * - Lifecycle strategy (singleton or transient)
+ * - Whether the class requires an IAgent wrapper (non-IAgent classes)
+ * - Module import path for lazy loading
+ *
+ * @packageDocumentation
+ */
+
+/**
+ * Metadata entry for a pipeline agent type
+ */
+export interface AgentTypeEntry {
+  /** Registry key used in AgentRegistry */
+  readonly agentId: string;
+  /** Human-readable agent name */
+  readonly name: string;
+  /** Instance lifecycle: singleton (shared) or transient (per-request) */
+  readonly lifecycle: 'singleton' | 'transient';
+  /** True if the class does not implement IAgent and needs a wrapper */
+  readonly requiresWrapper: boolean;
+  /** Module path for dynamic import (relative to this file) */
+  readonly importPath: string;
+}
+
+/**
+ * Mapping from pipeline agentType strings to agent metadata.
+ *
+ * Covers all three pipeline modes:
+ * - Greenfield: project-initializer through pr-reviewer
+ * - Enhancement: document-reader through regression-tester
+ * - Import: issue-reader through pr-reviewer
+ *
+ * Agents shared across pipelines (controller, worker, pr-reviewer,
+ * issue-generator) appear once in the map.
+ */
+export const AGENT_TYPE_MAP: Readonly<Record<string, AgentTypeEntry>> = {
+  // ── Greenfield pipeline agents ──────────────────────────────────────
+
+  'project-initializer': {
+    agentId: 'project-initializer',
+    name: 'Project Initializer',
+    lifecycle: 'singleton',
+    requiresWrapper: true,
+    importPath: '../project-initializer/index.js',
+  },
+
+  'mode-detector': {
+    agentId: 'mode-detector',
+    name: 'Mode Detector',
+    lifecycle: 'singleton',
+    requiresWrapper: true,
+    importPath: '../mode-detector/index.js',
+  },
+
+  'collector': {
+    agentId: 'collector-agent',
+    name: 'Collector Agent',
+    lifecycle: 'singleton',
+    requiresWrapper: false,
+    importPath: '../collector/index.js',
+  },
+
+  'prd-writer': {
+    agentId: 'prd-writer-agent',
+    name: 'PRD Writer Agent',
+    lifecycle: 'singleton',
+    requiresWrapper: false,
+    importPath: '../prd-writer/index.js',
+  },
+
+  'srs-writer': {
+    agentId: 'srs-writer-agent',
+    name: 'SRS Writer Agent',
+    lifecycle: 'singleton',
+    requiresWrapper: false,
+    importPath: '../srs-writer/index.js',
+  },
+
+  'repo-detector': {
+    agentId: 'repo-detector-agent',
+    name: 'Repo Detector',
+    lifecycle: 'singleton',
+    requiresWrapper: false,
+    importPath: '../repo-detector/index.js',
+  },
+
+  'github-repo-setup': {
+    agentId: 'github-repo-setup-agent',
+    name: 'GitHub Repo Setup Agent',
+    lifecycle: 'singleton',
+    requiresWrapper: false,
+    importPath: '../github-repo-setup/index.js',
+  },
+
+  'sds-writer': {
+    agentId: 'sds-writer-agent',
+    name: 'SDS Writer Agent',
+    lifecycle: 'singleton',
+    requiresWrapper: false,
+    importPath: '../sds-writer/index.js',
+  },
+
+  'issue-generator': {
+    agentId: 'issue-generator',
+    name: 'Issue Generator',
+    lifecycle: 'singleton',
+    requiresWrapper: true,
+    importPath: '../issue-generator/index.js',
+  },
+
+  'controller': {
+    agentId: 'controller',
+    name: 'Controller',
+    lifecycle: 'singleton',
+    requiresWrapper: true,
+    importPath: '../controller/index.js',
+  },
+
+  'worker': {
+    agentId: 'worker-agent',
+    name: 'Worker Agent',
+    lifecycle: 'transient',
+    requiresWrapper: false,
+    importPath: '../worker/index.js',
+  },
+
+  'pr-reviewer': {
+    agentId: 'pr-reviewer-agent',
+    name: 'PR Reviewer Agent',
+    lifecycle: 'singleton',
+    requiresWrapper: false,
+    importPath: '../pr-reviewer/index.js',
+  },
+
+  // ── Enhancement pipeline agents ─────────────────────────────────────
+
+  'document-reader': {
+    agentId: 'document-reader-agent',
+    name: 'Document Reader Agent',
+    lifecycle: 'singleton',
+    requiresWrapper: false,
+    importPath: '../document-reader/index.js',
+  },
+
+  'codebase-analyzer': {
+    agentId: 'codebase-analyzer-agent',
+    name: 'Codebase Analyzer Agent',
+    lifecycle: 'singleton',
+    requiresWrapper: false,
+    importPath: '../codebase-analyzer/index.js',
+  },
+
+  'code-reader': {
+    agentId: 'code-reader',
+    name: 'Code Reader',
+    lifecycle: 'singleton',
+    requiresWrapper: true,
+    importPath: '../code-reader/index.js',
+  },
+
+  'doc-code-comparator': {
+    agentId: 'doc-code-comparator-agent',
+    name: 'Doc-Code Comparator Agent',
+    lifecycle: 'singleton',
+    requiresWrapper: false,
+    importPath: '../doc-code-comparator/index.js',
+  },
+
+  'impact-analyzer': {
+    agentId: 'impact-analyzer-agent',
+    name: 'Impact Analyzer Agent',
+    lifecycle: 'singleton',
+    requiresWrapper: false,
+    importPath: '../impact-analyzer/index.js',
+  },
+
+  'prd-updater': {
+    agentId: 'prd-updater-agent',
+    name: 'PRD Updater Agent',
+    lifecycle: 'singleton',
+    requiresWrapper: false,
+    importPath: '../prd-updater/index.js',
+  },
+
+  'srs-updater': {
+    agentId: 'srs-updater-agent',
+    name: 'SRS Updater Agent',
+    lifecycle: 'singleton',
+    requiresWrapper: false,
+    importPath: '../srs-updater/index.js',
+  },
+
+  'sds-updater': {
+    agentId: 'sds-updater-agent',
+    name: 'SDS Updater Agent',
+    lifecycle: 'singleton',
+    requiresWrapper: false,
+    importPath: '../sds-updater/index.js',
+  },
+
+  'regression-tester': {
+    agentId: 'regression-tester-agent',
+    name: 'Regression Tester Agent',
+    lifecycle: 'singleton',
+    requiresWrapper: false,
+    importPath: '../regression-tester/index.js',
+  },
+
+  // ── Import pipeline agents ──────────────────────────────────────────
+
+  'issue-reader': {
+    agentId: 'issue-reader-agent',
+    name: 'Issue Reader Agent',
+    lifecycle: 'singleton',
+    requiresWrapper: false,
+    importPath: '../issue-reader/index.js',
+  },
+
+  // ── Cross-pipeline agents ───────────────────────────────────────────
+
+  'ci-fixer': {
+    agentId: 'ci-fix-agent',
+    name: 'CI Fix Agent',
+    lifecycle: 'singleton',
+    requiresWrapper: false,
+    importPath: '../ci-fixer/index.js',
+  },
+
+  'analysis-orchestrator': {
+    agentId: 'analysis-orchestrator-agent',
+    name: 'Analysis Orchestrator Agent',
+    lifecycle: 'singleton',
+    requiresWrapper: false,
+    importPath: '../analysis-orchestrator/index.js',
+  },
+} as const;
+
+/**
+ * Get all pipeline agentType keys from the mapping
+ */
+export function getAgentTypes(): string[] {
+  return Object.keys(AGENT_TYPE_MAP);
+}
+
+/**
+ * Look up an AgentTypeEntry by pipeline agentType string
+ *
+ * @param agentType - Pipeline agentType value (e.g., 'collector')
+ * @returns The entry, or undefined if not mapped
+ */
+export function getAgentTypeEntry(agentType: string): AgentTypeEntry | undefined {
+  return AGENT_TYPE_MAP[agentType];
+}
+
+/**
+ * Get all unique agentId values from the mapping
+ */
+export function getRegisteredAgentIds(): string[] {
+  return [...new Set(Object.values(AGENT_TYPE_MAP).map((entry) => entry.agentId))];
+}

--- a/src/agents/bootstrapAgents.ts
+++ b/src/agents/bootstrapAgents.ts
@@ -1,0 +1,85 @@
+/**
+ * bootstrapAgents - Registers all pipeline agents into AgentRegistry
+ *
+ * Iterates over AGENT_TYPE_MAP and registers each entry in the singleton
+ * AgentRegistry. Registration is idempotent: already-registered agents
+ * are silently skipped.
+ *
+ * The factory functions throw by default because actual agent instantiation
+ * is deferred to AgentDispatcher (see #521). This module only populates
+ * the registry so that metadata lookups and dependency validation work.
+ *
+ * @packageDocumentation
+ */
+
+import { AgentRegistry } from './AgentRegistry.js';
+import { AGENT_TYPE_MAP } from './AgentTypeMapping.js';
+import type { AgentTypeEntry } from './AgentTypeMapping.js';
+
+/**
+ * Number of agents registered during the most recent bootstrap call.
+ * Useful for diagnostics and testing.
+ */
+export interface BootstrapResult {
+  /** Total entries processed from AGENT_TYPE_MAP */
+  readonly totalEntries: number;
+  /** Number of agents newly registered in this call */
+  readonly registered: number;
+  /** Number of agents skipped (already registered) */
+  readonly skipped: number;
+}
+
+/**
+ * Register all pipeline agents into the AgentRegistry.
+ *
+ * Safe to call multiple times; duplicate registrations are skipped.
+ * Factory functions are placeholder stubs that throw -- real factories
+ * will be wired in by AgentDispatcher (#521).
+ *
+ * @returns Summary of how many agents were registered vs skipped
+ *
+ * @example
+ * ```typescript
+ * import { bootstrapAgents } from './bootstrapAgents.js';
+ *
+ * const result = await bootstrapAgents();
+ * console.log(`Registered ${result.registered} agents`);
+ * ```
+ */
+export async function bootstrapAgents(): Promise<BootstrapResult> {
+  const registry = AgentRegistry.getInstance();
+
+  let registered = 0;
+  let skipped = 0;
+
+  const entries = Object.entries(AGENT_TYPE_MAP) as ReadonlyArray<[string, AgentTypeEntry]>;
+
+  for (const [agentType, entry] of entries) {
+    if (registry.has(entry.agentId)) {
+      skipped++;
+      continue;
+    }
+
+    registry.register({
+      agentId: entry.agentId,
+      name: entry.name,
+      description: `Pipeline agent for '${agentType}' stage`,
+      lifecycle: entry.lifecycle,
+      dependencies: [],
+      factory: () => {
+        throw new Error(
+          `Agent '${entry.agentId}' must be created through AgentDispatcher. ` +
+            `Direct factory invocation is not supported.`
+        );
+      },
+    });
+
+    registered++;
+  }
+
+  return {
+    totalEntries: entries.length,
+    registered,
+    skipped,
+  };
+}

--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -45,6 +45,19 @@ export {
   CircularDependencyError as AgentCircularDependencyError,
 } from './AgentRegistry.js';
 
+export {
+  AGENT_TYPE_MAP,
+  getAgentTypes,
+  getAgentTypeEntry,
+  getRegisteredAgentIds,
+} from './AgentTypeMapping.js';
+
+export type { AgentTypeEntry } from './AgentTypeMapping.js';
+
+export { bootstrapAgents } from './bootstrapAgents.js';
+
+export type { BootstrapResult } from './bootstrapAgents.js';
+
 export { isAgent } from './types.js';
 
 export type {

--- a/tests/agents/AgentTypeMapping.test.ts
+++ b/tests/agents/AgentTypeMapping.test.ts
@@ -1,0 +1,251 @@
+import { describe, it, expect } from 'vitest';
+import {
+  AGENT_TYPE_MAP,
+  getAgentTypes,
+  getAgentTypeEntry,
+  getRegisteredAgentIds,
+} from '../../src/agents/AgentTypeMapping.js';
+import type { AgentTypeEntry } from '../../src/agents/AgentTypeMapping.js';
+import {
+  GREENFIELD_STAGES,
+  ENHANCEMENT_STAGES,
+  IMPORT_STAGES,
+} from '../../src/ad-sdlc-orchestrator/types.js';
+
+describe('AgentTypeMapping', () => {
+  describe('AGENT_TYPE_MAP structure', () => {
+    it('should be a non-empty object', () => {
+      const keys = Object.keys(AGENT_TYPE_MAP);
+      expect(keys.length).toBeGreaterThan(0);
+    });
+
+    it('should have valid AgentTypeEntry shape for every entry', () => {
+      for (const [agentType, entry] of Object.entries(AGENT_TYPE_MAP)) {
+        expect(entry.agentId).toBeTypeOf('string');
+        expect(entry.agentId.length).toBeGreaterThan(0);
+
+        expect(entry.name).toBeTypeOf('string');
+        expect(entry.name.length).toBeGreaterThan(0);
+
+        expect(['singleton', 'transient']).toContain(entry.lifecycle);
+
+        expect(entry.requiresWrapper).toBeTypeOf('boolean');
+
+        expect(entry.importPath).toBeTypeOf('string');
+        expect(entry.importPath).toMatch(/\.js$/);
+
+        // Ensure agentType key itself is a non-empty string
+        expect(agentType.length).toBeGreaterThan(0);
+      }
+    });
+
+    it('should have unique agentId values', () => {
+      const agentIds = Object.values(AGENT_TYPE_MAP).map((e) => e.agentId);
+      const unique = new Set(agentIds);
+      expect(unique.size).toBe(agentIds.length);
+    });
+  });
+
+  describe('pipeline stage coverage', () => {
+    it('should cover all Greenfield pipeline agentType values', () => {
+      for (const stage of GREENFIELD_STAGES) {
+        expect(
+          AGENT_TYPE_MAP[stage.agentType],
+          `Missing mapping for Greenfield agentType '${stage.agentType}'`
+        ).toBeDefined();
+      }
+    });
+
+    it('should cover all Enhancement pipeline agentType values', () => {
+      for (const stage of ENHANCEMENT_STAGES) {
+        expect(
+          AGENT_TYPE_MAP[stage.agentType],
+          `Missing mapping for Enhancement agentType '${stage.agentType}'`
+        ).toBeDefined();
+      }
+    });
+
+    it('should cover all Import pipeline agentType values', () => {
+      for (const stage of IMPORT_STAGES) {
+        expect(
+          AGENT_TYPE_MAP[stage.agentType],
+          `Missing mapping for Import agentType '${stage.agentType}'`
+        ).toBeDefined();
+      }
+    });
+  });
+
+  describe('specific agent entries', () => {
+    it('should map collector to collector-agent (IAgent)', () => {
+      const entry = AGENT_TYPE_MAP['collector'];
+      expect(entry).toBeDefined();
+      expect(entry!.agentId).toBe('collector-agent');
+      expect(entry!.lifecycle).toBe('singleton');
+      expect(entry!.requiresWrapper).toBe(false);
+    });
+
+    it('should map worker to worker-agent (transient lifecycle)', () => {
+      const entry = AGENT_TYPE_MAP['worker'];
+      expect(entry).toBeDefined();
+      expect(entry!.agentId).toBe('worker-agent');
+      expect(entry!.lifecycle).toBe('transient');
+      expect(entry!.requiresWrapper).toBe(false);
+    });
+
+    it('should mark project-initializer as requiring wrapper', () => {
+      const entry = AGENT_TYPE_MAP['project-initializer'];
+      expect(entry).toBeDefined();
+      expect(entry!.requiresWrapper).toBe(true);
+    });
+
+    it('should mark mode-detector as requiring wrapper', () => {
+      const entry = AGENT_TYPE_MAP['mode-detector'];
+      expect(entry).toBeDefined();
+      expect(entry!.requiresWrapper).toBe(true);
+    });
+
+    it('should mark issue-generator as requiring wrapper', () => {
+      const entry = AGENT_TYPE_MAP['issue-generator'];
+      expect(entry).toBeDefined();
+      expect(entry!.requiresWrapper).toBe(true);
+    });
+
+    it('should mark controller as requiring wrapper', () => {
+      const entry = AGENT_TYPE_MAP['controller'];
+      expect(entry).toBeDefined();
+      expect(entry!.requiresWrapper).toBe(true);
+    });
+
+    it('should mark code-reader as requiring wrapper', () => {
+      const entry = AGENT_TYPE_MAP['code-reader'];
+      expect(entry).toBeDefined();
+      expect(entry!.requiresWrapper).toBe(true);
+    });
+
+    it('should map IAgent agents without wrapper requirement', () => {
+      const iAgentTypes = [
+        'collector',
+        'prd-writer',
+        'srs-writer',
+        'repo-detector',
+        'github-repo-setup',
+        'sds-writer',
+        'worker',
+        'pr-reviewer',
+        'document-reader',
+        'codebase-analyzer',
+        'doc-code-comparator',
+        'impact-analyzer',
+        'prd-updater',
+        'srs-updater',
+        'sds-updater',
+        'regression-tester',
+        'issue-reader',
+        'ci-fixer',
+        'analysis-orchestrator',
+      ];
+
+      for (const agentType of iAgentTypes) {
+        const entry = AGENT_TYPE_MAP[agentType];
+        expect(entry, `Missing entry for '${agentType}'`).toBeDefined();
+        expect(
+          entry!.requiresWrapper,
+          `'${agentType}' should not require wrapper`
+        ).toBe(false);
+      }
+    });
+
+    it('should map non-IAgent agents with wrapper requirement', () => {
+      const nonIAgentTypes = [
+        'project-initializer',
+        'mode-detector',
+        'issue-generator',
+        'controller',
+        'code-reader',
+      ];
+
+      for (const agentType of nonIAgentTypes) {
+        const entry = AGENT_TYPE_MAP[agentType];
+        expect(entry, `Missing entry for '${agentType}'`).toBeDefined();
+        expect(
+          entry!.requiresWrapper,
+          `'${agentType}' should require wrapper`
+        ).toBe(true);
+      }
+    });
+  });
+
+  describe('getAgentTypes', () => {
+    it('should return all keys from AGENT_TYPE_MAP', () => {
+      const types = getAgentTypes();
+      const mapKeys = Object.keys(AGENT_TYPE_MAP);
+
+      expect(types).toHaveLength(mapKeys.length);
+      for (const key of mapKeys) {
+        expect(types).toContain(key);
+      }
+    });
+
+    it('should return a new array on each call', () => {
+      const types1 = getAgentTypes();
+      const types2 = getAgentTypes();
+      expect(types1).not.toBe(types2);
+      expect(types1).toEqual(types2);
+    });
+  });
+
+  describe('getAgentTypeEntry', () => {
+    it('should return entry for known agentType', () => {
+      const entry = getAgentTypeEntry('collector');
+      expect(entry).toBeDefined();
+      expect(entry!.agentId).toBe('collector-agent');
+    });
+
+    it('should return undefined for unknown agentType', () => {
+      const entry = getAgentTypeEntry('nonexistent-agent');
+      expect(entry).toBeUndefined();
+    });
+
+    it('should return undefined for empty string', () => {
+      const entry = getAgentTypeEntry('');
+      expect(entry).toBeUndefined();
+    });
+  });
+
+  describe('getRegisteredAgentIds', () => {
+    it('should return unique agentId values', () => {
+      const ids = getRegisteredAgentIds();
+      const unique = new Set(ids);
+      expect(unique.size).toBe(ids.length);
+    });
+
+    it('should include known agent IDs', () => {
+      const ids = getRegisteredAgentIds();
+      expect(ids).toContain('collector-agent');
+      expect(ids).toContain('worker-agent');
+      expect(ids).toContain('pr-reviewer-agent');
+      expect(ids).toContain('project-initializer');
+      expect(ids).toContain('controller');
+    });
+
+    it('should return a new array on each call', () => {
+      const ids1 = getRegisteredAgentIds();
+      const ids2 = getRegisteredAgentIds();
+      expect(ids1).not.toBe(ids2);
+      expect(ids1).toEqual(ids2);
+    });
+  });
+
+  describe('immutability', () => {
+    it('should not allow modification of AGENT_TYPE_MAP entries', () => {
+      // AGENT_TYPE_MAP is declared as Readonly<Record<...>>, so TypeScript
+      // prevents modification at compile time. At runtime, the 'as const'
+      // assertion makes it a deeply frozen-like structure.
+      const entry = AGENT_TYPE_MAP['collector'];
+      expect(entry).toBeDefined();
+
+      // Verify we can still read properties
+      expect(entry!.agentId).toBe('collector-agent');
+    });
+  });
+});

--- a/tests/agents/bootstrapAgents.test.ts
+++ b/tests/agents/bootstrapAgents.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { AgentRegistry } from '../../src/agents/AgentRegistry.js';
+import { bootstrapAgents } from '../../src/agents/bootstrapAgents.js';
+import { AGENT_TYPE_MAP } from '../../src/agents/AgentTypeMapping.js';
+import type { AgentMetadata, IAgent } from '../../src/agents/types.js';
+
+describe('bootstrapAgents', () => {
+  beforeEach(() => {
+    AgentRegistry.reset();
+  });
+
+  afterEach(() => {
+    AgentRegistry.reset();
+  });
+
+  it('should register all agents from AGENT_TYPE_MAP', async () => {
+    const result = await bootstrapAgents();
+    const registry = AgentRegistry.getInstance();
+
+    const expectedCount = Object.keys(AGENT_TYPE_MAP).length;
+    expect(result.totalEntries).toBe(expectedCount);
+    expect(result.registered).toBe(expectedCount);
+    expect(result.skipped).toBe(0);
+
+    for (const [, entry] of Object.entries(AGENT_TYPE_MAP)) {
+      expect(registry.has(entry.agentId)).toBe(true);
+    }
+  });
+
+  it('should be idempotent on second call', async () => {
+    const first = await bootstrapAgents();
+    const second = await bootstrapAgents();
+
+    expect(first.registered).toBe(first.totalEntries);
+    expect(second.registered).toBe(0);
+    expect(second.skipped).toBe(second.totalEntries);
+  });
+
+  it('should skip agents already registered manually', async () => {
+    const registry = AgentRegistry.getInstance();
+
+    // Pre-register one agent manually
+    const collectorEntry = AGENT_TYPE_MAP['collector'];
+    registry.register({
+      agentId: collectorEntry!.agentId,
+      name: 'Pre-registered Collector',
+      description: 'Manually registered',
+      lifecycle: 'singleton',
+      dependencies: [],
+      factory: () => ({ agentId: 'collector-agent', name: 'Mock' } as IAgent),
+    });
+
+    const result = await bootstrapAgents();
+
+    expect(result.skipped).toBe(1);
+    expect(result.registered).toBe(result.totalEntries - 1);
+
+    // Verify the manually-registered agent was not overwritten
+    const metadata = registry.get(collectorEntry!.agentId);
+    expect(metadata.name).toBe('Pre-registered Collector');
+  });
+
+  it('should register metadata with correct agentId and name', async () => {
+    await bootstrapAgents();
+    const registry = AgentRegistry.getInstance();
+
+    for (const [, entry] of Object.entries(AGENT_TYPE_MAP)) {
+      const metadata = registry.get(entry.agentId);
+      expect(metadata.agentId).toBe(entry.agentId);
+      expect(metadata.name).toBe(entry.name);
+    }
+  });
+
+  it('should register metadata with correct lifecycle', async () => {
+    await bootstrapAgents();
+    const registry = AgentRegistry.getInstance();
+
+    for (const [, entry] of Object.entries(AGENT_TYPE_MAP)) {
+      const metadata = registry.get(entry.agentId);
+      expect(metadata.lifecycle).toBe(entry.lifecycle);
+    }
+  });
+
+  it('should register metadata with empty dependencies', async () => {
+    await bootstrapAgents();
+    const registry = AgentRegistry.getInstance();
+
+    for (const [, entry] of Object.entries(AGENT_TYPE_MAP)) {
+      const metadata = registry.get(entry.agentId);
+      expect(metadata.dependencies).toEqual([]);
+    }
+  });
+
+  it('should register factory that throws with clear error message', async () => {
+    await bootstrapAgents();
+    const registry = AgentRegistry.getInstance();
+
+    const metadata = registry.get('collector-agent');
+    expect(() => metadata.factory({})).toThrow('AgentDispatcher');
+    expect(() => metadata.factory({})).toThrow('collector-agent');
+  });
+
+  it('should register worker-agent as transient', async () => {
+    await bootstrapAgents();
+    const registry = AgentRegistry.getInstance();
+
+    const metadata = registry.get('worker-agent');
+    expect(metadata.lifecycle).toBe('transient');
+  });
+
+  it('should register most agents as singleton', async () => {
+    await bootstrapAgents();
+    const registry = AgentRegistry.getInstance();
+
+    const singletonEntries = Object.values(AGENT_TYPE_MAP).filter(
+      (e) => e.lifecycle === 'singleton'
+    );
+
+    for (const entry of singletonEntries) {
+      const metadata = registry.get(entry.agentId);
+      expect(metadata.lifecycle).toBe('singleton');
+    }
+  });
+
+  it('should include description with agentType reference', async () => {
+    await bootstrapAgents();
+    const registry = AgentRegistry.getInstance();
+
+    // Check a few known entries
+    const collectorMeta = registry.get('collector-agent');
+    expect(collectorMeta.description).toContain('collector');
+
+    const workerMeta = registry.get('worker-agent');
+    expect(workerMeta.description).toContain('worker');
+  });
+
+  it('should return consistent totals', async () => {
+    const result = await bootstrapAgents();
+
+    expect(result.totalEntries).toBe(result.registered + result.skipped);
+  });
+
+  it('should handle partial pre-registration correctly', async () => {
+    const registry = AgentRegistry.getInstance();
+
+    // Pre-register 3 agents
+    const preRegisterTypes = ['collector', 'worker', 'pr-reviewer'] as const;
+    for (const agentType of preRegisterTypes) {
+      const entry = AGENT_TYPE_MAP[agentType];
+      registry.register({
+        agentId: entry!.agentId,
+        name: `Pre-${entry!.name}`,
+        description: 'Pre-registered',
+        lifecycle: entry!.lifecycle,
+        dependencies: [],
+        factory: () => ({ agentId: entry!.agentId, name: 'Mock' } as IAgent),
+      });
+    }
+
+    const result = await bootstrapAgents();
+
+    expect(result.skipped).toBe(3);
+    expect(result.registered).toBe(result.totalEntries - 3);
+  });
+});


### PR DESCRIPTION
## Summary
- Create `AgentTypeMapping.ts` with entries for all 24 pipeline agent types across Greenfield, Enhancement, and Import pipelines, mapping pipeline `agentType` strings (e.g., `'collector'`) to registry metadata (e.g., `agentId: 'collector-agent'`)
- Create `bootstrapAgents.ts` that idempotently registers all mapped agents into `AgentRegistry` with placeholder factory stubs (real factories deferred to AgentDispatcher in #521)
- Export both modules from `src/agents/index.ts`

## Details

Each `AgentTypeEntry` includes:
- `agentId` — the registry key matching the agent's `AGENT_ID` constant
- `name` — human-readable agent name
- `lifecycle` — `singleton` or `transient` (only `worker` is transient)
- `requiresWrapper` — `true` for non-IAgent classes (`ProjectInitializer`, `ModeDetector`, `IssueGenerator`, `Controller`, `CodeReaderAgent`)
- `importPath` — module path for future dynamic imports

`bootstrapAgents()` returns a `BootstrapResult` with counts of registered vs skipped entries, making it safe to call multiple times.

## Test plan
- [x] 24 tests for `AgentTypeMapping` — structure validation, pipeline stage coverage (Greenfield, Enhancement, Import), specific agent property verification, helper function behavior
- [x] 12 tests for `bootstrapAgents` — full registration, idempotency, pre-registration skip, metadata correctness, factory error messaging, lifecycle correctness
- [x] All 105 agent tests pass (69 existing + 36 new)
- [x] No new type errors introduced (verified with `tsc --noEmit`)

Closes #520
Part of #511