### PR TITLE
fix(architecture-generator): use OS temp directory for SRSParser file tests

### DIFF
--- a/tests/architecture-generator/architecture-generator.test.ts
+++ b/tests/architecture-generator/architecture-generator.test.ts
@@ -7,6 +7,7 @@
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import * as fs from 'fs';
+import * as os from 'os';
 import * as path from 'path';
 import {
   ArchitectureGenerator,
@@ -330,19 +331,18 @@ describe('SRSParser', () => {
   });
 
   describe('parseFile', () => {
-    const testDir = '/tmp/architecture-generator-test';
-    const testFile = path.join(testDir, 'test-srs.md');
+    let testDir: string;
+    let testFile: string;
 
     beforeEach(() => {
-      if (!fs.existsSync(testDir)) {
-        fs.mkdirSync(testDir, { recursive: true });
-      }
+      testDir = fs.mkdtempSync(path.join(os.tmpdir(), 'architecture-generator-test-'));
+      testFile = path.join(testDir, 'test-srs.md');
       fs.writeFileSync(testFile, SAMPLE_SRS_CONTENT);
     });
 
     afterEach(() => {
-      if (fs.existsSync(testFile)) {
-        fs.unlinkSync(testFile);
+      if (fs.existsSync(testDir)) {
+        fs.rmSync(testDir, { recursive: true, force: true });
       }
     });
 


### PR DESCRIPTION
Closes #568

## Summary
- Replace hardcoded `/tmp/architecture-generator-test` path with `os.tmpdir()` + `fs.mkdtempSync()`
- Each test run creates a unique temp directory, cleaned up in `afterEach`
- Same pattern applied in #574 (ProjectInitializer) and #576 (SecureFileOps)

## Root Cause
The `SRSParser > parseFile` tests used a hardcoded `/tmp/architecture-generator-test` path. In sandboxed environments, writes to arbitrary `/tmp/` subdirectories are blocked with `EPERM: operation not permitted`.

## Changes
- Add `import * as os from 'os'` 
- Replace `const testDir = '/tmp/architecture-generator-test'` with `fs.mkdtempSync(path.join(os.tmpdir(), 'architecture-generator-test-'))`
- Replace `fs.unlinkSync(testFile)` cleanup with `fs.rmSync(testDir, { recursive: true, force: true })` for full directory cleanup

## Test Plan
- [x] All 59 architecture-generator tests pass (including 2 previously failing `parseFile` tests)
- [x] Sandbox-compatible — works with Claude Code sandbox restrictions