### PR TITLE
fix(code-reader): add configurable parse threshold and per-file error diagnostics

### DIFF
--- a/src/code-reader/index.ts
+++ b/src/code-reader/index.ts
@@ -69,3 +69,5 @@ export {
   TooManyParseErrorsError,
   InvalidTsConfigError,
 } from './errors.js';
+
+export type { ParseErrorDetail } from './errors.js';

--- a/src/code-reader/types.ts
+++ b/src/code-reader/types.ts
@@ -456,6 +456,8 @@ export interface CodeReaderConfig {
   readonly maxFileSize?: number;
   /** Maximum files to process at once (for memory management) */
   readonly batchSize?: number;
+  /** Maximum allowed ratio of files with parse errors (0.0–1.0, default 0.5) */
+  readonly parseErrorThreshold?: number;
 }
 
 /**
@@ -480,6 +482,7 @@ export const DEFAULT_CODE_READER_CONFIG: Required<CodeReaderConfig> = {
   analyzeDependencies: true,
   maxFileSize: 5 * 1024 * 1024, // 5MB
   batchSize: 100,
+  parseErrorThreshold: 0.5,
 } as const;
 
 /**

--- a/tests/code-reader/errors.test.ts
+++ b/tests/code-reader/errors.test.ts
@@ -192,6 +192,25 @@ describe('TooManyParseErrorsError', () => {
     const error = new TooManyParseErrorsError(1, 10, 0.05);
     expect(error instanceof CodeReaderError).toBe(true);
   });
+
+  it('should include per-file error details when provided', () => {
+    const fileErrors = [
+      { filePath: '/src/a.ts', message: 'Cannot find name X', line: 5 },
+      { filePath: '/src/b.ts', message: 'Type error' },
+    ];
+    const error = new TooManyParseErrorsError(2, 3, 0.5, fileErrors);
+    expect(error.fileErrors).toHaveLength(2);
+    expect(error.message).toContain('Failed files:');
+    expect(error.message).toContain('/src/a.ts:5');
+    expect(error.message).toContain('Cannot find name X');
+    expect(error.message).toContain('/src/b.ts');
+  });
+
+  it('should default to empty fileErrors array', () => {
+    const error = new TooManyParseErrorsError(5, 10, 0.3);
+    expect(error.fileErrors).toHaveLength(0);
+    expect(error.message).not.toContain('Failed files:');
+  });
 });
 
 describe('InvalidTsConfigError', () => {


### PR DESCRIPTION
## Summary

- Add `parseErrorThreshold` option to `CodeReaderConfig` (default 0.5), replacing the hardcoded 50% threshold
- Enhance `TooManyParseErrorsError` with `fileErrors` array containing `ParseErrorDetail` entries (file path, error message, line number)
- Error messages now list up to 10 failed files with specific diagnostic details
- Export new `ParseErrorDetail` type from module index

Closes #566

## Context

The 9 originally failing tests were already fixed by a previous change (dynamic import refactor in #537). This PR addresses the remaining acceptance criteria: making the threshold configurable and providing actionable per-file error messages when parsing fails.

## Test Plan

- [x] All 52 code-reader tests pass (24 agent + 28 error tests)
- [x] 4 new tests: configurable threshold (2) + per-file error details (2)
- [x] TypeScript build passes (`tsc --noEmit`)
- [x] ESLint passes (0 errors)
- [x] CI workflows pass