### PR TITLE
fix(config): synchronize JSON Schema files with updated Zod schemas

### DIFF
--- a/schemas/agents.schema.json
+++ b/schemas/agents.schema.json
@@ -42,12 +42,21 @@
           },
           "category": {
             "type": "string",
-            "enum": ["document_pipeline", "issue_management", "execution"],
+            "enum": [
+              "orchestration",
+              "infrastructure",
+              "document_pipeline",
+              "project_setup",
+              "document_update",
+              "issue_management",
+              "execution",
+              "analysis_pipeline",
+              "enhancement_pipeline"
+            ],
             "description": "Agent category"
           },
           "order": {
-            "type": "integer",
-            "minimum": 1,
+            "type": "number",
             "description": "Execution order within category"
           },
           "capabilities": {
@@ -114,6 +123,30 @@
                 "description": "Average issues generated per project"
               }
             }
+          },
+          "token_budget": {
+            "type": "object",
+            "description": "Token budget for this agent",
+            "properties": {
+              "default_limit": {
+                "type": "integer",
+                "description": "Default token limit"
+              },
+              "cost_limit_usd": {
+                "type": "number",
+                "description": "Cost limit in USD"
+              },
+              "model_preference": {
+                "type": "string",
+                "enum": ["sonnet", "opus", "haiku"],
+                "description": "Preferred model for this agent"
+              }
+            }
+          },
+          "model_preference": {
+            "type": "string",
+            "enum": ["sonnet", "opus", "haiku"],
+            "description": "Preferred Claude model for this agent"
           }
         }
       }
@@ -141,7 +174,7 @@
           },
           "execution_mode": {
             "type": "string",
-            "enum": ["sequential", "parallel"],
+            "enum": ["sequential", "parallel", "on_demand", "mixed"],
             "default": "sequential",
             "description": "How agents in this category execute"
           }
@@ -157,11 +190,32 @@
           "description": "Agent dependency definitions",
           "additionalProperties": {
             "type": "object",
+            "required": ["requires"],
             "properties": {
               "requires": {
                 "type": "array",
                 "items": { "type": "string" },
                 "description": "Required agents that must complete first"
+              },
+              "blocks": {
+                "type": "array",
+                "items": { "type": "string" },
+                "description": "Agents blocked by this agent"
+              },
+              "alternative_to": {
+                "type": "array",
+                "items": { "type": "string" },
+                "description": "Agents this can substitute for"
+              },
+              "alternative_inputs": {
+                "type": "array",
+                "items": { "type": "string" },
+                "description": "Alternative input sources"
+              },
+              "orchestrates": {
+                "type": "array",
+                "items": { "type": "string" },
+                "description": "Agents orchestrated by this agent"
               }
             }
           }
@@ -189,6 +243,10 @@
                   { "type": "array", "items": { "type": "string" } }
                 ],
                 "description": "Data files passed between agents"
+              },
+              "mode": {
+                "type": "string",
+                "description": "Data flow mode"
               }
             }
           }

--- a/schemas/workflow.schema.json
+++ b/schemas/workflow.schema.json
@@ -5,6 +5,49 @@
   "description": "Schema for workflow.yaml configuration file",
   "type": "object",
   "required": ["version", "pipeline"],
+  "definitions": {
+    "pipeline_stage": {
+      "type": "object",
+      "required": ["name"],
+      "properties": {
+        "name": { "type": "string", "minLength": 1, "description": "Stage name" },
+        "agent": { "type": "string", "description": "Agent to execute this stage" },
+        "description": { "type": "string", "description": "Stage description" },
+        "inputs": {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              { "type": "string" },
+              { "type": "object" }
+            ]
+          },
+          "description": "Input files/patterns (strings or typed objects)"
+        },
+        "outputs": { "type": "array", "items": { "type": "string" }, "description": "Output files/patterns" },
+        "next": { "type": ["string", "null"], "description": "Next stage name" },
+        "approval_required": { "type": "boolean", "default": false, "description": "Whether approval is required" },
+        "parallel": { "type": "boolean", "default": false, "description": "Whether stage runs in parallel" },
+        "max_parallel": { "type": "integer", "minimum": 1, "maximum": 10, "description": "Max parallel workers" },
+        "conditional": { "type": "boolean", "description": "Whether this stage is conditionally executed" },
+        "on_ci_failure": {
+          "type": "object",
+          "description": "CI failure handling configuration",
+          "properties": {
+            "agent": { "type": "string", "description": "Agent to handle CI failure" },
+            "description": { "type": "string", "description": "Description of failure handler" },
+            "max_attempts": { "type": "integer", "minimum": 1, "description": "Max retry attempts on CI failure" },
+            "inputs": { "type": "array", "items": { "type": "string" }, "description": "Inputs for failure handler" },
+            "outputs": { "type": "array", "items": { "type": "string" }, "description": "Outputs from failure handler" }
+          }
+        },
+        "substages": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/pipeline_stage" },
+          "description": "Nested substages within this stage"
+        }
+      }
+    }
+  },
   "properties": {
     "version": {
       "type": "string",
@@ -40,17 +83,16 @@
           "default": "INFO",
           "description": "Logging level"
         },
+        "approval_mode": {
+          "type": "string",
+          "enum": ["auto", "manual", "critical", "custom"],
+          "default": "auto",
+          "description": "Approval mode for pipeline gates"
+        },
         "approval_gates": {
           "type": "object",
-          "description": "Human-in-the-loop approval gates",
-          "properties": {
-            "after_collection": { "type": "boolean", "default": true },
-            "after_prd": { "type": "boolean", "default": true },
-            "after_srs": { "type": "boolean", "default": true },
-            "after_sds": { "type": "boolean", "default": true },
-            "after_issues": { "type": "boolean", "default": true },
-            "before_merge": { "type": "boolean", "default": false }
-          }
+          "description": "Human-in-the-loop approval gates (dynamic keys)",
+          "additionalProperties": { "type": "boolean" }
         },
         "retry_policy": {
           "type": "object",
@@ -76,28 +118,59 @@
     },
     "pipeline": {
       "type": "object",
-      "required": ["stages"],
-      "description": "Pipeline configuration",
+      "description": "Pipeline configuration with optional mode-based stages",
       "properties": {
-        "stages": {
-          "type": "array",
-          "minItems": 1,
-          "description": "Pipeline stages",
-          "items": {
-            "type": "object",
-            "required": ["name", "agent"],
-            "properties": {
-              "name": { "type": "string", "minLength": 1, "description": "Stage name" },
-              "agent": { "type": "string", "minLength": 1, "description": "Agent to execute this stage" },
-              "description": { "type": "string", "description": "Stage description" },
-              "inputs": { "type": "array", "items": { "type": "string" }, "description": "Input files/patterns" },
-              "outputs": { "type": "array", "items": { "type": "string" }, "description": "Output files/patterns" },
-              "next": { "type": ["string", "null"], "description": "Next stage name" },
-              "approval_required": { "type": "boolean", "default": false, "description": "Whether approval is required" },
-              "parallel": { "type": "boolean", "default": false, "description": "Whether stage runs in parallel" },
-              "max_parallel": { "type": "integer", "minimum": 1, "maximum": 10, "description": "Max parallel workers" }
+        "default_mode": {
+          "type": "string",
+          "enum": ["greenfield", "enhancement", "import"],
+          "description": "Default pipeline mode"
+        },
+        "modes": {
+          "type": "object",
+          "description": "Pipeline modes with per-mode stage definitions",
+          "properties": {
+            "greenfield": {
+              "type": "object",
+              "properties": {
+                "description": { "type": "string" },
+                "stages": {
+                  "type": "array",
+                  "minItems": 1,
+                  "items": { "$ref": "#/definitions/pipeline_stage" }
+                }
+              },
+              "required": ["stages"]
+            },
+            "enhancement": {
+              "type": "object",
+              "properties": {
+                "description": { "type": "string" },
+                "stages": {
+                  "type": "array",
+                  "minItems": 1,
+                  "items": { "$ref": "#/definitions/pipeline_stage" }
+                }
+              },
+              "required": ["stages"]
+            },
+            "import": {
+              "type": "object",
+              "properties": {
+                "description": { "type": "string" },
+                "stages": {
+                  "type": "array",
+                  "minItems": 1,
+                  "items": { "$ref": "#/definitions/pipeline_stage" }
+                }
+              },
+              "required": ["stages"]
             }
           }
+        },
+        "stages": {
+          "type": "array",
+          "description": "Legacy flat stages (when not using modes)",
+          "items": { "$ref": "#/definitions/pipeline_stage" }
         }
       }
     },
@@ -293,6 +366,126 @@
       "properties": {
         "enabled": { "type": "boolean", "default": false },
         "metrics": { "type": "array", "items": { "type": "string" } }
+      }
+    },
+    "scratchpad": {
+      "type": "object",
+      "description": "Scratchpad backend configuration",
+      "properties": {
+        "backend": {
+          "type": "string",
+          "enum": ["file", "sqlite", "redis"],
+          "default": "file",
+          "description": "Storage backend type"
+        },
+        "file": {
+          "type": "object",
+          "description": "File backend configuration",
+          "properties": {
+            "base_path": { "type": "string" },
+            "file_mode": { "type": "integer" },
+            "dir_mode": { "type": "integer" },
+            "format": { "type": "string", "enum": ["yaml", "json", "raw"] }
+          }
+        },
+        "sqlite": {
+          "type": "object",
+          "description": "SQLite backend configuration",
+          "properties": {
+            "db_path": { "type": "string" },
+            "wal_mode": { "type": "boolean" },
+            "busy_timeout": { "type": "integer" }
+          }
+        },
+        "redis": {
+          "type": "object",
+          "description": "Redis backend configuration",
+          "properties": {
+            "host": { "type": "string" },
+            "port": { "type": "integer" },
+            "password": { "type": "string" },
+            "db": { "type": "integer" },
+            "prefix": { "type": "string" },
+            "ttl": { "type": "integer" },
+            "connect_timeout": { "type": "integer" },
+            "max_retries": { "type": "integer" },
+            "lock": {
+              "type": "object",
+              "properties": {
+                "lock_ttl": { "type": "integer" },
+                "lock_timeout": { "type": "integer" },
+                "lock_retry_interval": { "type": "integer" }
+              }
+            },
+            "fallback": {
+              "type": "object",
+              "properties": {
+                "enabled": { "type": "boolean" },
+                "file_config": {
+                  "type": "object",
+                  "properties": {
+                    "base_path": { "type": "string" },
+                    "file_mode": { "type": "integer" },
+                    "dir_mode": { "type": "integer" },
+                    "format": { "type": "string", "enum": ["yaml", "json", "raw"] }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "telemetry": {
+      "type": "object",
+      "description": "Telemetry configuration (opt-in only)",
+      "properties": {
+        "enabled": { "type": "boolean", "default": false },
+        "flush_interval_ms": { "type": "integer", "minimum": 1000, "default": 60000 },
+        "max_buffer_size": { "type": "integer", "minimum": 1, "maximum": 1000, "default": 100 },
+        "include_debug_events": { "type": "boolean", "default": false }
+      }
+    },
+    "token_budgets": {
+      "type": "object",
+      "description": "Token budget configuration for pipeline and agents",
+      "properties": {
+        "default_model": {
+          "type": "string",
+          "enum": ["sonnet", "opus", "haiku"],
+          "description": "Default model for budget calculations"
+        },
+        "pipeline": {
+          "type": "object",
+          "description": "Pipeline-level token budget",
+          "properties": {
+            "max_tokens": { "type": "integer", "description": "Maximum tokens for the entire pipeline" },
+            "max_cost_usd": { "type": "number", "description": "Maximum cost in USD for the pipeline" },
+            "warning_threshold": { "type": "number", "minimum": 0, "maximum": 1, "description": "Threshold (0-1) to trigger budget warning" }
+          }
+        },
+        "defaults": {
+          "type": "object",
+          "description": "Default budgets per agent category or role",
+          "additionalProperties": {
+            "type": "object",
+            "properties": {
+              "max_tokens": { "type": "integer" },
+              "max_cost_usd": { "type": "number" }
+            }
+          }
+        },
+        "agents": {
+          "type": "object",
+          "description": "Per-agent token budgets",
+          "additionalProperties": {
+            "type": "object",
+            "properties": {
+              "max_tokens": { "type": "integer" },
+              "max_cost_usd": { "type": "number" }
+            }
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary
- Update `schemas/agents.schema.json` and `schemas/workflow.schema.json` to match the Zod schemas in `src/config/schemas.ts` (updated in PR #529)
- Add missing schema sections: scratchpad, telemetry, token_budgets, on_ci_failure, substages
- Correct enum values, field types, and structural patterns to align with runtime validation

## Changes

### agents.schema.json
- **AgentDefinition.category**: expanded from 3 to 9 enum values (added `orchestration`, `infrastructure`, `project_setup`, `document_update`, `analysis_pipeline`, `enhancement_pipeline`)
- **AgentDefinition.order**: changed from `integer` with `minimum: 1` to `number` (no constraints)
- **AgentCategory.execution_mode**: added `on_demand` and `mixed` options
- **AgentDefinition**: added `token_budget` and `model_preference` fields
- **AgentDependency**: added `blocks`, `alternative_to`, `alternative_inputs`, `orchestrates` fields; added `required: ["requires"]`
- **DataFlow**: added `mode` field

### workflow.schema.json
- **ApprovalGates**: changed from fixed keys to `additionalProperties: boolean` (matches `z.record(z.string(), z.boolean())`)
- **Pipeline**: added `default_mode`, `modes.{greenfield|enhancement|import}` structure with per-mode stages
- **PipelineStage**: `agent` is now optional; added `conditional`, `on_ci_failure`, `substages` (recursive via `$ref`)
- **PipelineStage.inputs**: support both string and object items (matches `StageIOSchema`)
- **Global**: added `approval_mode` enum field
- **New sections**: `scratchpad` (file/sqlite/redis backends), `telemetry`, `token_budgets`

## Test plan
- [x] JSON Schema files are valid JSON (verified with `json.load()`)
- [x] TypeScript build unaffected (no TS changes)
- [x] No schema-related test failures
- [x] Changes match Zod schema definitions in `src/config/schemas.ts`

Closes #517
Part of #511