### PR TITLE
fix(agents): Add message history windowing and prior output aggregate limits

### DIFF
--- a/src/agents/AgentBridge.ts
+++ b/src/agents/AgentBridge.ts
@@ -69,6 +69,12 @@ export interface AgentRequest {
 
   /** Restrict which tools are available (by tool name) */
   allowedTools?: string[];
+
+  /** Number of recent turn-pairs to keep in message history (default: 3) */
+  historyWindowSize?: number;
+
+  /** Maximum aggregate bytes for prior stage outputs in user message (default: 50000) */
+  maxPriorOutputBytes?: number;
 }
 
 /**

--- a/src/agents/bridges/AnthropicApiBridge.ts
+++ b/src/agents/bridges/AnthropicApiBridge.ts
@@ -36,6 +36,12 @@ const DEFAULT_CALL_TIMEOUT_MS = 120_000;
 /** Maximum retry attempts for transient API errors */
 const MAX_API_RETRIES = 3;
 
+/** Default message history window: keep last 3 turn-pairs (assistant + tool_result) */
+const DEFAULT_HISTORY_WINDOW_SIZE = 3;
+
+/** Default aggregate size limit for prior stage outputs injected into the user message (50KB) */
+const DEFAULT_MAX_PRIOR_OUTPUT_BYTES = 50_000;
+
 /**
  * Rate limiter configuration for Anthropic API calls.
  */
@@ -163,6 +169,7 @@ export class AnthropicApiBridge implements AgentBridge {
     let totalOutputTokens = 0;
 
     const callTimeoutMs = request.timeoutMs ?? DEFAULT_CALL_TIMEOUT_MS;
+    const historyWindowSize = request.historyWindowSize ?? DEFAULT_HISTORY_WINDOW_SIZE;
 
     try {
       const typedClient = client as {
@@ -176,7 +183,7 @@ export class AnthropicApiBridge implements AgentBridge {
           model: modelId,
           max_tokens: maxTokens,
           system: systemPrompt,
-          messages,
+          messages: this.windowMessages(messages, historyWindowSize),
         };
         if (tools.length > 0) {
           createParams['tools'] = tools;
@@ -463,20 +470,70 @@ export class AnthropicApiBridge implements AgentBridge {
   }
 
   /**
+   * Window the message history to keep token costs bounded across multi-turn conversations.
+   * Always preserves the first user message (the task description).
+   * Returns the last windowSize turn-pairs plus the initial message.
+   */
+  private windowMessages(
+    messages: ConversationMessage[],
+    windowSize: number
+  ): ConversationMessage[] {
+    if (messages.length <= 1) return messages;
+    const firstMessage = messages[0] as ConversationMessage;
+    const recentMessages = messages.slice(1).slice(-(windowSize * 2));
+    return [firstMessage, ...recentMessages];
+  }
+
+  /**
+   * Build the prior stage outputs section with an aggregate size limit.
+   * Each stage's output is individually capped at 10KB; the aggregate is capped
+   * at maxAggregateBytes. Appends an omission notice if stages are excluded.
+   */
+  private buildPriorOutputContext(
+    priorOutputs: Record<string, string>,
+    maxAggregateBytes: number
+  ): string {
+    const entries = Object.entries(priorOutputs);
+    if (entries.length === 0) return '';
+
+    const stageParts: string[] = [];
+    let totalSize = 0;
+    let stagesAdded = 0;
+
+    for (const [stage, output] of entries) {
+      const truncated =
+        output.length > 10000 ? output.slice(0, 10000) + '\n... (truncated)' : output;
+      const chunk = `### ${stage}\n\`\`\`\n${truncated}\n\`\`\`\n`;
+
+      if (totalSize + chunk.length > maxAggregateBytes) {
+        const omitted = entries.length - stagesAdded;
+        stageParts.push(
+          `\n... (${String(omitted)} stage${omitted === 1 ? '' : 's'} omitted — aggregate output limit reached)`
+        );
+        break;
+      }
+
+      stageParts.push(chunk);
+      totalSize += chunk.length;
+      stagesAdded++;
+    }
+
+    return '\n## Prior Stage Outputs\n\n' + stageParts.join('\n');
+  }
+
+  /**
    * Build the user message from request input and prior stage outputs.
    */
   private buildUserMessage(request: AgentRequest): string {
     const parts = [request.input];
 
-    const priorEntries = Object.entries(request.priorStageOutputs);
-    if (priorEntries.length > 0) {
-      parts.push('\n## Prior Stage Outputs\n');
-      for (const [stage, output] of priorEntries) {
-        // Truncate large outputs to stay within token budget
-        const truncated =
-          output.length > 10000 ? output.slice(0, 10000) + '\n... (truncated)' : output;
-        parts.push(`### ${stage}\n\`\`\`\n${truncated}\n\`\`\`\n`);
-      }
+    const maxPriorOutputBytes = request.maxPriorOutputBytes ?? DEFAULT_MAX_PRIOR_OUTPUT_BYTES;
+    const priorContext = this.buildPriorOutputContext(
+      request.priorStageOutputs,
+      maxPriorOutputBytes
+    );
+    if (priorContext) {
+      parts.push(priorContext);
     }
 
     return parts.join('\n');

--- a/tests/agents/bridges/AnthropicApiBridge.test.ts
+++ b/tests/agents/bridges/AnthropicApiBridge.test.ts
@@ -606,4 +606,163 @@ describe('AnthropicApiBridge', () => {
       expect(bridge.supports('any-agent')).toBe(true);
     });
   });
+
+  describe('message history windowing', () => {
+    let tempDir: string;
+
+    beforeEach(async () => {
+      tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'bridge-window-'));
+      await fs.writeFile(path.join(tempDir, 'data.txt'), 'content\n', 'utf-8');
+    });
+
+    afterEach(async () => {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    });
+
+    it('should cap messages sent to API when window size is exceeded', async () => {
+      const bridge = new AnthropicApiBridge({
+        apiKey: 'test-key',
+        rateLimitConfig: { requestsPerMinute: 1000, minDelayMs: 0, maxConcurrent: 10 },
+      });
+      const sentMessageCounts: number[] = [];
+      let callCount = 0;
+
+      (bridge as unknown as Record<string, unknown>)['getClient'] = async () => ({
+        messages: {
+          create: async (params: Record<string, unknown>) => {
+            callCount++;
+            sentMessageCounts.push((params['messages'] as unknown[]).length);
+            if (callCount < 5) {
+              return {
+                content: [
+                  {
+                    type: 'tool_use',
+                    id: `tu_${callCount}`,
+                    name: 'read_file',
+                    input: { path: 'data.txt' },
+                  },
+                ],
+                stop_reason: 'tool_use',
+                usage: { input_tokens: 10, output_tokens: 10 },
+              };
+            }
+            return {
+              content: [{ type: 'text', text: 'done' }],
+              stop_reason: 'end_turn',
+              usage: { input_tokens: 10, output_tokens: 5 },
+            };
+          },
+        },
+      });
+
+      await bridge.execute(
+        createRequest({ projectDir: tempDir, historyWindowSize: 1, maxTurns: 5 })
+      );
+
+      // Turn 1: sent [user] = 1 message (window not yet applicable)
+      expect(sentMessageCounts[0]).toBe(1);
+      // Turn 2+: window=1 keeps [initial_user, last_assistant, last_tool_result] = 3 messages
+      for (const count of sentMessageCounts.slice(1)) {
+        expect(count).toBe(3);
+      }
+    });
+
+    it('should always preserve the first user message regardless of window size', async () => {
+      const bridge = new AnthropicApiBridge({
+        apiKey: 'test-key',
+        rateLimitConfig: { requestsPerMinute: 1000, minDelayMs: 0, maxConcurrent: 10 },
+      });
+      const firstRolesInEachCall: string[] = [];
+      let callCount = 0;
+
+      (bridge as unknown as Record<string, unknown>)['getClient'] = async () => ({
+        messages: {
+          create: async (params: Record<string, unknown>) => {
+            callCount++;
+            const msgs = params['messages'] as Array<{ role: string }>;
+            firstRolesInEachCall.push(msgs[0]?.role ?? '');
+            if (callCount === 1) {
+              return {
+                content: [
+                  { type: 'tool_use', id: 'tu_1', name: 'read_file', input: { path: 'data.txt' } },
+                ],
+                stop_reason: 'tool_use',
+                usage: { input_tokens: 10, output_tokens: 10 },
+              };
+            }
+            return {
+              content: [{ type: 'text', text: 'done' }],
+              stop_reason: 'end_turn',
+              usage: { input_tokens: 10, output_tokens: 5 },
+            };
+          },
+        },
+      });
+
+      await bridge.execute(createRequest({ projectDir: tempDir, historyWindowSize: 1 }));
+
+      expect(callCount).toBe(2);
+      for (const role of firstRolesInEachCall) {
+        expect(role).toBe('user');
+      }
+    });
+  });
+
+  describe('prior output aggregate limit', () => {
+    it('should omit stages that exceed the aggregate byte limit', () => {
+      const bridge = new AnthropicApiBridge({ apiKey: 'test-key' });
+      const buildMsg = (bridge as unknown as Record<string, unknown>)['buildUserMessage'] as (
+        req: AgentRequest
+      ) => string;
+
+      // 5 stages × ~10KB each; aggregate limit of 30KB — only first 2 should fit
+      const priorOutputs: Record<string, string> = {};
+      for (let i = 1; i <= 5; i++) {
+        priorOutputs[`stage_${i}`] = 'a'.repeat(15000);
+      }
+
+      const message = buildMsg.call(bridge, createRequest({ priorStageOutputs: priorOutputs, maxPriorOutputBytes: 30_000 }));
+
+      expect(message).toContain('stage_1');
+      expect(message).toContain('omitted');
+      expect(message).not.toContain('stage_5');
+    });
+
+    it('should include all stages when total is within aggregate limit', () => {
+      const bridge = new AnthropicApiBridge({ apiKey: 'test-key' });
+      const buildMsg = (bridge as unknown as Record<string, unknown>)['buildUserMessage'] as (
+        req: AgentRequest
+      ) => string;
+
+      const message = buildMsg.call(
+        bridge,
+        createRequest({
+          priorStageOutputs: { stage_a: 'small A', stage_b: 'small B' },
+          maxPriorOutputBytes: 50_000,
+        })
+      );
+
+      expect(message).toContain('stage_a');
+      expect(message).toContain('stage_b');
+      expect(message).not.toContain('omitted');
+    });
+
+    it('should use 50KB default aggregate limit when maxPriorOutputBytes is not set', () => {
+      const bridge = new AnthropicApiBridge({ apiKey: 'test-key' });
+      const buildMsg = (bridge as unknown as Record<string, unknown>)['buildUserMessage'] as (
+        req: AgentRequest
+      ) => string;
+
+      // 6 stages × 10KB each = ~60KB total → exceeds 50KB default
+      const priorOutputs: Record<string, string> = {};
+      for (let i = 1; i <= 6; i++) {
+        priorOutputs[`stage_${i}`] = 'b'.repeat(10000);
+      }
+
+      const message = buildMsg.call(bridge, createRequest({ priorStageOutputs: priorOutputs }));
+
+      expect(message).toContain('omitted');
+      expect(message).not.toContain('stage_6');
+    });
+  });
 });


### PR DESCRIPTION
Closes #585

## What

### Summary
Addresses unbounded memory growth in `AnthropicApiBridge` by introducing message history windowing and aggregate prior output limits.

### Change Type
- [x] Bugfix (fixes an issue)

### Affected Components
- `src/agents/AgentBridge.ts` — new `historyWindowSize` and `maxPriorOutputBytes` fields on `AgentRequest`
- `src/agents/bridges/AnthropicApiBridge.ts` — `windowMessages()` and `buildPriorOutputContext()` added

## Why

### Problem Solved
Without limits, a 15-stage pipeline with 10 turns per agent can send 150KB+ of prior context and 20+ messages per API call, causing 100x expected token cost growth.

### Related Issues
- Closes #585

## How

### Implementation Details
1. **Message windowing** (`windowMessages`): Keeps the last `historyWindowSize` turn-pairs (default: 3) plus the initial user message. The first message is always preserved to maintain task context.
2. **Aggregate prior output limit** (`buildPriorOutputContext`): Iterates stages in order, includes each up to its individual 10KB cap, and stops when the aggregate would exceed `maxPriorOutputBytes` (default: 50KB). Appends a count indicator for omitted stages.
3. Both limits are configurable via `AgentRequest` fields; defaults are backward-compatible.

### Testing Done
- [x] 5 new tests covering window boundary, first-message preservation, aggregate limit, within-limit pass-through, default 50KB cap
- [x] All 29 tests pass
- [x] TypeScript build clean
- [x] ESLint: 0 errors

### Test Plan
```
npm test tests/agents/bridges/AnthropicApiBridge.test.ts
```
All 29 tests should pass, including the new `message history windowing` and `prior output aggregate limit` describe blocks.

### Breaking Changes
None — new fields are optional with backward-compatible defaults.