### PR TITLE
fix(project-initializer): use OS temp directory for test output

### DIFF
--- a/tests/project-initializer/ProjectInitializer.test.ts
+++ b/tests/project-initializer/ProjectInitializer.test.ts
@@ -3,6 +3,7 @@
  */
 
 import * as fs from 'fs';
+import * as os from 'os';
 import * as path from 'path';
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -16,35 +17,30 @@ import { resetPrerequisiteValidator } from '../../src/project-initializer/Prereq
 import type { InitOptions } from '../../src/project-initializer/types.js';
 
 describe('ProjectInitializer', () => {
-  const testDir = path.join(process.cwd(), 'test-output');
+  let testDir: string;
   const testProjectName = 'test-project';
-  const testProjectPath = path.join(testDir, testProjectName);
-
-  const defaultOptions: InitOptions = {
-    projectName: testProjectName,
-    techStack: 'typescript',
-    template: 'standard',
-    targetDir: testDir,
-    skipValidation: true,
-  };
+  let testProjectPath: string;
+  let defaultOptions: InitOptions;
 
   beforeEach(() => {
     resetProjectInitializer();
     resetPrerequisiteValidator();
-    // Clean up test directory
-    if (fs.existsSync(testProjectPath)) {
-      fs.rmSync(testProjectPath, { recursive: true });
-    }
-    // Create test directory
-    if (!fs.existsSync(testDir)) {
-      fs.mkdirSync(testDir, { recursive: true });
-    }
+    // Use OS temp directory to avoid sandbox write restrictions on .claude paths
+    testDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pi-test-'));
+    testProjectPath = path.join(testDir, testProjectName);
+    defaultOptions = {
+      projectName: testProjectName,
+      techStack: 'typescript',
+      template: 'standard',
+      targetDir: testDir,
+      skipValidation: true,
+    };
   });
 
   afterEach(() => {
-    // Clean up after tests
-    if (fs.existsSync(testProjectPath)) {
-      fs.rmSync(testProjectPath, { recursive: true });
+    // Clean up temp directory
+    if (fs.existsSync(testDir)) {
+      fs.rmSync(testDir, { recursive: true });
     }
   });
 


### PR DESCRIPTION
## Summary

- Move test output from project-local `test-output/` directory to `os.tmpdir()`-based temp directories using `fs.mkdtempSync()`
- Each test run creates a unique temp directory and cleans it up in `afterEach`
- Fixes `EPERM: operation not permitted` errors when tests write to `.claude/agents/` paths under sandboxed environments

Closes #565

## Root Cause Analysis

All 14 `ProjectInitializer.test.ts` tests failed with:
```
EPERM: operation not permitted, open 'test-output/test-project/.claude/agents/collector.md'
```

The tests created a `.claude/agents/` subdirectory inside `test-output/` within the project tree. Sandboxed environments (e.g., Claude Code sessions) restrict writes to paths matching `.claude` within the project directory, causing all `fs.writeFileSync` calls in `generateAgentDefinitions()` to fail.

## Test Plan

- [x] All 18 ProjectInitializer tests pass (including 14 previously failing)
- [x] Tests pass with sandbox enabled (verified locally)
- [x] Tests pass with sandbox disabled (verified locally)
- [x] TypeScript build passes (`tsc --noEmit`)
- [x] No project directory pollution (no `test-output/` artifacts)
- [x] CI workflows pass