### PR TITLE
feat(orchestrator): implement AgentDispatcher with per-agent call adapters (#521)

### DIFF
--- a/src/agents/AgentDispatcher.ts
+++ b/src/agents/AgentDispatcher.ts
@@ -1,0 +1,624 @@
+/**
+ * AgentDispatcher - Dispatches pipeline stages to their corresponding agents
+ *
+ * Bridges the gap between the orchestrator's pipeline execution and individual
+ * agent invocation. Each pipeline agentType string is resolved to an IAgent
+ * instance via AGENT_TYPE_MAP, then a per-agent "call adapter" function
+ * translates session context into the correct method call for that agent.
+ *
+ * Key design decisions:
+ * - Dynamic `import()` for all agent modules (no static imports)
+ * - Singleton caching for agents with lifecycle='singleton'
+ * - Per-agent call adapters handle the heterogeneous IAgent APIs
+ * - A default adapter provides generic fallback behavior
+ *
+ * @packageDocumentation
+ */
+
+import path from 'node:path';
+import type { PipelineStageDefinition, OrchestratorSession } from '../ad-sdlc-orchestrator/types.js';
+import type { IAgent } from './types.js';
+import { isAgent } from './types.js';
+import { getAgentTypeEntry } from './AgentTypeMapping.js';
+import type { AgentTypeEntry } from './AgentTypeMapping.js';
+
+/**
+ * Function signature for per-agent call adapters.
+ *
+ * An adapter extracts the relevant data from the orchestrator session,
+ * calls the agent's primary method, and returns the output as a string.
+ */
+export type AgentCallAdapter = (
+  agent: IAgent,
+  stage: PipelineStageDefinition,
+  session: OrchestratorSession
+) => Promise<string>;
+
+/**
+ * Error thrown when a dispatcher operation fails
+ */
+export class AgentDispatchError extends Error {
+  constructor(agentType: string, cause: string) {
+    super(`Failed to dispatch agent '${agentType}': ${cause}`);
+    this.name = 'AgentDispatchError';
+  }
+}
+
+/**
+ * Error thrown when no suitable agent class is found in a module
+ */
+export class AgentModuleError extends Error {
+  constructor(agentType: string, importPath: string) {
+    super(
+      `No valid agent class found in module '${importPath}' for agent type '${agentType}'`
+    );
+    this.name = 'AgentModuleError';
+  }
+}
+
+/**
+ * Cast an IAgent to a duck-typing record for method probing.
+ *
+ * IAgent is a strict interface without an index signature, so TypeScript
+ * rejects a direct cast to `Record<string, unknown>`. This helper
+ * performs the two-step cast `agent -> unknown -> Record` once.
+ *
+ * @param agent - The agent instance to cast
+ * @returns A record view of the agent for duck-typing checks
+ */
+function toRecord(agent: IAgent): Record<string, unknown> {
+  return agent as unknown as Record<string, unknown>;
+}
+
+/**
+ * AgentDispatcher - Creates agent instances and dispatches stage execution
+ *
+ * Usage:
+ * ```typescript
+ * const dispatcher = new AgentDispatcher();
+ *
+ * // Register a custom adapter for a specific agent type
+ * dispatcher.registerAdapter('collector', async (agent, stage, session) => {
+ *   const a = toRecord(agent);
+ *   const result = await (a.collectFromText as Function)(session.userRequest);
+ *   return JSON.stringify(result);
+ * });
+ *
+ * // Dispatch a pipeline stage
+ * const output = await dispatcher.dispatch(stage, session);
+ * ```
+ */
+export class AgentDispatcher {
+  private readonly agentCache = new Map<string, IAgent>();
+  private readonly callAdapters = new Map<string, AgentCallAdapter>();
+
+  constructor() {
+    this.registerDefaultAdapters();
+  }
+
+  /**
+   * Dispatch a pipeline stage to its corresponding agent.
+   *
+   * Resolves the agentType from the stage definition, creates or retrieves
+   * the agent instance, selects the appropriate call adapter, and invokes it.
+   *
+   * @param stage - Pipeline stage definition identifying which agent to invoke
+   * @param session - Current orchestrator session with project context
+   * @returns Agent output string
+   * @throws AgentDispatchError if the agent type is unknown or dispatch fails
+   */
+  async dispatch(
+    stage: PipelineStageDefinition,
+    session: OrchestratorSession
+  ): Promise<string> {
+    const entry = getAgentTypeEntry(stage.agentType);
+    if (!entry) {
+      throw new AgentDispatchError(
+        stage.agentType,
+        `Unknown agent type '${stage.agentType}' — not found in AGENT_TYPE_MAP`
+      );
+    }
+
+    let agent: IAgent;
+    try {
+      agent = await this.getOrCreateAgent(stage.agentType, entry);
+    } catch (error) {
+      if (error instanceof AgentDispatchError || error instanceof AgentModuleError) {
+        throw error;
+      }
+      const message = error instanceof Error ? error.message : String(error);
+      throw new AgentDispatchError(stage.agentType, `Agent creation failed: ${message}`);
+    }
+
+    const adapter = this.callAdapters.get(stage.agentType) ?? this.defaultAdapter;
+
+    try {
+      return await adapter(agent, stage, session);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new AgentDispatchError(
+        stage.agentType,
+        `Agent execution failed: ${message}`
+      );
+    }
+  }
+
+  /**
+   * Register a custom call adapter for a specific agent type.
+   *
+   * Custom adapters override the default adapter for the given agentType.
+   * This is useful for agents that have non-standard APIs.
+   *
+   * @param agentType - Pipeline agent type string (e.g., 'collector')
+   * @param adapter - Function that calls the agent's primary method
+   */
+  registerAdapter(agentType: string, adapter: AgentCallAdapter): void {
+    this.callAdapters.set(agentType, adapter);
+  }
+
+  /**
+   * Check if a custom adapter is registered for the given agent type.
+   *
+   * @param agentType - Pipeline agent type string
+   * @returns True if a custom adapter is registered
+   */
+  hasAdapter(agentType: string): boolean {
+    return this.callAdapters.has(agentType);
+  }
+
+  /**
+   * Inject a pre-created agent instance into the cache.
+   *
+   * Useful for testing or when agents are created externally.
+   *
+   * @param agentType - Pipeline agent type string
+   * @param agent - Pre-created agent instance
+   */
+  setAgent(agentType: string, agent: IAgent): void {
+    this.agentCache.set(agentType, agent);
+  }
+
+  /**
+   * Get a cached agent instance, if present.
+   *
+   * @param agentType - Pipeline agent type string
+   * @returns The cached agent, or undefined
+   */
+  getCachedAgent(agentType: string): IAgent | undefined {
+    return this.agentCache.get(agentType);
+  }
+
+  /**
+   * Get the number of cached agent instances.
+   *
+   * @returns The number of agents currently in the cache
+   */
+  get cacheSize(): number {
+    return this.agentCache.size;
+  }
+
+  /**
+   * Dispose all cached agents and clear the cache.
+   */
+  async disposeAll(): Promise<void> {
+    const disposePromises: Promise<void>[] = [];
+
+    for (const [, agent] of this.agentCache) {
+      disposePromises.push(
+        agent.dispose().catch(() => {
+          // Suppress individual dispose errors
+        })
+      );
+    }
+
+    await Promise.all(disposePromises);
+    this.agentCache.clear();
+    this.callAdapters.clear();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private: Agent Creation
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Get or create an agent instance based on AGENT_TYPE_MAP entry.
+   *
+   * For singleton lifecycle agents, the instance is cached after first creation.
+   * For transient agents, a new instance is created on every call.
+   *
+   * @param agentType - Pipeline agent type string
+   * @param entry - Agent type entry from AGENT_TYPE_MAP
+   * @returns The agent instance
+   */
+  private async getOrCreateAgent(
+    agentType: string,
+    entry: AgentTypeEntry
+  ): Promise<IAgent> {
+    // Check cache for singletons
+    if (entry.lifecycle === 'singleton') {
+      const cached = this.agentCache.get(agentType);
+      if (cached) {
+        return cached;
+      }
+    }
+
+    // Dynamic import the module
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const mod: Record<string, unknown> = await import(entry.importPath);
+
+    // Create agent from the imported module
+    const agent = await this.createAgentFromModule(mod, agentType, entry);
+
+    // Cache singleton instances
+    if (entry.lifecycle === 'singleton') {
+      this.agentCache.set(agentType, agent);
+    }
+
+    return agent;
+  }
+
+  /**
+   * Create an IAgent instance from a dynamically imported module.
+   *
+   * Discovery strategy:
+   * 1. Look for a `get*Agent()` or `get*()` singleton accessor function
+   * 2. Look for an exported class that produces IAgent instances
+   * 3. Look for a `default` export that is a class or IAgent
+   *
+   * For modules whose classes do not implement IAgent (`requiresWrapper`),
+   * a lightweight wrapper is created that delegates initialize/dispose.
+   *
+   * @param mod - The dynamically imported module
+   * @param agentType - Pipeline agent type string
+   * @param entry - Agent type entry from AGENT_TYPE_MAP
+   * @returns An IAgent instance
+   */
+  private async createAgentFromModule(
+    mod: Record<string, unknown>,
+    agentType: string,
+    entry: AgentTypeEntry
+  ): Promise<IAgent> {
+    // Strategy 1: Look for singleton accessor (get*Agent, get*)
+    const accessorNames = this.findAccessorNames(mod);
+    for (const name of accessorNames) {
+      const accessor = mod[name] as () => unknown;
+      const instance = accessor();
+      if (isAgent(instance)) {
+        return instance;
+      }
+      // If it returns a non-IAgent, wrap it if requiresWrapper
+      if (entry.requiresWrapper && instance !== null && typeof instance === 'object') {
+        return this.wrapNonAgent(instance as Record<string, unknown>, entry);
+      }
+    }
+
+    // Strategy 2: Look for exported classes whose names match the agent
+    const classNames = this.findClassNames(mod, agentType);
+    for (const name of classNames) {
+      const Ctor = mod[name] as new (...args: unknown[]) => unknown;
+      try {
+        const instance = new Ctor();
+        if (isAgent(instance)) {
+          await instance.initialize();
+          return instance;
+        }
+        if (entry.requiresWrapper && instance !== null && typeof instance === 'object') {
+          const wrapped = this.wrapNonAgent(instance as Record<string, unknown>, entry);
+          await wrapped.initialize();
+          return wrapped;
+        }
+      } catch {
+        // Constructor may require arguments; skip and try next
+        continue;
+      }
+    }
+
+    // Strategy 3: Default export
+    if (mod['default'] !== undefined) {
+      const defaultExport = mod['default'];
+      if (isAgent(defaultExport as Record<string, unknown>)) {
+        return defaultExport as IAgent;
+      }
+      if (typeof defaultExport === 'function') {
+        try {
+          const Ctor = defaultExport as new (...args: unknown[]) => unknown;
+          const instance = new Ctor();
+          if (isAgent(instance)) {
+            await instance.initialize();
+            return instance;
+          }
+        } catch {
+          // Not a constructable default
+        }
+      }
+    }
+
+    throw new AgentModuleError(agentType, entry.importPath);
+  }
+
+  /**
+   * Find singleton accessor function names in a module (e.g., getCollectorAgent).
+   *
+   * @param mod - The dynamically imported module
+   * @returns Array of function names starting with 'get'
+   */
+  private findAccessorNames(mod: Record<string, unknown>): string[] {
+    return Object.keys(mod).filter(
+      (key) => key.startsWith('get') && typeof mod[key] === 'function'
+    );
+  }
+
+  /**
+   * Find class-like exports whose names are plausible for the given agentType.
+   *
+   * Prioritizes exports whose names contain the agentType fragments.
+   *
+   * @param mod - The dynamically imported module
+   * @param agentType - Pipeline agent type string used for relevance scoring
+   * @returns Array of class-like export names, sorted by relevance
+   */
+  private findClassNames(mod: Record<string, unknown>, agentType: string): string[] {
+    const fragments = agentType.split('-').map((f) => f.toLowerCase());
+
+    return Object.keys(mod)
+      .filter((key) => {
+        const val = mod[key];
+        // Check if it looks like a class (function with prototype)
+        return (
+          typeof val === 'function' &&
+          val.prototype !== undefined &&
+          key[0] === key[0]?.toUpperCase()
+        );
+      })
+      .sort((a, b) => {
+        // Prioritize names that match more agentType fragments
+        const aLower = a.toLowerCase();
+        const bLower = b.toLowerCase();
+        const aScore = fragments.filter((f) => aLower.includes(f)).length;
+        const bScore = fragments.filter((f) => bLower.includes(f)).length;
+        return bScore - aScore;
+      });
+  }
+
+  /**
+   * Wrap a non-IAgent object in a lightweight IAgent-compatible wrapper.
+   *
+   * @param instance - The non-IAgent object to wrap
+   * @param entry - Agent type entry providing agentId and name
+   * @returns An IAgent wrapper around the instance
+   */
+  private wrapNonAgent(
+    instance: Record<string, unknown>,
+    entry: AgentTypeEntry
+  ): IAgent {
+    return {
+      agentId: entry.agentId,
+      name: entry.name,
+
+      async initialize(): Promise<void> {
+        if (typeof instance['initialize'] === 'function') {
+          await (instance['initialize'] as () => Promise<void>)();
+        }
+      },
+
+      async dispose(): Promise<void> {
+        if (typeof instance['dispose'] === 'function') {
+          await (instance['dispose'] as () => Promise<void>)();
+        }
+      },
+
+      // Preserve access to the wrapped instance for adapters
+      ...({ _wrapped: instance } as Record<string, unknown>),
+    } as IAgent;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private: Call Adapters
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Register the built-in per-agent call adapters.
+   *
+   * Each adapter knows how to extract data from OrchestratorSession
+   * and call the corresponding agent's primary method.
+   */
+  private registerDefaultAdapters(): void {
+    // Collector: collectFromText(text, projectName?)
+    this.callAdapters.set('collector', async (agent, _stage, session) => {
+      const a = toRecord(agent);
+      if (typeof a['collectFromText'] === 'function') {
+        const projectName = path.basename(session.projectDir);
+        const result = await (a['collectFromText'] as (text: string, project?: string) => Promise<unknown>)(
+          session.userRequest,
+          projectName
+        );
+        return JSON.stringify(result);
+      }
+      return this.defaultAdapter(agent, _stage, session);
+    });
+
+    // PRD Writer: generateFromProject(projectId)
+    this.callAdapters.set('prd-writer', this.createProjectIdAdapter('generateFromProject'));
+
+    // SRS Writer: generateFromProject(projectId)
+    this.callAdapters.set('srs-writer', this.createProjectIdAdapter('generateFromProject'));
+
+    // SDS Writer: generateFromProject(projectId)
+    this.callAdapters.set('sds-writer', this.createProjectIdAdapter('generateFromProject'));
+
+    // Repo Detector: startSession + detect + finalize pattern
+    this.callAdapters.set('repo-detector', async (agent, _stage, session) => {
+      const a = toRecord(agent);
+      if (typeof a['startSession'] === 'function') {
+        await (a['startSession'] as (dir: string) => Promise<unknown>)(session.projectDir);
+      }
+      if (typeof a['detect'] === 'function') {
+        const result = await (a['detect'] as () => Promise<unknown>)();
+        if (typeof a['finalize'] === 'function') {
+          await (a['finalize'] as () => Promise<unknown>)();
+        }
+        return JSON.stringify(result);
+      }
+      return this.defaultAdapter(agent, _stage, session);
+    });
+
+    // GitHub Repo Setup: similar session pattern
+    this.callAdapters.set('github-repo-setup', async (agent, _stage, session) => {
+      const a = toRecord(agent);
+      if (typeof a['startSession'] === 'function') {
+        await (a['startSession'] as (dir: string) => Promise<unknown>)(session.projectDir);
+      }
+      if (typeof a['setup'] === 'function') {
+        const result = await (a['setup'] as () => Promise<unknown>)();
+        if (typeof a['finalize'] === 'function') {
+          await (a['finalize'] as () => Promise<unknown>)();
+        }
+        return JSON.stringify(result);
+      }
+      return this.defaultAdapter(agent, _stage, session);
+    });
+
+    // Document Reader: startSession + readAll + finalize pattern
+    this.callAdapters.set('document-reader', async (agent, _stage, session) => {
+      const a = toRecord(agent);
+      if (typeof a['startSession'] === 'function') {
+        await (a['startSession'] as (dir: string) => Promise<unknown>)(session.projectDir);
+      }
+      if (typeof a['readAll'] === 'function') {
+        const result = await (a['readAll'] as () => Promise<unknown>)();
+        if (typeof a['finalize'] === 'function') {
+          await (a['finalize'] as () => Promise<unknown>)();
+        }
+        return JSON.stringify(result);
+      }
+      return this.defaultAdapter(agent, _stage, session);
+    });
+
+    // Codebase Analyzer: startSession + analyze + finalize
+    this.callAdapters.set('codebase-analyzer', async (agent, _stage, session) => {
+      const a = toRecord(agent);
+      if (typeof a['startSession'] === 'function') {
+        await (a['startSession'] as (dir: string) => Promise<unknown>)(session.projectDir);
+      }
+      if (typeof a['analyze'] === 'function') {
+        const result = await (a['analyze'] as () => Promise<unknown>)();
+        if (typeof a['finalize'] === 'function') {
+          await (a['finalize'] as () => Promise<unknown>)();
+        }
+        return JSON.stringify(result);
+      }
+      return this.defaultAdapter(agent, _stage, session);
+    });
+
+    // Impact Analyzer: startSession + analyze + finalize
+    this.callAdapters.set('impact-analyzer', async (agent, _stage, session) => {
+      const a = toRecord(agent);
+      if (typeof a['startSession'] === 'function') {
+        await (a['startSession'] as (dir: string) => Promise<unknown>)(session.projectDir);
+      }
+      if (typeof a['analyze'] === 'function') {
+        const result = await (a['analyze'] as () => Promise<unknown>)();
+        if (typeof a['finalize'] === 'function') {
+          await (a['finalize'] as () => Promise<unknown>)();
+        }
+        return JSON.stringify(result);
+      }
+      return this.defaultAdapter(agent, _stage, session);
+    });
+
+    // PRD/SRS/SDS Updaters: updateFromProject(projectId)
+    this.callAdapters.set('prd-updater', this.createProjectIdAdapter('updateFromProject'));
+    this.callAdapters.set('srs-updater', this.createProjectIdAdapter('updateFromProject'));
+    this.callAdapters.set('sds-updater', this.createProjectIdAdapter('updateFromProject'));
+
+    // Regression Tester: startSession + run + finalize
+    this.callAdapters.set('regression-tester', async (agent, _stage, session) => {
+      const a = toRecord(agent);
+      if (typeof a['startSession'] === 'function') {
+        await (a['startSession'] as (dir: string) => Promise<unknown>)(session.projectDir);
+      }
+      if (typeof a['run'] === 'function') {
+        const result = await (a['run'] as () => Promise<unknown>)();
+        if (typeof a['finalize'] === 'function') {
+          await (a['finalize'] as () => Promise<unknown>)();
+        }
+        return JSON.stringify(result);
+      }
+      return this.defaultAdapter(agent, _stage, session);
+    });
+
+    // Issue Reader (Import pipeline): read(projectDir)
+    this.callAdapters.set('issue-reader', async (agent, _stage, session) => {
+      const a = toRecord(agent);
+      if (typeof a['startSession'] === 'function') {
+        await (a['startSession'] as (dir: string) => Promise<unknown>)(session.projectDir);
+      }
+      if (typeof a['read'] === 'function') {
+        const result = await (a['read'] as () => Promise<unknown>)();
+        if (typeof a['finalize'] === 'function') {
+          await (a['finalize'] as () => Promise<unknown>)();
+        }
+        return JSON.stringify(result);
+      }
+      return this.defaultAdapter(agent, _stage, session);
+    });
+  }
+
+  /**
+   * Create a call adapter that invokes a projectId-based method.
+   *
+   * Used by doc writers (generateFromProject) and updaters (updateFromProject).
+   *
+   * @param methodName - The method name to invoke on the agent
+   * @returns A call adapter that extracts projectId and invokes the method
+   */
+  private createProjectIdAdapter(methodName: string): AgentCallAdapter {
+    return async (agent, _stage, session) => {
+      const a = toRecord(agent);
+      if (typeof a[methodName] === 'function') {
+        const projectId = path.basename(session.projectDir);
+        const result = await (a[methodName] as (id: string) => Promise<unknown>)(projectId);
+        return JSON.stringify(result);
+      }
+      return this.defaultAdapter(agent, _stage, session);
+    };
+  }
+
+  /**
+   * Default call adapter used when no specific adapter is registered.
+   *
+   * Attempts common method patterns in order:
+   * 1. generateFromProject(projectId) -- doc writers
+   * 2. analyze(projectDir) -- analyzers
+   * 3. Falls back to a descriptive string
+   *
+   * @param agent - The agent instance
+   * @param stage - The pipeline stage definition
+   * @param session - The orchestrator session
+   * @returns Agent output string
+   */
+  private defaultAdapter: AgentCallAdapter = async (agent, stage, session) => {
+    const a = toRecord(agent);
+
+    // Try generateFromProject pattern (doc writers)
+    if (typeof a['generateFromProject'] === 'function') {
+      const projectId = path.basename(session.projectDir);
+      const result = await (a['generateFromProject'] as (id: string) => Promise<unknown>)(projectId);
+      return JSON.stringify(result);
+    }
+
+    // Try analyze pattern (analyzers)
+    if (typeof a['analyze'] === 'function') {
+      const result = await (a['analyze'] as (dir: string) => Promise<unknown>)(session.projectDir);
+      return JSON.stringify(result);
+    }
+
+    // Try execute pattern (generic agents)
+    if (typeof a['execute'] === 'function') {
+      const result = await (a['execute'] as (session: OrchestratorSession) => Promise<unknown>)(session);
+      return JSON.stringify(result);
+    }
+
+    return `Agent ${agent.agentId} executed for stage "${stage.name}"`;
+  };
+}

--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -58,6 +58,14 @@ export { bootstrapAgents } from './bootstrapAgents.js';
 
 export type { BootstrapResult } from './bootstrapAgents.js';
 
+export {
+  AgentDispatcher,
+  AgentDispatchError,
+  AgentModuleError,
+} from './AgentDispatcher.js';
+
+export type { AgentCallAdapter } from './AgentDispatcher.js';
+
 export { isAgent } from './types.js';
 
 export type {

--- a/tests/agents/AgentDispatcher.test.ts
+++ b/tests/agents/AgentDispatcher.test.ts
@@ -1,0 +1,720 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  AgentDispatcher,
+  AgentDispatchError,
+  AgentModuleError,
+} from '../../src/agents/AgentDispatcher.js';
+import type { AgentCallAdapter } from '../../src/agents/AgentDispatcher.js';
+import type { IAgent } from '../../src/agents/types.js';
+import type {
+  PipelineStageDefinition,
+  OrchestratorSession,
+} from '../../src/ad-sdlc-orchestrator/types.js';
+
+// ---------------------------------------------------------------------------
+// Test Helpers
+// ---------------------------------------------------------------------------
+
+class MockAgent implements IAgent {
+  readonly agentId: string;
+  readonly name: string;
+  public initialized = false;
+  public disposed = false;
+
+  /** Track method calls for assertion */
+  public calls: Array<{ method: string; args: unknown[] }> = [];
+
+  constructor(agentId: string, name: string) {
+    this.agentId = agentId;
+    this.name = name;
+  }
+
+  async initialize(): Promise<void> {
+    this.initialized = true;
+  }
+
+  async dispose(): Promise<void> {
+    this.disposed = true;
+  }
+}
+
+/**
+ * Create a MockAgent that also has generateFromProject for doc-writer testing
+ */
+function createDocWriterAgent(agentId: string, name: string): MockAgent & { generateFromProject: (id: string) => Promise<unknown> } {
+  const agent = new MockAgent(agentId, name) as MockAgent & {
+    generateFromProject: (id: string) => Promise<unknown>;
+  };
+  agent.generateFromProject = async (projectId: string) => {
+    agent.calls.push({ method: 'generateFromProject', args: [projectId] });
+    return { generated: true, projectId };
+  };
+  return agent;
+}
+
+/**
+ * Create a MockAgent with collectFromText for collector testing
+ */
+function createCollectorAgent(): MockAgent & { collectFromText: (text: string, project?: string) => Promise<unknown> } {
+  const agent = new MockAgent('collector-agent', 'Collector Agent') as MockAgent & {
+    collectFromText: (text: string, project?: string) => Promise<unknown>;
+  };
+  agent.collectFromText = async (text: string, project?: string) => {
+    agent.calls.push({ method: 'collectFromText', args: [text, project] });
+    return { collected: true, text, project };
+  };
+  return agent;
+}
+
+/**
+ * Create a MockAgent with session-based methods (startSession/detect/finalize)
+ */
+function createSessionAgent(agentId: string, name: string, primaryMethod: string): MockAgent {
+  const agent = new MockAgent(agentId, name);
+  const a = agent as Record<string, unknown>;
+  a['startSession'] = async (dir: string) => {
+    agent.calls.push({ method: 'startSession', args: [dir] });
+  };
+  a[primaryMethod] = async () => {
+    agent.calls.push({ method: primaryMethod, args: [] });
+    return { result: primaryMethod };
+  };
+  a['finalize'] = async () => {
+    agent.calls.push({ method: 'finalize', args: [] });
+  };
+  return agent;
+}
+
+function createStage(overrides: Partial<PipelineStageDefinition> = {}): PipelineStageDefinition {
+  return {
+    name: 'collection',
+    agentType: 'collector',
+    description: 'Test stage',
+    parallel: false,
+    approvalRequired: false,
+    dependsOn: [],
+    ...overrides,
+  } as PipelineStageDefinition;
+}
+
+function createSession(overrides: Partial<OrchestratorSession> = {}): OrchestratorSession {
+  return {
+    sessionId: 'test-session-001',
+    projectDir: '/test/project',
+    userRequest: 'Build a todo app',
+    mode: 'greenfield',
+    startedAt: '2026-01-01T00:00:00Z',
+    status: 'running',
+    stageResults: [],
+    scratchpadDir: '/test/project/.ad-sdlc/scratchpad',
+    ...overrides,
+  } as OrchestratorSession;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('AgentDispatcher', () => {
+  let dispatcher: AgentDispatcher;
+
+  beforeEach(() => {
+    dispatcher = new AgentDispatcher();
+  });
+
+  afterEach(async () => {
+    await dispatcher.disposeAll();
+  });
+
+  // ─── Constructor & Registration ────────────────────────────────────────
+
+  describe('constructor', () => {
+    it('should create an instance with default adapters registered', () => {
+      // The constructor registers default adapters for known agent types
+      expect(dispatcher.hasAdapter('collector')).toBe(true);
+      expect(dispatcher.hasAdapter('prd-writer')).toBe(true);
+      expect(dispatcher.hasAdapter('srs-writer')).toBe(true);
+      expect(dispatcher.hasAdapter('sds-writer')).toBe(true);
+      expect(dispatcher.hasAdapter('repo-detector')).toBe(true);
+      expect(dispatcher.hasAdapter('github-repo-setup')).toBe(true);
+      expect(dispatcher.hasAdapter('document-reader')).toBe(true);
+      expect(dispatcher.hasAdapter('codebase-analyzer')).toBe(true);
+      expect(dispatcher.hasAdapter('impact-analyzer')).toBe(true);
+      expect(dispatcher.hasAdapter('prd-updater')).toBe(true);
+      expect(dispatcher.hasAdapter('srs-updater')).toBe(true);
+      expect(dispatcher.hasAdapter('sds-updater')).toBe(true);
+      expect(dispatcher.hasAdapter('regression-tester')).toBe(true);
+      expect(dispatcher.hasAdapter('issue-reader')).toBe(true);
+    });
+
+    it('should start with empty agent cache', () => {
+      expect(dispatcher.cacheSize).toBe(0);
+    });
+  });
+
+  // ─── registerAdapter ──────────────────────────────────────────────────
+
+  describe('registerAdapter', () => {
+    it('should register a custom adapter for an agent type', () => {
+      const adapter: AgentCallAdapter = async () => 'custom result';
+      dispatcher.registerAdapter('custom-agent', adapter);
+
+      expect(dispatcher.hasAdapter('custom-agent')).toBe(true);
+    });
+
+    it('should override an existing adapter', () => {
+      const adapter1: AgentCallAdapter = async () => 'result-1';
+      const adapter2: AgentCallAdapter = async () => 'result-2';
+
+      dispatcher.registerAdapter('test-type', adapter1);
+      dispatcher.registerAdapter('test-type', adapter2);
+
+      expect(dispatcher.hasAdapter('test-type')).toBe(true);
+    });
+  });
+
+  // ─── setAgent / getCachedAgent ────────────────────────────────────────
+
+  describe('setAgent / getCachedAgent', () => {
+    it('should inject and retrieve a pre-created agent', () => {
+      const agent = new MockAgent('test-agent', 'Test Agent');
+      dispatcher.setAgent('test-type', agent);
+
+      const cached = dispatcher.getCachedAgent('test-type');
+      expect(cached).toBe(agent);
+      expect(dispatcher.cacheSize).toBe(1);
+    });
+
+    it('should return undefined for a non-cached agent', () => {
+      expect(dispatcher.getCachedAgent('nonexistent')).toBeUndefined();
+    });
+  });
+
+  // ─── dispatch with pre-injected agents ────────────────────────────────
+
+  describe('dispatch', () => {
+    it('should throw AgentDispatchError for unknown agent type', async () => {
+      const stage = createStage({ agentType: 'nonexistent-agent' });
+      const session = createSession();
+
+      await expect(dispatcher.dispatch(stage, session)).rejects.toThrow(
+        AgentDispatchError
+      );
+      await expect(dispatcher.dispatch(stage, session)).rejects.toThrow(
+        "Unknown agent type 'nonexistent-agent'"
+      );
+    });
+
+    it('should dispatch collector agent with collectFromText', async () => {
+      const agent = createCollectorAgent();
+      dispatcher.setAgent('collector', agent);
+
+      const stage = createStage({
+        name: 'collection',
+        agentType: 'collector',
+      });
+      const session = createSession({
+        projectDir: '/home/user/my-project',
+        userRequest: 'Build a REST API',
+      });
+
+      const result = await dispatcher.dispatch(stage, session);
+      const parsed = JSON.parse(result);
+
+      expect(parsed.collected).toBe(true);
+      expect(parsed.text).toBe('Build a REST API');
+      expect(parsed.project).toBe('my-project');
+      expect(agent.calls).toHaveLength(1);
+      expect(agent.calls[0]!.method).toBe('collectFromText');
+    });
+
+    it('should dispatch doc writer agent with generateFromProject', async () => {
+      const agent = createDocWriterAgent('prd-writer-agent', 'PRD Writer Agent');
+      dispatcher.setAgent('prd-writer', agent);
+
+      const stage = createStage({
+        name: 'prd_generation',
+        agentType: 'prd-writer',
+      });
+      const session = createSession({ projectDir: '/home/user/my-app' });
+
+      const result = await dispatcher.dispatch(stage, session);
+      const parsed = JSON.parse(result);
+
+      expect(parsed.generated).toBe(true);
+      expect(parsed.projectId).toBe('my-app');
+      expect(agent.calls[0]!.method).toBe('generateFromProject');
+    });
+
+    it('should dispatch repo-detector agent with startSession/detect/finalize', async () => {
+      const agent = createSessionAgent('repo-detector-agent', 'Repo Detector', 'detect');
+      dispatcher.setAgent('repo-detector', agent);
+
+      const stage = createStage({
+        name: 'repo_detection',
+        agentType: 'repo-detector',
+      });
+      const session = createSession({ projectDir: '/test/repo' });
+
+      const result = await dispatcher.dispatch(stage, session);
+      const parsed = JSON.parse(result);
+
+      expect(parsed.result).toBe('detect');
+      expect(agent.calls).toHaveLength(3);
+      expect(agent.calls[0]!.method).toBe('startSession');
+      expect(agent.calls[0]!.args[0]).toBe('/test/repo');
+      expect(agent.calls[1]!.method).toBe('detect');
+      expect(agent.calls[2]!.method).toBe('finalize');
+    });
+
+    it('should dispatch github-repo-setup agent with startSession/setup/finalize', async () => {
+      const agent = createSessionAgent('github-repo-setup-agent', 'GitHub Repo Setup', 'setup');
+      dispatcher.setAgent('github-repo-setup', agent);
+
+      const stage = createStage({
+        name: 'github_repo_setup',
+        agentType: 'github-repo-setup',
+      });
+      const session = createSession({ projectDir: '/test/repo' });
+
+      const result = await dispatcher.dispatch(stage, session);
+      const parsed = JSON.parse(result);
+
+      expect(parsed.result).toBe('setup');
+      expect(agent.calls.map((c) => c.method)).toEqual([
+        'startSession',
+        'setup',
+        'finalize',
+      ]);
+    });
+
+    it('should dispatch document-reader with startSession/readAll/finalize', async () => {
+      const agent = createSessionAgent('document-reader-agent', 'Document Reader', 'readAll');
+      dispatcher.setAgent('document-reader', agent);
+
+      const stage = createStage({
+        name: 'document_reading',
+        agentType: 'document-reader',
+      });
+      const session = createSession();
+
+      const result = await dispatcher.dispatch(stage, session);
+      const parsed = JSON.parse(result);
+
+      expect(parsed.result).toBe('readAll');
+      expect(agent.calls.map((c) => c.method)).toEqual([
+        'startSession',
+        'readAll',
+        'finalize',
+      ]);
+    });
+
+    it('should dispatch codebase-analyzer with startSession/analyze/finalize', async () => {
+      const agent = createSessionAgent('codebase-analyzer-agent', 'Codebase Analyzer', 'analyze');
+      dispatcher.setAgent('codebase-analyzer', agent);
+
+      const stage = createStage({
+        name: 'codebase_analysis',
+        agentType: 'codebase-analyzer',
+      });
+      const session = createSession();
+
+      const result = await dispatcher.dispatch(stage, session);
+      expect(agent.calls.map((c) => c.method)).toEqual([
+        'startSession',
+        'analyze',
+        'finalize',
+      ]);
+    });
+
+    it('should dispatch updaters with updateFromProject', async () => {
+      const agent = new MockAgent('prd-updater-agent', 'PRD Updater Agent');
+      const a = agent as Record<string, unknown>;
+      a['updateFromProject'] = async (projectId: string) => {
+        agent.calls.push({ method: 'updateFromProject', args: [projectId] });
+        return { updated: true, projectId };
+      };
+      dispatcher.setAgent('prd-updater', agent);
+
+      const stage = createStage({
+        name: 'prd_update',
+        agentType: 'prd-updater',
+      });
+      const session = createSession({ projectDir: '/project/root' });
+
+      const result = await dispatcher.dispatch(stage, session);
+      const parsed = JSON.parse(result);
+
+      expect(parsed.updated).toBe(true);
+      expect(parsed.projectId).toBe('root');
+    });
+
+    it('should dispatch regression-tester with startSession/run/finalize', async () => {
+      const agent = createSessionAgent('regression-tester-agent', 'Regression Tester', 'run');
+      dispatcher.setAgent('regression-tester', agent);
+
+      const stage = createStage({
+        name: 'regression_testing',
+        agentType: 'regression-tester',
+      });
+      const session = createSession();
+
+      await dispatcher.dispatch(stage, session);
+
+      expect(agent.calls.map((c) => c.method)).toEqual([
+        'startSession',
+        'run',
+        'finalize',
+      ]);
+    });
+
+    it('should dispatch issue-reader with startSession/read/finalize', async () => {
+      const agent = createSessionAgent('issue-reader-agent', 'Issue Reader', 'read');
+      dispatcher.setAgent('issue-reader', agent);
+
+      const stage = createStage({
+        name: 'issue_reading',
+        agentType: 'issue-reader',
+      });
+      const session = createSession();
+
+      await dispatcher.dispatch(stage, session);
+
+      expect(agent.calls.map((c) => c.method)).toEqual([
+        'startSession',
+        'read',
+        'finalize',
+      ]);
+    });
+
+    it('should wrap dispatch errors in AgentDispatchError', async () => {
+      const agent = new MockAgent('collector-agent', 'Collector Agent');
+      const a = agent as Record<string, unknown>;
+      a['collectFromText'] = async () => {
+        throw new Error('Network timeout');
+      };
+      dispatcher.setAgent('collector', agent);
+
+      const stage = createStage({ agentType: 'collector' });
+      const session = createSession();
+
+      await expect(dispatcher.dispatch(stage, session)).rejects.toThrow(
+        AgentDispatchError
+      );
+      await expect(dispatcher.dispatch(stage, session)).rejects.toThrow(
+        'Agent execution failed: Network timeout'
+      );
+    });
+  });
+
+  // ─── Custom adapter dispatch ──────────────────────────────────────────
+
+  describe('dispatch with custom adapter', () => {
+    it('should use custom adapter when registered', async () => {
+      const agent = new MockAgent('collector-agent', 'Collector Agent');
+      dispatcher.setAgent('collector', agent);
+
+      // Override the default collector adapter
+      dispatcher.registerAdapter('collector', async (_agent, _stage, session) => {
+        return `Custom: ${session.userRequest}`;
+      });
+
+      const stage = createStage({ agentType: 'collector' });
+      const session = createSession({ userRequest: 'Hello' });
+
+      const result = await dispatcher.dispatch(stage, session);
+      expect(result).toBe('Custom: Hello');
+    });
+  });
+
+  // ─── Default adapter fallback ─────────────────────────────────────────
+
+  describe('default adapter fallback', () => {
+    it('should try generateFromProject for agents with that method', async () => {
+      // Use an agent type that does not have a registered adapter
+      // We need to simulate this by clearing adapters and using a known type
+      const agent = createDocWriterAgent('analysis-orchestrator-agent', 'Analysis Orchestrator');
+      dispatcher.setAgent('analysis-orchestrator', agent);
+
+      // analysis-orchestrator does not have a registered adapter,
+      // so the default adapter should be used
+      const stage = createStage({
+        name: 'codebase_analysis' as PipelineStageDefinition['name'],
+        agentType: 'analysis-orchestrator',
+      });
+      const session = createSession({ projectDir: '/test/project' });
+
+      // The default adapter should discover generateFromProject
+      const result = await dispatcher.dispatch(stage, session);
+      const parsed = JSON.parse(result);
+      expect(parsed.generated).toBe(true);
+      expect(parsed.projectId).toBe('project');
+    });
+
+    it('should try analyze for agents with that method', async () => {
+      const agent = new MockAgent('analysis-orchestrator-agent', 'Analysis Orchestrator');
+      const a = agent as Record<string, unknown>;
+      a['analyze'] = async (dir: string) => {
+        agent.calls.push({ method: 'analyze', args: [dir] });
+        return { analyzed: true, dir };
+      };
+      dispatcher.setAgent('analysis-orchestrator', agent);
+
+      const stage = createStage({
+        name: 'codebase_analysis' as PipelineStageDefinition['name'],
+        agentType: 'analysis-orchestrator',
+      });
+      const session = createSession({ projectDir: '/test/project' });
+
+      const result = await dispatcher.dispatch(stage, session);
+      const parsed = JSON.parse(result);
+      expect(parsed.analyzed).toBe(true);
+    });
+
+    it('should try execute for agents with that method', async () => {
+      const agent = new MockAgent('analysis-orchestrator-agent', 'Analysis Orchestrator');
+      const a = agent as Record<string, unknown>;
+      a['execute'] = async (session: OrchestratorSession) => {
+        agent.calls.push({ method: 'execute', args: [session] });
+        return { executed: true };
+      };
+      dispatcher.setAgent('analysis-orchestrator', agent);
+
+      const stage = createStage({
+        name: 'codebase_analysis' as PipelineStageDefinition['name'],
+        agentType: 'analysis-orchestrator',
+      });
+      const session = createSession();
+
+      const result = await dispatcher.dispatch(stage, session);
+      const parsed = JSON.parse(result);
+      expect(parsed.executed).toBe(true);
+    });
+
+    it('should return descriptive string for agents with no matching method', async () => {
+      const agent = new MockAgent('analysis-orchestrator-agent', 'Analysis Orchestrator');
+      dispatcher.setAgent('analysis-orchestrator', agent);
+
+      const stage = createStage({
+        name: 'codebase_analysis' as PipelineStageDefinition['name'],
+        agentType: 'analysis-orchestrator',
+      });
+      const session = createSession();
+
+      const result = await dispatcher.dispatch(stage, session);
+      expect(result).toContain('analysis-orchestrator-agent');
+      expect(result).toContain('codebase_analysis');
+    });
+  });
+
+  // ─── Singleton caching behavior ───────────────────────────────────────
+
+  describe('singleton caching', () => {
+    it('should return the same cached agent on repeated dispatch', async () => {
+      const agent = createCollectorAgent();
+      dispatcher.setAgent('collector', agent);
+
+      const stage = createStage({ agentType: 'collector' });
+      const session = createSession();
+
+      // Dispatch twice
+      await dispatcher.dispatch(stage, session);
+      await dispatcher.dispatch(stage, session);
+
+      // Agent should have been called twice but be the same instance
+      expect(agent.calls).toHaveLength(2);
+      expect(dispatcher.getCachedAgent('collector')).toBe(agent);
+    });
+
+    it('should track cache size correctly', () => {
+      const agent1 = new MockAgent('agent-1', 'Agent 1');
+      const agent2 = new MockAgent('agent-2', 'Agent 2');
+
+      dispatcher.setAgent('type-1', agent1);
+      dispatcher.setAgent('type-2', agent2);
+
+      expect(dispatcher.cacheSize).toBe(2);
+    });
+  });
+
+  // ─── disposeAll ───────────────────────────────────────────────────────
+
+  describe('disposeAll', () => {
+    it('should dispose all cached agents and clear the cache', async () => {
+      const agent1 = new MockAgent('agent-1', 'Agent 1');
+      const agent2 = new MockAgent('agent-2', 'Agent 2');
+
+      dispatcher.setAgent('type-1', agent1);
+      dispatcher.setAgent('type-2', agent2);
+
+      await dispatcher.disposeAll();
+
+      expect(agent1.disposed).toBe(true);
+      expect(agent2.disposed).toBe(true);
+      expect(dispatcher.cacheSize).toBe(0);
+    });
+
+    it('should clear adapters on disposeAll', async () => {
+      dispatcher.registerAdapter('custom', async () => 'custom');
+      expect(dispatcher.hasAdapter('custom')).toBe(true);
+
+      await dispatcher.disposeAll();
+
+      expect(dispatcher.hasAdapter('custom')).toBe(false);
+    });
+
+    it('should handle dispose errors gracefully', async () => {
+      const agent = new MockAgent('agent-1', 'Agent 1');
+      agent.dispose = async () => {
+        throw new Error('Dispose failed');
+      };
+
+      dispatcher.setAgent('type-1', agent);
+
+      // Should not throw
+      await expect(dispatcher.disposeAll()).resolves.toBeUndefined();
+      expect(dispatcher.cacheSize).toBe(0);
+    });
+  });
+
+  // ─── Adapter falls back to default when method not found ──────────────
+
+  describe('adapter fallback to defaultAdapter', () => {
+    it('should fall back to default when collector has no collectFromText', async () => {
+      // Agent without collectFromText but with analyze
+      const agent = new MockAgent('collector-agent', 'Collector Agent');
+      const a = agent as Record<string, unknown>;
+      a['analyze'] = async (dir: string) => ({ analyzed: dir });
+      dispatcher.setAgent('collector', agent);
+
+      const stage = createStage({ agentType: 'collector' });
+      const session = createSession();
+
+      const result = await dispatcher.dispatch(stage, session);
+      const parsed = JSON.parse(result);
+      expect(parsed.analyzed).toBe(session.projectDir);
+    });
+
+    it('should fall back to default when repo-detector has no startSession', async () => {
+      const agent = new MockAgent('repo-detector-agent', 'Repo Detector');
+      dispatcher.setAgent('repo-detector', agent);
+
+      const stage = createStage({
+        name: 'repo_detection',
+        agentType: 'repo-detector',
+      });
+      const session = createSession();
+
+      // Should not throw; uses default adapter's descriptive string
+      const result = await dispatcher.dispatch(stage, session);
+      expect(result).toContain('repo-detector-agent');
+    });
+  });
+
+  // ─── SRS / SDS writer dispatches ─────────────────────────────────────
+
+  describe('srs-writer and sds-writer dispatches', () => {
+    it('should dispatch srs-writer with generateFromProject', async () => {
+      const agent = createDocWriterAgent('srs-writer-agent', 'SRS Writer Agent');
+      dispatcher.setAgent('srs-writer', agent);
+
+      const stage = createStage({
+        name: 'srs_generation',
+        agentType: 'srs-writer',
+      });
+      const session = createSession({ projectDir: '/workspace/my-srs-project' });
+
+      const result = await dispatcher.dispatch(stage, session);
+      const parsed = JSON.parse(result);
+
+      expect(parsed.generated).toBe(true);
+      expect(parsed.projectId).toBe('my-srs-project');
+    });
+
+    it('should dispatch sds-writer with generateFromProject', async () => {
+      const agent = createDocWriterAgent('sds-writer-agent', 'SDS Writer Agent');
+      dispatcher.setAgent('sds-writer', agent);
+
+      const stage = createStage({
+        name: 'sds_generation',
+        agentType: 'sds-writer',
+      });
+      const session = createSession({ projectDir: '/workspace/design-project' });
+
+      const result = await dispatcher.dispatch(stage, session);
+      const parsed = JSON.parse(result);
+
+      expect(parsed.generated).toBe(true);
+      expect(parsed.projectId).toBe('design-project');
+    });
+  });
+
+  // ─── Impact analyzer dispatch ─────────────────────────────────────────
+
+  describe('impact-analyzer dispatch', () => {
+    it('should dispatch impact-analyzer with startSession/analyze/finalize', async () => {
+      const agent = createSessionAgent('impact-analyzer-agent', 'Impact Analyzer', 'analyze');
+      dispatcher.setAgent('impact-analyzer', agent);
+
+      const stage = createStage({
+        name: 'impact_analysis',
+        agentType: 'impact-analyzer',
+      });
+      const session = createSession({ projectDir: '/test/impact-project' });
+
+      const result = await dispatcher.dispatch(stage, session);
+      const parsed = JSON.parse(result);
+
+      expect(parsed.result).toBe('analyze');
+      expect(agent.calls[0]!.method).toBe('startSession');
+      expect(agent.calls[0]!.args[0]).toBe('/test/impact-project');
+      expect(agent.calls[1]!.method).toBe('analyze');
+      expect(agent.calls[2]!.method).toBe('finalize');
+    });
+  });
+
+  // ─── SRS/SDS updater dispatch ─────────────────────────────────────────
+
+  describe('srs-updater and sds-updater dispatch', () => {
+    it('should dispatch srs-updater with updateFromProject', async () => {
+      const agent = new MockAgent('srs-updater-agent', 'SRS Updater Agent');
+      const a = agent as Record<string, unknown>;
+      a['updateFromProject'] = async (projectId: string) => {
+        agent.calls.push({ method: 'updateFromProject', args: [projectId] });
+        return { updated: true };
+      };
+      dispatcher.setAgent('srs-updater', agent);
+
+      const stage = createStage({
+        name: 'srs_update',
+        agentType: 'srs-updater',
+      });
+      const session = createSession({ projectDir: '/test/update-project' });
+
+      const result = await dispatcher.dispatch(stage, session);
+      const parsed = JSON.parse(result);
+      expect(parsed.updated).toBe(true);
+      expect(agent.calls[0]!.args[0]).toBe('update-project');
+    });
+
+    it('should dispatch sds-updater with updateFromProject', async () => {
+      const agent = new MockAgent('sds-updater-agent', 'SDS Updater Agent');
+      const a = agent as Record<string, unknown>;
+      a['updateFromProject'] = async (projectId: string) => {
+        agent.calls.push({ method: 'updateFromProject', args: [projectId] });
+        return { updated: true };
+      };
+      dispatcher.setAgent('sds-updater', agent);
+
+      const stage = createStage({
+        name: 'sds_update',
+        agentType: 'sds-updater',
+      });
+      const session = createSession({ projectDir: '/test/sds-project' });
+
+      const result = await dispatcher.dispatch(stage, session);
+      const parsed = JSON.parse(result);
+      expect(parsed.updated).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Implement `AgentDispatcher` class that bridges the orchestrator pipeline with individual agent invocation
- Each pipeline `agentType` string is resolved via `AGENT_TYPE_MAP` and dispatched through per-agent call adapters
- Adapters translate `OrchestratorSession` context into the correct method calls for each agent's heterogeneous API

## Changes
- **`src/agents/AgentDispatcher.ts`** (new): Core dispatcher with singleton caching, dynamic `import()`, per-agent adapters, non-IAgent wrappers, and default fallback adapter
- **`src/agents/index.ts`** (modified): Export `AgentDispatcher`, `AgentDispatchError`, `AgentModuleError`, and `AgentCallAdapter` type
- **`tests/agents/AgentDispatcher.test.ts`** (new): 34 tests covering dispatch for all agent types, singleton caching, custom adapters, default adapter fallback, error wrapping, and dispose

## Design Decisions
- **Dynamic imports only**: All agent modules are loaded via `import()` to avoid circular dependencies and reduce startup cost
- **Per-agent adapters**: Each agent type has a registered adapter that knows its API (e.g., `collectFromText` for collector, `generateFromProject` for doc writers, `startSession/detect/finalize` for session-based agents)
- **Default adapter**: Falls back to probing `generateFromProject`, `analyze`, or `execute` methods
- **`toRecord()` helper**: Safely casts `IAgent` to `Record<string, unknown>` through `unknown` to satisfy strict TypeScript checking
- **`setAgent()` for testing**: Allows injecting pre-created agents, avoiding real dynamic imports in tests

## Test Plan
- [x] 34 unit tests pass (all agent dispatch patterns, caching, errors, dispose)
- [x] TypeScript compilation passes (`tsc --noEmit`)
- [x] ESLint passes with 0 errors and 0 warnings
- [x] All 139 existing agent tests continue to pass

Part of #511
Refs: #521