### PR TITLE
feat(agents): add StubBridge detection and explicit warnings in pipeline execution

### DIFF
--- a/src/ad-sdlc-orchestrator/AdsdlcOrchestratorAgent.ts
+++ b/src/ad-sdlc-orchestrator/AdsdlcOrchestratorAgent.ts
@@ -684,6 +684,7 @@ export class AdsdlcOrchestratorAgent implements IAgent {
       const startTime = Date.now();
       try {
         const bridge = registry.resolve(invocation.agentType);
+        const isStub = registry.isStub(invocation.agentType);
         const request: AgentRequest = {
           agentType: invocation.agentType,
           input: invocation.inputs.join('\n'),
@@ -699,10 +700,11 @@ export class AdsdlcOrchestratorAgent implements IAgent {
           agentType: invocation.agentType,
           status: response.success ? 'completed' : 'failed',
           durationMs: Date.now() - startTime,
-          output: response.output,
+          output: isStub ? `[STUB] ${response.output}` : response.output,
           artifacts: [...invocation.outputs, ...response.artifacts.map((a) => a.path)],
           error: response.error ?? null,
           retryCount: 0,
+          ...(isStub && { warnings: ['StubBridge used — no real agent execution'] }),
         };
       } catch (error) {
         return {
@@ -760,6 +762,7 @@ export class AdsdlcOrchestratorAgent implements IAgent {
       const startTime = Date.now();
       try {
         const bridge = registry.resolve(invocation.agentType);
+        const isStub = registry.isStub(invocation.agentType);
         const request: AgentRequest = {
           agentType: invocation.agentType,
           input: invocation.inputs.join('\n'),
@@ -775,10 +778,11 @@ export class AdsdlcOrchestratorAgent implements IAgent {
           agentType: invocation.agentType,
           status: response.success ? 'completed' : 'failed',
           durationMs: Date.now() - startTime,
-          output: response.output,
+          output: isStub ? `[STUB] ${response.output}` : response.output,
           artifacts: [...invocation.outputs, ...response.artifacts.map((a) => a.path)],
           error: response.error ?? null,
           retryCount: 0,
+          ...(isStub && { warnings: ['StubBridge used — no real agent execution'] }),
         });
 
         // Stop on failure — sequential stages are dependent

--- a/src/ad-sdlc-orchestrator/types.ts
+++ b/src/ad-sdlc-orchestrator/types.ts
@@ -122,6 +122,8 @@ export interface StageResult {
   readonly error: string | null;
   /** Number of retry attempts */
   readonly retryCount: number;
+  /** Warning messages (e.g., StubBridge detection) */
+  readonly warnings?: readonly string[];
 }
 
 /**

--- a/src/agents/BridgeRegistry.ts
+++ b/src/agents/BridgeRegistry.ts
@@ -52,6 +52,27 @@ export class BridgeRegistry {
         return bridge;
       }
     }
+    console.warn(
+      `[BridgeRegistry] No real bridge registered for agent type "${agentType}" — using StubBridge (no-op). ` +
+        'Set ANTHROPIC_API_KEY or run inside Claude Code session to enable real execution.'
+    );
+    return this.stubBridge;
+  }
+
+  /**
+   * Check if the resolved bridge for an agent type is the StubBridge fallback.
+   *
+   * @param agentType - Pipeline agent type string
+   * @returns True if no real bridge handles this type
+   */
+  isStub(agentType: string): boolean {
+    return !this.bridges.some((b) => b.supports(agentType));
+  }
+
+  /**
+   * Get the StubBridge instance used as fallback.
+   */
+  getStubBridge(): AgentBridge {
     return this.stubBridge;
   }
 


### PR DESCRIPTION
## Summary

- Add `isStub()` and `getStubBridge()` methods to `BridgeRegistry` with console warning on StubBridge fallback
- Add optional `warnings` field to `StageResult` type for per-stage diagnostics
- Detect StubBridge usage in `executeSequential()` and `executeParallel()`, prefix output with `[STUB]` tag and attach warnings array
- Add `--strict` CLI flag that rejects pipeline execution when any agent would use StubBridge

Closes #563

## Test Plan

- [x] 7 new unit tests covering `isStub()`, `getStubBridge()`, and resolve warning behavior
- [x] All 21 BridgeRegistry tests pass
- [x] TypeScript build passes (`tsc --noEmit`)
- [x] ESLint passes on all `src/` files (0 errors)
- [x] CI workflows pass