### PR TITLE
fix(orchestrator): Enforce timeout cascade hierarchy in stage retry loop

### DIFF
--- a/src/ad-sdlc-orchestrator/AdsdlcOrchestratorAgent.ts
+++ b/src/ad-sdlc-orchestrator/AdsdlcOrchestratorAgent.ts
@@ -562,14 +562,22 @@ export class AdsdlcOrchestratorAgent implements IAgent {
     session: OrchestratorSession
   ): Promise<StageResult> {
     const maxRetries = this.config.maxRetries;
-    const timeoutMs = this.getTimeoutForStage(stage.name);
+    const stageTimeoutMs = this.getTimeoutForStage(stage.name);
+    const stageDeadline = Date.now() + stageTimeoutMs;
     let lastError: string | null = null;
 
     for (let attempt = 0; attempt <= maxRetries; attempt++) {
       const startTime = Date.now();
+      // Timeout cascade: inner attempt timeout must not exceed remaining stage budget
+      const remainingMs = stageDeadline - Date.now();
+      if (remainingMs <= 0) {
+        lastError = `Stage '${stage.name}' budget exhausted before attempt ${String(attempt + 1)}`;
+        break;
+      }
+      const attemptTimeoutMs = Math.min(remainingMs, stageTimeoutMs);
 
       try {
-        const output = await this.executeStageAgent(stage, session, timeoutMs);
+        const output = await this.executeStageAgent(stage, session, attemptTimeoutMs);
 
         return {
           name: stage.name,

--- a/src/ad-sdlc-orchestrator/types.ts
+++ b/src/ad-sdlc-orchestrator/types.ts
@@ -211,10 +211,15 @@ export interface PipelineRequest {
 }
 
 /**
- * Per-stage timeout configuration
+ * Per-stage timeout configuration.
+ *
+ * Timeout hierarchy invariant: API_CALL (120s) < STAGE (default 300s).
+ * The orchestrator enforces this by capping per-attempt timeout to
+ * the remaining stage budget, preventing retry cascades from exceeding
+ * the stage deadline.
  */
 export interface StageTimeoutConfig {
-  /** Default timeout for all stages in milliseconds */
+  /** Default timeout for all stages in milliseconds (must be > API call timeout) */
   readonly default: number;
   /** Per-stage timeout overrides */
   readonly overrides?: Readonly<Partial<Record<StageName, number>>>;


### PR DESCRIPTION
## Summary

Enforce timeout cascade hierarchy so that retry cascades (API_CALL x retries) cannot exceed the stage deadline.

Part of #590 (Phase 7: Operational Hardening)

## Why

Previously, 3 retries at 120s API timeout each could take 8 minutes against a 5-minute stage timeout:
- Stage timeout: 300s (5 min)
- API call timeout: 120s (2 min)
- Max retries: 3
- Worst case: 120s x 4 attempts = 480s > 300s stage budget

## What (Closes #594)

### Budget-aware retry in `executeStageWithRetry()`
- Calculate `stageDeadline = Date.now() + stageTimeoutMs` at retry loop start
- Before each attempt, compute `remainingMs = stageDeadline - Date.now()`
- If remaining budget <= 0, break immediately with budget exhaustion error
- Cap per-attempt timeout to `Math.min(remainingMs, stageTimeoutMs)`

### Documentation
- Added timeout hierarchy invariant documentation to `StageTimeoutConfig` interface

## Where

| File | Change |
|------|--------|
| `src/ad-sdlc-orchestrator/AdsdlcOrchestratorAgent.ts` | Budget-aware retry logic |
| `src/ad-sdlc-orchestrator/types.ts` | Timeout hierarchy documentation |

## How

### Test plan
- [x] `npx tsc --noEmit` — Compilation passes
- [x] `tests/ad-sdlc-orchestrator/` — 129/129 tests pass
- [x] Prettier formatting verified

Closes #594