### PR TITLE
test(modules): Add unit tests for repo-detector and schemas modules

### DIFF
--- a/tests/repo-detector/RepoDetector.test.ts
+++ b/tests/repo-detector/RepoDetector.test.ts
@@ -1,0 +1,793 @@
+/**
+ * Tests for RepoDetector module
+ *
+ * Tests repository detection logic, session management,
+ * error handling, and detection mode determination.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+
+// Mock the security module before importing RepoDetector
+const mockExecGitSync = vi.fn();
+const mockExecGhSync = vi.fn();
+const mockParseCommandString = vi.fn((cmd: string) => {
+  const parts = cmd.split(/\s+/);
+  return { command: parts[0], args: parts.slice(1) };
+});
+
+vi.mock('../../src/security/index.js', () => ({
+  getCommandSanitizer: () => ({
+    parseCommandString: mockParseCommandString,
+    execGitSync: mockExecGitSync,
+    execGhSync: mockExecGhSync,
+  }),
+}));
+
+// Mock the logging module
+vi.mock('../../src/logging/index.js', () => ({
+  getLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    child: () => ({
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    }),
+  }),
+}));
+
+import {
+  RepoDetector,
+  getRepoDetector,
+  resetRepoDetector,
+  REPO_DETECTOR_AGENT_ID,
+} from '../../src/repo-detector/RepoDetector.js';
+
+import {
+  RepoDetectorError,
+  ProjectNotFoundError,
+  NoActiveSessionError,
+  InvalidSessionStateError,
+  GitCommandError,
+  GitCommandTimeoutError,
+  GitHubAuthenticationError,
+  GitHubCommandError,
+  GitHubNotAccessibleError,
+  OutputWriteError,
+  DetectionTimeoutError,
+} from '../../src/repo-detector/errors.js';
+
+import {
+  DEFAULT_REPO_DETECTOR_CONFIG,
+  DEFAULT_TIMEOUT_CONFIG,
+  DEFAULT_GITHUB_CONFIG,
+  DEFAULT_DETECTION_CONFIG,
+} from '../../src/repo-detector/types.js';
+
+describe('RepoDetector', () => {
+  let tempDir: string;
+  let detector: RepoDetector;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'repo-detector-test-'));
+
+    resetRepoDetector();
+    vi.clearAllMocks();
+
+    detector = new RepoDetector();
+  });
+
+  afterEach(() => {
+    if (fs.existsSync(tempDir)) {
+      fs.rmSync(tempDir, { recursive: true });
+    }
+    resetRepoDetector();
+  });
+
+  /**
+   * Helper to create a .git directory inside tempDir
+   */
+  function createGitDir(): void {
+    fs.mkdirSync(path.join(tempDir, '.git'), { recursive: true });
+  }
+
+  /**
+   * Helper to set up standard git mock for an initialized repo with commits
+   */
+  function setupGitMockWithCommits(
+    options: {
+      branch?: string;
+      clean?: boolean;
+      remoteUrl?: string | null;
+    } = {}
+  ): void {
+    const { branch = 'main', clean = true, remoteUrl = null } = options;
+
+    mockExecGitSync.mockImplementation((args: string[]) => {
+      if (args.includes('HEAD') && args.includes('rev-parse') && !args.includes('--abbrev-ref')) {
+        return { success: true, stdout: 'abc123', stderr: '' };
+      }
+      if (args.includes('--abbrev-ref')) {
+        return { success: true, stdout: `${branch}\n`, stderr: '' };
+      }
+      if (args.includes('--porcelain')) {
+        const output = clean ? '' : 'M  src/file.ts\n?? new-file.ts\n';
+        return { success: true, stdout: output, stderr: '' };
+      }
+      if (args.includes('get-url')) {
+        if (remoteUrl) {
+          return { success: true, stdout: `${remoteUrl}\n`, stderr: '' };
+        }
+        return { success: false, stdout: '', stderr: 'fatal: No such remote' };
+      }
+      return { success: false, stdout: '', stderr: '' };
+    });
+  }
+
+  describe('Constructor and Configuration', () => {
+    it('should create instance with default configuration', () => {
+      const instance = new RepoDetector();
+      expect(instance).toBeInstanceOf(RepoDetector);
+      expect(instance.agentId).toBe(REPO_DETECTOR_AGENT_ID);
+      expect(instance.name).toBe('Repository Detector Agent');
+    });
+
+    it('should merge custom configuration with defaults', () => {
+      const customConfig = {
+        scratchpadBasePath: 'custom/scratchpad',
+        timeouts: { gitCommandMs: 3000, ghCommandMs: 8000 },
+      };
+      const instance = new RepoDetector(customConfig);
+      expect(instance).toBeInstanceOf(RepoDetector);
+    });
+
+    it('should handle partial timeout overrides', () => {
+      const instance = new RepoDetector({
+        timeouts: { gitCommandMs: 2000, ghCommandMs: DEFAULT_TIMEOUT_CONFIG.ghCommandMs },
+      });
+      expect(instance).toBeInstanceOf(RepoDetector);
+    });
+
+    it('should handle partial github config overrides', () => {
+      const instance = new RepoDetector({ github: { checkAuthentication: false } });
+      expect(instance).toBeInstanceOf(RepoDetector);
+    });
+
+    it('should handle partial detection config overrides', () => {
+      const instance = new RepoDetector({
+        detection: { requireCommits: true, requireCleanState: true },
+      });
+      expect(instance).toBeInstanceOf(RepoDetector);
+    });
+  });
+
+  describe('Agent ID', () => {
+    it('should have the correct agent ID constant', () => {
+      expect(REPO_DETECTOR_AGENT_ID).toBe('repo-detector-agent');
+    });
+  });
+
+  describe('Initialize and Dispose', () => {
+    it('should initialize successfully', async () => {
+      await expect(detector.initialize()).resolves.toBeUndefined();
+    });
+
+    it('should be idempotent on multiple initialize calls', async () => {
+      await detector.initialize();
+      await expect(detector.initialize()).resolves.toBeUndefined();
+    });
+
+    it('should dispose and clear session', async () => {
+      detector.startSession('test-project', tempDir);
+      expect(detector.getSession()).not.toBeNull();
+
+      await detector.dispose();
+      expect(detector.getSession()).toBeNull();
+    });
+
+    it('should allow re-initialization after dispose', async () => {
+      await detector.initialize();
+      await detector.dispose();
+      await expect(detector.initialize()).resolves.toBeUndefined();
+    });
+  });
+
+  describe('Singleton Pattern', () => {
+    it('should return same instance from getRepoDetector', () => {
+      const instance1 = getRepoDetector();
+      const instance2 = getRepoDetector();
+      expect(instance1).toBe(instance2);
+    });
+
+    it('should reset singleton with resetRepoDetector', () => {
+      const instance1 = getRepoDetector();
+      resetRepoDetector();
+      const instance2 = getRepoDetector();
+      expect(instance1).not.toBe(instance2);
+    });
+
+    it('should accept config on first getRepoDetector call', () => {
+      resetRepoDetector();
+      const instance = getRepoDetector({ scratchpadBasePath: 'custom' });
+      expect(instance).toBeInstanceOf(RepoDetector);
+    });
+  });
+
+  describe('Session Management', () => {
+    it('should start a new session', () => {
+      const session = detector.startSession('test-project', tempDir);
+
+      expect(session).toBeDefined();
+      expect(session.sessionId).toBeDefined();
+      expect(session.projectId).toBe('test-project');
+      expect(session.status).toBe('detecting');
+      expect(session.rootPath).toBe(tempDir);
+      expect(session.result).toBeNull();
+      expect(session.errors).toEqual([]);
+      expect(session.startedAt).toBeDefined();
+      expect(session.updatedAt).toBeDefined();
+    });
+
+    it('should return session via getSession', () => {
+      detector.startSession('test-project', tempDir);
+      const session = detector.getSession();
+
+      expect(session).not.toBeNull();
+      expect(session?.projectId).toBe('test-project');
+    });
+
+    it('should return null when no session exists', () => {
+      expect(detector.getSession()).toBeNull();
+    });
+
+    it('should replace existing session when starting a new one', () => {
+      const session1 = detector.startSession('project-1', tempDir);
+      const session2 = detector.startSession('project-2', tempDir);
+
+      expect(session1.sessionId).not.toBe(session2.sessionId);
+      expect(detector.getSession()?.projectId).toBe('project-2');
+    });
+  });
+
+  describe('Detection - No Git Repository', () => {
+    it('should detect new mode for directory without .git', async () => {
+      detector.startSession('test-project', tempDir);
+      mockExecGitSync.mockReturnValue({ success: false, stdout: '', stderr: 'not a git repo' });
+
+      const result = await detector.detect();
+
+      expect(result.mode).toBe('new');
+      expect(result.confidence).toBe(1.0);
+      expect(result.gitStatus.initialized).toBe(false);
+      expect(result.gitStatus.hasCommits).toBe(false);
+      expect(result.gitStatus.currentBranch).toBeNull();
+      expect(result.gitStatus.isClean).toBe(true);
+      expect(result.remoteStatus.configured).toBe(false);
+      expect(result.recommendation.skipRepoSetup).toBe(false);
+      expect(result.recommendation.reason).toContain('No Git repository found');
+    });
+  });
+
+  describe('Detection - Git Initialized Without Commits', () => {
+    it('should detect existing mode with low confidence for git without commits', async () => {
+      createGitDir();
+      detector.startSession('test-project', tempDir);
+
+      mockExecGitSync.mockImplementation((args: string[]) => {
+        if (args.includes('HEAD') && args.includes('rev-parse')) {
+          return { success: false, stdout: '', stderr: 'fatal: bad default revision' };
+        }
+        if (args.includes('--abbrev-ref')) {
+          return { success: false, stdout: '', stderr: 'fatal' };
+        }
+        if (args.includes('--porcelain')) {
+          return { success: true, stdout: '', stderr: '' };
+        }
+        if (args.includes('get-url')) {
+          return { success: false, stdout: '', stderr: 'fatal: No such remote' };
+        }
+        return { success: false, stdout: '', stderr: '' };
+      });
+
+      const result = await detector.detect();
+
+      expect(result.mode).toBe('existing');
+      expect(result.confidence).toBe(0.7);
+      expect(result.gitStatus.initialized).toBe(true);
+      expect(result.gitStatus.hasCommits).toBe(false);
+      expect(result.recommendation.skipRepoSetup).toBe(false);
+      expect(result.recommendation.reason).toContain('no commits found');
+    });
+  });
+
+  describe('Detection - Git With Commits But No Remote', () => {
+    it('should detect existing mode for git with commits but no remote', async () => {
+      createGitDir();
+      detector.startSession('test-project', tempDir);
+      setupGitMockWithCommits();
+
+      const result = await detector.detect();
+
+      expect(result.mode).toBe('existing');
+      expect(result.confidence).toBe(0.8);
+      expect(result.gitStatus.initialized).toBe(true);
+      expect(result.gitStatus.hasCommits).toBe(true);
+      expect(result.gitStatus.currentBranch).toBe('main');
+      expect(result.gitStatus.isClean).toBe(true);
+      expect(result.remoteStatus.configured).toBe(false);
+      expect(result.recommendation.skipRepoSetup).toBe(false);
+      expect(result.recommendation.reason).toContain('no remote configured');
+    });
+  });
+
+  describe('Detection - Non-GitHub Remote', () => {
+    it('should detect existing mode for GitLab remote', async () => {
+      createGitDir();
+      detector.startSession('test-project', tempDir);
+      setupGitMockWithCommits({ remoteUrl: 'https://gitlab.com/owner/repo.git' });
+
+      const result = await detector.detect();
+
+      expect(result.mode).toBe('existing');
+      expect(result.confidence).toBe(0.85);
+      expect(result.remoteStatus.configured).toBe(true);
+      expect(result.remoteStatus.remoteType).toBe('gitlab');
+      expect(result.recommendation.skipRepoSetup).toBe(true);
+      expect(result.recommendation.reason).toContain('Non-GitHub remote');
+    });
+
+    it('should detect Bitbucket remote type', async () => {
+      createGitDir();
+      detector.startSession('test-project', tempDir);
+      setupGitMockWithCommits({ remoteUrl: 'https://bitbucket.org/owner/repo.git' });
+
+      const result = await detector.detect();
+
+      expect(result.remoteStatus.remoteType).toBe('bitbucket');
+      expect(result.recommendation.skipRepoSetup).toBe(true);
+    });
+
+    it('should detect other remote type for unknown hosts', async () => {
+      createGitDir();
+      detector.startSession('test-project', tempDir);
+      setupGitMockWithCommits({ remoteUrl: 'https://selfhosted.example.com/owner/repo.git' });
+
+      const result = await detector.detect();
+
+      expect(result.remoteStatus.remoteType).toBe('other');
+    });
+  });
+
+  describe('Detection - GitHub Remote With gh CLI', () => {
+    it('should detect existing accessible GitHub repo via gh CLI', async () => {
+      createGitDir();
+      detector.startSession('test-project', tempDir);
+      setupGitMockWithCommits({ remoteUrl: 'https://github.com/owner/my-repo.git' });
+
+      mockExecGhSync.mockReturnValue({
+        success: true,
+        stdout: JSON.stringify({
+          name: 'my-repo',
+          owner: { login: 'owner' },
+          isPrivate: false,
+          defaultBranchRef: { name: 'main' },
+          url: 'https://github.com/owner/my-repo',
+        }),
+        stderr: '',
+      });
+
+      const result = await detector.detect();
+
+      expect(result.mode).toBe('existing');
+      expect(result.confidence).toBe(1.0);
+      expect(result.githubStatus.exists).toBe(true);
+      expect(result.githubStatus.accessible).toBe(true);
+      expect(result.githubStatus.owner).toBe('owner');
+      expect(result.githubStatus.name).toBe('my-repo');
+      expect(result.githubStatus.visibility).toBe('public');
+      expect(result.githubStatus.defaultBranch).toBe('main');
+      expect(result.recommendation.skipRepoSetup).toBe(true);
+    });
+
+    it('should detect private GitHub repo', async () => {
+      createGitDir();
+      detector.startSession('test-project', tempDir);
+      setupGitMockWithCommits({ remoteUrl: 'https://github.com/owner/private-repo.git' });
+
+      mockExecGhSync.mockReturnValue({
+        success: true,
+        stdout: JSON.stringify({
+          name: 'private-repo',
+          owner: { login: 'owner' },
+          isPrivate: true,
+          defaultBranchRef: { name: 'main' },
+          url: 'https://github.com/owner/private-repo',
+        }),
+        stderr: '',
+      });
+
+      const result = await detector.detect();
+
+      expect(result.githubStatus.visibility).toBe('private');
+    });
+  });
+
+  describe('Detection - GitHub Remote Without gh CLI Access', () => {
+    it('should fallback to URL parsing when gh CLI fails', async () => {
+      createGitDir();
+      detector.startSession('test-project', tempDir);
+      setupGitMockWithCommits({ remoteUrl: 'https://github.com/owner/my-repo.git' });
+
+      mockExecGhSync.mockReturnValue({
+        success: false,
+        stdout: '',
+        stderr: 'gh: not authenticated',
+      });
+
+      const result = await detector.detect();
+
+      expect(result.mode).toBe('existing');
+      expect(result.confidence).toBe(0.9);
+      expect(result.githubStatus.exists).toBe(true);
+      expect(result.githubStatus.accessible).toBe(false);
+      expect(result.githubStatus.owner).toBe('owner');
+      expect(result.githubStatus.name).toBe('my-repo');
+      expect(result.githubStatus.url).toBe('https://github.com/owner/my-repo');
+      expect(result.recommendation.skipRepoSetup).toBe(true);
+      expect(result.recommendation.reason).toContain('Verify accessibility');
+    });
+
+    it('should parse SSH GitHub URLs', async () => {
+      createGitDir();
+      detector.startSession('test-project', tempDir);
+      setupGitMockWithCommits({ remoteUrl: 'git@github.com:owner/my-repo.git' });
+
+      mockExecGhSync.mockReturnValue({
+        success: false,
+        stdout: '',
+        stderr: 'error',
+      });
+
+      const result = await detector.detect();
+
+      expect(result.githubStatus.exists).toBe(true);
+      expect(result.githubStatus.owner).toBe('owner');
+      expect(result.githubStatus.name).toBe('my-repo');
+    });
+  });
+
+  describe('Detection - Dirty Working Directory', () => {
+    it('should detect dirty working directory', async () => {
+      createGitDir();
+      detector.startSession('test-project', tempDir);
+      setupGitMockWithCommits({ branch: 'feature-branch', clean: false });
+
+      const result = await detector.detect();
+
+      expect(result.gitStatus.isClean).toBe(false);
+      expect(result.gitStatus.currentBranch).toBe('feature-branch');
+    });
+  });
+
+  describe('Detection - Error Handling', () => {
+    it('should reject when no active session', async () => {
+      await expect(detector.detect()).rejects.toThrow(NoActiveSessionError);
+    });
+
+    it('should reject when session is not in detecting state', async () => {
+      createGitDir();
+      detector.startSession('test-project', tempDir);
+      mockExecGitSync.mockReturnValue({ success: false, stdout: '', stderr: '' });
+
+      await detector.detect();
+      await expect(detector.detect()).rejects.toThrow(InvalidSessionStateError);
+    });
+
+    it('should reject when project path does not exist', async () => {
+      const nonExistentPath = path.join(tempDir, 'non-existent');
+      detector.startSession('test-project', nonExistentPath);
+
+      await expect(detector.detect()).rejects.toThrow(ProjectNotFoundError);
+    });
+
+    it('should set session status to failed on error', async () => {
+      const nonExistentPath = path.join(tempDir, 'non-existent');
+      detector.startSession('test-project', nonExistentPath);
+
+      try {
+        await detector.detect();
+      } catch {
+        // Expected
+      }
+
+      const session = detector.getSession();
+      expect(session?.status).toBe('failed');
+      expect(session?.errors.length).toBeGreaterThan(0);
+    });
+
+    it('should handle non-Error throw values', async () => {
+      const nonExistentPath = path.join(tempDir, 'non-existent');
+      detector.startSession('test-project', nonExistentPath);
+
+      await expect(detector.detect()).rejects.toBeInstanceOf(Error);
+    });
+  });
+
+  describe('Detection - Save Result', () => {
+    it('should save result to scratchpad on success', async () => {
+      detector.startSession('test-project', tempDir);
+      mockExecGitSync.mockReturnValue({ success: false, stdout: '', stderr: '' });
+
+      await detector.detect();
+
+      // Verify scratchpad file was created
+      const expectedDir = path.join(tempDir, '.ad-sdlc/scratchpad/repo/test-project');
+      const expectedFile = path.join(expectedDir, 'github_repo.yaml');
+      expect(fs.existsSync(expectedFile)).toBe(true);
+
+      const content = fs.readFileSync(expectedFile, 'utf-8');
+      expect(content).toContain('repository_detection');
+      expect(content).toContain('mode: new');
+    });
+
+    it('should throw OutputWriteError when save path is invalid', async () => {
+      // Use a config with a scratchpad path containing a null byte (always fails mkdirSync)
+      const badDetector = new RepoDetector({
+        scratchpadBasePath: 'path\x00with-null',
+      });
+      badDetector.startSession('test-project', tempDir);
+      mockExecGitSync.mockReturnValue({ success: false, stdout: '', stderr: '' });
+
+      await expect(badDetector.detect()).rejects.toThrow(OutputWriteError);
+    });
+  });
+
+  describe('Detection - Session Updates', () => {
+    it('should update session to completed on success', async () => {
+      detector.startSession('test-project', tempDir);
+      mockExecGitSync.mockReturnValue({ success: false, stdout: '', stderr: '' });
+
+      await detector.detect();
+
+      const session = detector.getSession();
+      expect(session?.status).toBe('completed');
+      expect(session?.result).not.toBeNull();
+      expect(session?.result?.detectedAt).toBeDefined();
+    });
+  });
+
+  describe('Detection - Git Command Exception Handling', () => {
+    it('should handle git rev-parse throwing exception', async () => {
+      createGitDir();
+      detector.startSession('test-project', tempDir);
+
+      mockExecGitSync.mockImplementation((args: string[]) => {
+        if (args.includes('HEAD') && args.includes('rev-parse') && !args.includes('--abbrev-ref')) {
+          throw new Error('git process error');
+        }
+        if (args.includes('--abbrev-ref')) {
+          throw new Error('git process error');
+        }
+        if (args.includes('--porcelain')) {
+          throw new Error('git process error');
+        }
+        if (args.includes('get-url')) {
+          return { success: false, stdout: '', stderr: '' };
+        }
+        return { success: false, stdout: '', stderr: '' };
+      });
+
+      const result = await detector.detect();
+
+      expect(result.gitStatus.initialized).toBe(true);
+      expect(result.gitStatus.hasCommits).toBe(false);
+      expect(result.gitStatus.currentBranch).toBeNull();
+      expect(result.gitStatus.isClean).toBe(true);
+    });
+
+    it('should handle remote get-url throwing exception', async () => {
+      createGitDir();
+      detector.startSession('test-project', tempDir);
+
+      mockExecGitSync.mockImplementation((args: string[]) => {
+        if (args.includes('HEAD') && args.includes('rev-parse') && !args.includes('--abbrev-ref')) {
+          return { success: true, stdout: 'abc123', stderr: '' };
+        }
+        if (args.includes('--abbrev-ref')) {
+          return { success: true, stdout: 'main\n', stderr: '' };
+        }
+        if (args.includes('--porcelain')) {
+          return { success: true, stdout: '', stderr: '' };
+        }
+        if (args.includes('get-url')) {
+          throw new Error('remote error');
+        }
+        return { success: false, stdout: '', stderr: '' };
+      });
+
+      const result = await detector.detect();
+
+      expect(result.remoteStatus.configured).toBe(false);
+      expect(result.remoteStatus.originUrl).toBeNull();
+    });
+  });
+});
+
+describe('RepoDetector Errors', () => {
+  describe('RepoDetectorError', () => {
+    it('should create base error with code and details', () => {
+      const error = new RepoDetectorError('Test error', 'TEST_CODE', { key: 'value' });
+
+      expect(error).toBeInstanceOf(Error);
+      expect(error.message).toBe('Test error');
+      expect(error.code).toBe('TEST_CODE');
+      expect(error.details).toEqual({ key: 'value' });
+      expect(error.name).toBe('RepoDetectorError');
+    });
+
+    it('should create error without details', () => {
+      const error = new RepoDetectorError('Test', 'CODE');
+      expect(error.details).toBeUndefined();
+    });
+  });
+
+  describe('ProjectNotFoundError', () => {
+    it('should include path in message', () => {
+      const error = new ProjectNotFoundError('/path/to/project');
+
+      expect(error.message).toContain('/path/to/project');
+      expect(error.code).toBe('PROJECT_NOT_FOUND');
+      expect(error.name).toBe('ProjectNotFoundError');
+      expect(error.details).toEqual({ path: '/path/to/project' });
+    });
+  });
+
+  describe('NoActiveSessionError', () => {
+    it('should have descriptive message', () => {
+      const error = new NoActiveSessionError();
+
+      expect(error.message).toContain('No active detection session');
+      expect(error.code).toBe('NO_ACTIVE_SESSION');
+      expect(error.name).toBe('NoActiveSessionError');
+    });
+  });
+
+  describe('InvalidSessionStateError', () => {
+    it('should include current and required status', () => {
+      const error = new InvalidSessionStateError('completed', 'detecting');
+
+      expect(error.message).toContain('completed');
+      expect(error.message).toContain('detecting');
+      expect(error.code).toBe('INVALID_SESSION_STATE');
+      expect(error.name).toBe('InvalidSessionStateError');
+      expect(error.details).toEqual({ currentStatus: 'completed', requiredStatus: 'detecting' });
+    });
+  });
+
+  describe('GitCommandError', () => {
+    it('should include command and message', () => {
+      const error = new GitCommandError('git status', 'failed', 128);
+
+      expect(error.message).toContain('git status');
+      expect(error.message).toContain('failed');
+      expect(error.code).toBe('GIT_COMMAND_ERROR');
+      expect(error.name).toBe('GitCommandError');
+      expect(error.details).toEqual({ command: 'git status', exitCode: 128 });
+    });
+
+    it('should work without exit code', () => {
+      const error = new GitCommandError('git status', 'failed');
+      expect(error.details).toEqual({ command: 'git status', exitCode: undefined });
+    });
+  });
+
+  describe('GitCommandTimeoutError', () => {
+    it('should include command and timeout', () => {
+      const error = new GitCommandTimeoutError('git fetch', 5000);
+
+      expect(error.message).toContain('git fetch');
+      expect(error.message).toContain('5000');
+      expect(error.code).toBe('GIT_COMMAND_TIMEOUT');
+      expect(error.name).toBe('GitCommandTimeoutError');
+    });
+  });
+
+  describe('GitHubAuthenticationError', () => {
+    it('should have auth-related message', () => {
+      const error = new GitHubAuthenticationError();
+
+      expect(error.message).toContain('not authenticated');
+      expect(error.code).toBe('GITHUB_AUTH_ERROR');
+      expect(error.name).toBe('GitHubAuthenticationError');
+    });
+  });
+
+  describe('GitHubCommandError', () => {
+    it('should include command details', () => {
+      const error = new GitHubCommandError('gh repo view', 'failed to query');
+
+      expect(error.message).toContain('gh repo view');
+      expect(error.code).toBe('GITHUB_COMMAND_ERROR');
+      expect(error.name).toBe('GitHubCommandError');
+    });
+  });
+
+  describe('GitHubNotAccessibleError', () => {
+    it('should include repo URL and reason', () => {
+      const error = new GitHubNotAccessibleError('https://github.com/owner/repo', 'Not authorized');
+
+      expect(error.message).toContain('https://github.com/owner/repo');
+      expect(error.message).toContain('Not authorized');
+      expect(error.code).toBe('GITHUB_NOT_ACCESSIBLE');
+      expect(error.name).toBe('GitHubNotAccessibleError');
+    });
+
+    it('should work without reason', () => {
+      const error = new GitHubNotAccessibleError('https://github.com/owner/repo');
+
+      expect(error.message).toContain('https://github.com/owner/repo');
+      expect(error.message).not.toContain(' - ');
+    });
+
+    it('should handle empty string reason', () => {
+      const error = new GitHubNotAccessibleError('https://github.com/owner/repo', '');
+      expect(error.message).not.toContain(' - ');
+    });
+  });
+
+  describe('OutputWriteError', () => {
+    it('should include path and cause', () => {
+      const cause = new Error('Permission denied');
+      const error = new OutputWriteError('/output/path', cause);
+
+      expect(error.message).toContain('/output/path');
+      expect(error.code).toBe('OUTPUT_WRITE_ERROR');
+      expect(error.name).toBe('OutputWriteError');
+      expect(error.details).toEqual({ path: '/output/path', cause });
+    });
+
+    it('should work without cause', () => {
+      const error = new OutputWriteError('/output/path');
+      expect(error.message).toContain('/output/path');
+    });
+  });
+
+  describe('DetectionTimeoutError', () => {
+    it('should include timeout value', () => {
+      const error = new DetectionTimeoutError(30000);
+
+      expect(error.message).toContain('30000');
+      expect(error.code).toBe('DETECTION_TIMEOUT');
+      expect(error.name).toBe('DetectionTimeoutError');
+    });
+  });
+});
+
+describe('RepoDetector Default Configuration', () => {
+  it('should have correct default timeout config', () => {
+    expect(DEFAULT_TIMEOUT_CONFIG.gitCommandMs).toBe(5000);
+    expect(DEFAULT_TIMEOUT_CONFIG.ghCommandMs).toBe(10000);
+  });
+
+  it('should have correct default GitHub config', () => {
+    expect(DEFAULT_GITHUB_CONFIG.checkAuthentication).toBe(true);
+  });
+
+  it('should have correct default detection config', () => {
+    expect(DEFAULT_DETECTION_CONFIG.requireCommits).toBe(false);
+    expect(DEFAULT_DETECTION_CONFIG.requireCleanState).toBe(false);
+  });
+
+  it('should have correct default combined config', () => {
+    expect(DEFAULT_REPO_DETECTOR_CONFIG.scratchpadBasePath).toBe('.ad-sdlc/scratchpad');
+    expect(DEFAULT_REPO_DETECTOR_CONFIG.timeouts).toEqual(DEFAULT_TIMEOUT_CONFIG);
+    expect(DEFAULT_REPO_DETECTOR_CONFIG.github).toEqual(DEFAULT_GITHUB_CONFIG);
+    expect(DEFAULT_REPO_DETECTOR_CONFIG.detection).toEqual(DEFAULT_DETECTION_CONFIG);
+  });
+});

--- a/tests/schemas/common.test.ts
+++ b/tests/schemas/common.test.ts
@@ -1,0 +1,664 @@
+/**
+ * Tests for common Zod schema definitions
+ *
+ * Validates runtime parsing behavior for package.json, file locks,
+ * dependency graphs, progress tracking, controller state, and log entries.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import {
+  PackageJsonPartialSchema,
+  PackageJsonVersionSchema,
+  FileLockSchema,
+  DependencyNodeSchema,
+  DependencyGraphSchema,
+  ProgressCheckpointSchema,
+  ProgressReportSchema,
+  IssueQueueSchema,
+  WorkerStatusSchema,
+  ControllerStateSchema,
+  LogEntrySchema,
+  AuditLogEntrySchema,
+  PriorityAnalysisSchema,
+} from '../../src/schemas/common.js';
+
+describe('PackageJsonPartialSchema', () => {
+  it('should accept a full package.json', () => {
+    const data = {
+      name: 'my-package',
+      version: '1.0.0',
+      description: 'A test package',
+      main: 'index.js',
+      scripts: { build: 'tsc', test: 'vitest' },
+      dependencies: { zod: '^3.0.0' },
+      devDependencies: { vitest: '^1.0.0' },
+      peerDependencies: { react: '>=18' },
+      engines: { node: '>=20' },
+      type: 'module',
+    };
+
+    const result = PackageJsonPartialSchema.safeParse(data);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.name).toBe('my-package');
+      expect(result.data.version).toBe('1.0.0');
+      expect(result.data.type).toBe('module');
+    }
+  });
+
+  it('should accept an empty object', () => {
+    const result = PackageJsonPartialSchema.safeParse({});
+    expect(result.success).toBe(true);
+  });
+
+  it('should accept object with only name', () => {
+    const result = PackageJsonPartialSchema.safeParse({ name: 'test' });
+    expect(result.success).toBe(true);
+  });
+
+  it('should accept unknown fields (loose mode)', () => {
+    const data = {
+      name: 'test',
+      customField: 'custom-value',
+      eslintConfig: { rules: {} },
+    };
+
+    const result = PackageJsonPartialSchema.safeParse(data);
+    expect(result.success).toBe(true);
+  });
+
+  it('should reject type values other than module or commonjs', () => {
+    const data = { type: 'invalid' };
+
+    const result = PackageJsonPartialSchema.safeParse(data);
+    expect(result.success).toBe(false);
+  });
+
+  it('should accept commonjs type', () => {
+    const result = PackageJsonPartialSchema.safeParse({ type: 'commonjs' });
+    expect(result.success).toBe(true);
+  });
+
+  it('should reject non-object input', () => {
+    expect(PackageJsonPartialSchema.safeParse(null).success).toBe(false);
+    expect(PackageJsonPartialSchema.safeParse(undefined).success).toBe(false);
+    expect(PackageJsonPartialSchema.safeParse('string').success).toBe(false);
+    expect(PackageJsonPartialSchema.safeParse(42).success).toBe(false);
+  });
+
+  it('should reject scripts with non-string values', () => {
+    const data = { scripts: { build: 123 } };
+    const result = PackageJsonPartialSchema.safeParse(data);
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('PackageJsonVersionSchema', () => {
+  it('should accept version string', () => {
+    const result = PackageJsonVersionSchema.safeParse({ version: '2.1.0' });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.version).toBe('2.1.0');
+    }
+  });
+
+  it('should accept empty object', () => {
+    const result = PackageJsonVersionSchema.safeParse({});
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.version).toBeUndefined();
+    }
+  });
+
+  it('should accept unknown fields (loose mode)', () => {
+    const result = PackageJsonVersionSchema.safeParse({ version: '1.0.0', name: 'test' });
+    expect(result.success).toBe(true);
+  });
+
+  it('should reject non-string version', () => {
+    const result = PackageJsonVersionSchema.safeParse({ version: 123 });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('FileLockSchema', () => {
+  it('should accept valid file lock', () => {
+    const data = {
+      lockedBy: 'agent-1',
+      lockedAt: '2026-01-01T00:00:00Z',
+      operation: 'write',
+    };
+
+    const result = FileLockSchema.safeParse(data);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.lockedBy).toBe('agent-1');
+      expect(result.data.operation).toBe('write');
+    }
+  });
+
+  it('should accept file lock with expiresAt', () => {
+    const data = {
+      lockedBy: 'agent-1',
+      lockedAt: '2026-01-01T00:00:00Z',
+      operation: 'write',
+      expiresAt: '2026-01-01T00:05:00Z',
+    };
+
+    const result = FileLockSchema.safeParse(data);
+    expect(result.success).toBe(true);
+  });
+
+  it('should reject missing required fields', () => {
+    expect(FileLockSchema.safeParse({}).success).toBe(false);
+    expect(FileLockSchema.safeParse({ lockedBy: 'agent' }).success).toBe(false);
+    expect(FileLockSchema.safeParse({ lockedBy: 'agent', lockedAt: 'now' }).success).toBe(false);
+  });
+
+  it('should reject non-string field values', () => {
+    const data = {
+      lockedBy: 123,
+      lockedAt: '2026-01-01T00:00:00Z',
+      operation: 'write',
+    };
+    expect(FileLockSchema.safeParse(data).success).toBe(false);
+  });
+});
+
+describe('DependencyNodeSchema', () => {
+  it('should accept minimal node', () => {
+    const result = DependencyNodeSchema.safeParse({ name: 'my-module' });
+    expect(result.success).toBe(true);
+  });
+
+  it('should accept full node', () => {
+    const data = {
+      name: 'my-module',
+      version: '1.0.0',
+      dependencies: ['dep-a', 'dep-b'],
+    };
+
+    const result = DependencyNodeSchema.safeParse(data);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.dependencies).toEqual(['dep-a', 'dep-b']);
+    }
+  });
+
+  it('should reject missing name', () => {
+    const result = DependencyNodeSchema.safeParse({ version: '1.0.0' });
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject non-string dependencies', () => {
+    const result = DependencyNodeSchema.safeParse({
+      name: 'test',
+      dependencies: [123],
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('DependencyGraphSchema', () => {
+  it('should accept empty graph', () => {
+    const result = DependencyGraphSchema.safeParse({});
+    expect(result.success).toBe(true);
+  });
+
+  it('should accept full graph', () => {
+    const data = {
+      nodes: {
+        'module-a': { name: 'module-a', version: '1.0.0', dependencies: ['module-b'] },
+        'module-b': { name: 'module-b', version: '2.0.0' },
+      },
+      edges: [{ from: 'module-a', to: 'module-b' }],
+      root: 'module-a',
+    };
+
+    const result = DependencyGraphSchema.safeParse(data);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.root).toBe('module-a');
+    }
+  });
+
+  it('should accept unknown fields (loose mode)', () => {
+    const result = DependencyGraphSchema.safeParse({ customField: true });
+    expect(result.success).toBe(true);
+  });
+
+  it('should reject invalid edge structure', () => {
+    const data = {
+      edges: [{ source: 'a', target: 'b' }],
+    };
+    const result = DependencyGraphSchema.safeParse(data);
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('ProgressCheckpointSchema', () => {
+  it('should accept minimal checkpoint', () => {
+    const data = {
+      orderId: 'WO-001',
+      issueId: 'ISS-001',
+      step: 'implementation',
+      lastUpdated: '2026-01-01T00:00:00Z',
+    };
+
+    const result = ProgressCheckpointSchema.safeParse(data);
+    expect(result.success).toBe(true);
+  });
+
+  it('should accept full checkpoint', () => {
+    const data = {
+      orderId: 'WO-001',
+      issueId: 'ISS-001',
+      step: 'testing',
+      completedSteps: ['implementation', 'lint'],
+      lastUpdated: '2026-01-01T00:00:00Z',
+      retryCount: 2,
+      error: 'Test failed',
+    };
+
+    const result = ProgressCheckpointSchema.safeParse(data);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.retryCount).toBe(2);
+    }
+  });
+
+  it('should reject missing required fields', () => {
+    const result = ProgressCheckpointSchema.safeParse({ orderId: 'WO-001' });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('ProgressReportSchema', () => {
+  it('should accept empty report', () => {
+    const result = ProgressReportSchema.safeParse({});
+    expect(result.success).toBe(true);
+  });
+
+  it('should accept full report', () => {
+    const data = {
+      sessionId: 'session-123',
+      projectId: 'project-1',
+      currentPhase: 'implementation',
+      progress: 0.75,
+      completedTasks: 3,
+      totalTasks: 4,
+      errors: ['warning: flaky test'],
+      lastUpdated: '2026-01-01T00:00:00Z',
+    };
+
+    const result = ProgressReportSchema.safeParse(data);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.progress).toBe(0.75);
+    }
+  });
+
+  it('should reject non-number progress', () => {
+    const result = ProgressReportSchema.safeParse({ progress: 'high' });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('IssueQueueSchema', () => {
+  it('should accept empty queue with defaults', () => {
+    const result = IssueQueueSchema.safeParse({});
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.pending).toEqual([]);
+      expect(result.data.inProgress).toEqual([]);
+      expect(result.data.completed).toEqual([]);
+      expect(result.data.blocked).toEqual([]);
+    }
+  });
+
+  it('should accept populated queue', () => {
+    const data = {
+      pending: ['ISS-001', 'ISS-002'],
+      inProgress: ['ISS-003'],
+      completed: ['ISS-004'],
+      blocked: [],
+    };
+
+    const result = IssueQueueSchema.safeParse(data);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.pending).toEqual(['ISS-001', 'ISS-002']);
+    }
+  });
+
+  it('should reject non-string array elements', () => {
+    const result = IssueQueueSchema.safeParse({ pending: [123] });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('WorkerStatusSchema', () => {
+  it('should accept valid worker status', () => {
+    const data = {
+      id: 'worker-1',
+      status: 'idle' as const,
+      currentIssue: null,
+      startedAt: null,
+    };
+
+    const result = WorkerStatusSchema.safeParse(data);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.completedTasks).toBe(0);
+    }
+  });
+
+  it('should accept working worker with issue', () => {
+    const data = {
+      id: 'worker-2',
+      status: 'working' as const,
+      currentIssue: 'ISS-001',
+      startedAt: '2026-01-01T00:00:00Z',
+      completedTasks: 5,
+    };
+
+    const result = WorkerStatusSchema.safeParse(data);
+    expect(result.success).toBe(true);
+  });
+
+  it('should accept error status', () => {
+    const data = {
+      id: 'worker-3',
+      status: 'error' as const,
+      currentIssue: null,
+      startedAt: null,
+    };
+
+    const result = WorkerStatusSchema.safeParse(data);
+    expect(result.success).toBe(true);
+  });
+
+  it('should reject invalid status value', () => {
+    const data = {
+      id: 'worker-1',
+      status: 'running',
+      currentIssue: null,
+      startedAt: null,
+    };
+    const result = WorkerStatusSchema.safeParse(data);
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject missing required fields', () => {
+    const result = WorkerStatusSchema.safeParse({ id: 'worker-1' });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('ControllerStateSchema', () => {
+  it('should accept valid controller state', () => {
+    const data = {
+      sessionId: 'session-1',
+      projectId: 'project-1',
+      currentPhase: 'implementation',
+      startedAt: '2026-01-01T00:00:00Z',
+      updatedAt: '2026-01-01T01:00:00Z',
+      queue: {},
+      totalIssues: 10,
+    };
+
+    const result = ControllerStateSchema.safeParse(data);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.completedIssues).toBe(0);
+      expect(result.data.failedIssues).toBe(0);
+      expect(result.data.workers).toEqual([]);
+    }
+  });
+
+  it('should accept full controller state', () => {
+    const data = {
+      schemaVersion: '1.0.0',
+      sessionId: 'session-1',
+      projectId: 'project-1',
+      currentPhase: 'review',
+      startedAt: '2026-01-01T00:00:00Z',
+      updatedAt: '2026-01-01T01:00:00Z',
+      queue: {
+        pending: ['ISS-001'],
+        inProgress: ['ISS-002'],
+        completed: ['ISS-003'],
+        blocked: [],
+      },
+      workers: [
+        {
+          id: 'worker-1',
+          status: 'working' as const,
+          currentIssue: 'ISS-002',
+          startedAt: '2026-01-01T00:30:00Z',
+          completedTasks: 1,
+        },
+      ],
+      totalIssues: 3,
+      completedIssues: 1,
+      failedIssues: 0,
+    };
+
+    const result = ControllerStateSchema.safeParse(data);
+    expect(result.success).toBe(true);
+  });
+
+  it('should reject missing required fields', () => {
+    const result = ControllerStateSchema.safeParse({
+      sessionId: 'session-1',
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('LogEntrySchema', () => {
+  it('should accept minimal log entry', () => {
+    const data = {
+      timestamp: '2026-01-01T00:00:00Z',
+      level: 'INFO' as const,
+      message: 'Operation completed',
+      correlationId: 'corr-123',
+    };
+
+    const result = LogEntrySchema.safeParse(data);
+    expect(result.success).toBe(true);
+  });
+
+  it('should accept full log entry', () => {
+    const data = {
+      timestamp: '2026-01-01T00:00:00Z',
+      level: 'ERROR' as const,
+      message: 'Operation failed',
+      correlationId: 'corr-123',
+      agent: 'worker-agent',
+      stage: 'implementation',
+      projectId: 'project-1',
+      durationMs: 1500,
+      context: { file: 'test.ts', line: 42 },
+      error: {
+        name: 'TypeError',
+        message: 'Cannot read property',
+        stack: 'TypeError: Cannot read property...',
+      },
+    };
+
+    const result = LogEntrySchema.safeParse(data);
+    expect(result.success).toBe(true);
+  });
+
+  it('should accept all log levels', () => {
+    const levels = ['DEBUG', 'INFO', 'WARN', 'ERROR'] as const;
+
+    for (const level of levels) {
+      const result = LogEntrySchema.safeParse({
+        timestamp: '2026-01-01T00:00:00Z',
+        level,
+        message: 'test',
+        correlationId: 'corr',
+      });
+      expect(result.success).toBe(true);
+    }
+  });
+
+  it('should reject invalid log level', () => {
+    const result = LogEntrySchema.safeParse({
+      timestamp: '2026-01-01T00:00:00Z',
+      level: 'TRACE',
+      message: 'test',
+      correlationId: 'corr',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject missing required fields', () => {
+    expect(LogEntrySchema.safeParse({}).success).toBe(false);
+    expect(LogEntrySchema.safeParse({ timestamp: 'now' }).success).toBe(false);
+  });
+});
+
+describe('AuditLogEntrySchema', () => {
+  it('should accept valid audit entry', () => {
+    const data = {
+      type: 'file_created' as const,
+      actor: 'worker-agent',
+      resource: '/src/component.ts',
+      action: 'create',
+      result: 'success' as const,
+      timestamp: '2026-01-01T00:00:00Z',
+      correlationId: 'corr-123',
+    };
+
+    const result = AuditLogEntrySchema.safeParse(data);
+    expect(result.success).toBe(true);
+  });
+
+  it('should accept all audit types', () => {
+    const types = [
+      'api_key_used',
+      'github_issue_created',
+      'github_pr_created',
+      'github_pr_merged',
+      'file_created',
+      'file_deleted',
+      'file_modified',
+      'secret_accessed',
+      'validation_failed',
+      'security_violation',
+    ] as const;
+
+    for (const type of types) {
+      const data = {
+        type,
+        actor: 'system',
+        resource: '/test',
+        action: 'test',
+        result: 'success' as const,
+        timestamp: '2026-01-01T00:00:00Z',
+        correlationId: 'corr',
+      };
+      expect(AuditLogEntrySchema.safeParse(data).success).toBe(true);
+    }
+  });
+
+  it('should accept all result values', () => {
+    const results = ['success', 'failure', 'blocked'] as const;
+
+    for (const result of results) {
+      const data = {
+        type: 'file_created' as const,
+        actor: 'system',
+        resource: '/test',
+        action: 'test',
+        result,
+        timestamp: '2026-01-01T00:00:00Z',
+        correlationId: 'corr',
+      };
+      expect(AuditLogEntrySchema.safeParse(data).success).toBe(true);
+    }
+  });
+
+  it('should accept optional details and sessionId', () => {
+    const data = {
+      type: 'secret_accessed' as const,
+      actor: 'admin',
+      resource: 'API_KEY',
+      action: 'read',
+      result: 'success' as const,
+      details: { ip: '127.0.0.1', userAgent: 'cli' },
+      timestamp: '2026-01-01T00:00:00Z',
+      correlationId: 'corr-123',
+      sessionId: 'session-456',
+    };
+
+    const result = AuditLogEntrySchema.safeParse(data);
+    expect(result.success).toBe(true);
+  });
+
+  it('should reject invalid type', () => {
+    const data = {
+      type: 'unknown_event',
+      actor: 'system',
+      resource: '/test',
+      action: 'test',
+      result: 'success',
+      timestamp: '2026-01-01T00:00:00Z',
+      correlationId: 'corr',
+    };
+    expect(AuditLogEntrySchema.safeParse(data).success).toBe(false);
+  });
+
+  it('should reject invalid result', () => {
+    const data = {
+      type: 'file_created',
+      actor: 'system',
+      resource: '/test',
+      action: 'test',
+      result: 'partial',
+      timestamp: '2026-01-01T00:00:00Z',
+      correlationId: 'corr',
+    };
+    expect(AuditLogEntrySchema.safeParse(data).success).toBe(false);
+  });
+});
+
+describe('PriorityAnalysisSchema', () => {
+  it('should accept empty analysis', () => {
+    const result = PriorityAnalysisSchema.safeParse({});
+    expect(result.success).toBe(true);
+  });
+
+  it('should accept full analysis', () => {
+    const data = {
+      issueId: 'ISS-001',
+      priority: 1,
+      score: 95.5,
+      factors: { complexity: 0.8, dependencies: 0.6 },
+      dependencies: ['ISS-002', 'ISS-003'],
+    };
+
+    const result = PriorityAnalysisSchema.safeParse(data);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.score).toBe(95.5);
+    }
+  });
+
+  it('should accept unknown fields (loose mode)', () => {
+    const result = PriorityAnalysisSchema.safeParse({
+      issueId: 'ISS-001',
+      customMetric: 42,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('should reject non-number priority', () => {
+    const result = PriorityAnalysisSchema.safeParse({ priority: 'high' });
+    expect(result.success).toBe(false);
+  });
+});

--- a/tests/schemas/github.test.ts
+++ b/tests/schemas/github.test.ts
@@ -1,0 +1,583 @@
+/**
+ * Tests for GitHub Zod schema definitions
+ *
+ * Validates runtime parsing behavior for GitHub API responses including
+ * PR data, merge info, reviews, checks, repository info, security audits,
+ * and workflow run data.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import {
+  GitHubPRDataSchema,
+  GitHubPRDataArraySchema,
+  GitHubMergeInfoSchema,
+  GitHubReviewSchema,
+  GitHubReviewsResponseSchema,
+  GitHubCheckResultSchema,
+  GitHubCheckResultArraySchema,
+  GitHubRepoInfoSchema,
+  SecurityAuditResultSchema,
+  GitHubRunDataSchema,
+} from '../../src/schemas/github.js';
+
+describe('GitHubPRDataSchema', () => {
+  const validPR = {
+    number: 42,
+    url: 'https://github.com/owner/repo/pull/42',
+    title: 'feat: add authentication',
+    headRefName: 'feature/auth',
+    baseRefName: 'main',
+    createdAt: '2026-01-01T00:00:00Z',
+    state: 'OPEN',
+  };
+
+  it('should accept valid PR data', () => {
+    const result = GitHubPRDataSchema.safeParse(validPR);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.number).toBe(42);
+      expect(result.data.title).toBe('feat: add authentication');
+      expect(result.data.state).toBe('OPEN');
+    }
+  });
+
+  it('should accept PR with statusCheckRollup', () => {
+    const data = {
+      ...validPR,
+      statusCheckRollup: [{ name: 'build', status: 'completed' }, { status: 'in_progress' }],
+    };
+
+    const result = GitHubPRDataSchema.safeParse(data);
+    expect(result.success).toBe(true);
+  });
+
+  it('should accept PR with reviews', () => {
+    const data = {
+      ...validPR,
+      reviews: [
+        { state: 'APPROVED', author: { login: 'reviewer1' } },
+        { state: 'CHANGES_REQUESTED' },
+        {},
+      ],
+    };
+
+    const result = GitHubPRDataSchema.safeParse(data);
+    expect(result.success).toBe(true);
+  });
+
+  it('should accept unknown fields (loose mode)', () => {
+    const data = {
+      ...validPR,
+      body: 'PR description',
+      labels: [{ name: 'enhancement' }],
+    };
+
+    const result = GitHubPRDataSchema.safeParse(data);
+    expect(result.success).toBe(true);
+  });
+
+  it('should reject missing required fields', () => {
+    expect(GitHubPRDataSchema.safeParse({}).success).toBe(false);
+    expect(GitHubPRDataSchema.safeParse({ number: 1 }).success).toBe(false);
+    expect(
+      GitHubPRDataSchema.safeParse({
+        number: 1,
+        url: 'url',
+        title: 'title',
+      }).success
+    ).toBe(false);
+  });
+
+  it('should reject non-number PR number', () => {
+    const data = { ...validPR, number: '42' };
+    expect(GitHubPRDataSchema.safeParse(data).success).toBe(false);
+  });
+
+  it('should reject non-object input', () => {
+    expect(GitHubPRDataSchema.safeParse(null).success).toBe(false);
+    expect(GitHubPRDataSchema.safeParse(undefined).success).toBe(false);
+    expect(GitHubPRDataSchema.safeParse('string').success).toBe(false);
+  });
+});
+
+describe('GitHubPRDataArraySchema', () => {
+  it('should accept array of valid PRs', () => {
+    const data = [
+      {
+        number: 1,
+        url: 'https://github.com/owner/repo/pull/1',
+        title: 'PR 1',
+        headRefName: 'branch-1',
+        baseRefName: 'main',
+        createdAt: '2026-01-01T00:00:00Z',
+        state: 'OPEN',
+      },
+      {
+        number: 2,
+        url: 'https://github.com/owner/repo/pull/2',
+        title: 'PR 2',
+        headRefName: 'branch-2',
+        baseRefName: 'main',
+        createdAt: '2026-01-02T00:00:00Z',
+        state: 'MERGED',
+      },
+    ];
+
+    const result = GitHubPRDataArraySchema.safeParse(data);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toHaveLength(2);
+    }
+  });
+
+  it('should accept empty array', () => {
+    const result = GitHubPRDataArraySchema.safeParse([]);
+    expect(result.success).toBe(true);
+  });
+
+  it('should reject non-array input', () => {
+    expect(GitHubPRDataArraySchema.safeParse({}).success).toBe(false);
+    expect(GitHubPRDataArraySchema.safeParse('string').success).toBe(false);
+  });
+
+  it('should reject array with invalid PR', () => {
+    const data = [{ number: 'not-a-number' }];
+    expect(GitHubPRDataArraySchema.safeParse(data).success).toBe(false);
+  });
+});
+
+describe('GitHubMergeInfoSchema', () => {
+  it('should accept valid merge info', () => {
+    const data = { mergeable: true };
+
+    const result = GitHubMergeInfoSchema.safeParse(data);
+    expect(result.success).toBe(true);
+  });
+
+  it('should accept null mergeable', () => {
+    const data = { mergeable: null };
+
+    const result = GitHubMergeInfoSchema.safeParse(data);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.mergeable).toBeNull();
+    }
+  });
+
+  it('should accept full merge info', () => {
+    const data = {
+      mergeable: true,
+      mergeableState: 'clean',
+      files: [
+        { filename: 'src/auth.ts', status: 'added' },
+        { filename: 'tests/auth.test.ts', status: 'added' },
+      ],
+    };
+
+    const result = GitHubMergeInfoSchema.safeParse(data);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.files).toHaveLength(2);
+    }
+  });
+
+  it('should accept unknown fields (loose mode)', () => {
+    const data = { mergeable: true, headRefOid: 'abc123' };
+
+    const result = GitHubMergeInfoSchema.safeParse(data);
+    expect(result.success).toBe(true);
+  });
+
+  it('should reject non-boolean mergeable', () => {
+    const result = GitHubMergeInfoSchema.safeParse({ mergeable: 'yes' });
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject files with missing required fields', () => {
+    const data = {
+      mergeable: true,
+      files: [{ filename: 'test.ts' }],
+    };
+    expect(GitHubMergeInfoSchema.safeParse(data).success).toBe(false);
+  });
+});
+
+describe('GitHubReviewSchema', () => {
+  it('should accept valid review', () => {
+    const data = {
+      author: { login: 'reviewer' },
+      state: 'APPROVED',
+      body: 'Looks good to me!',
+      submittedAt: '2026-01-01T00:00:00Z',
+    };
+
+    const result = GitHubReviewSchema.safeParse(data);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.author.login).toBe('reviewer');
+      expect(result.data.state).toBe('APPROVED');
+    }
+  });
+
+  it('should accept unknown fields (loose mode)', () => {
+    const data = {
+      author: { login: 'reviewer' },
+      state: 'APPROVED',
+      body: 'LGTM',
+      submittedAt: '2026-01-01T00:00:00Z',
+      id: 12345,
+    };
+
+    const result = GitHubReviewSchema.safeParse(data);
+    expect(result.success).toBe(true);
+  });
+
+  it('should reject missing author', () => {
+    const data = {
+      state: 'APPROVED',
+      body: 'LGTM',
+      submittedAt: '2026-01-01T00:00:00Z',
+    };
+    expect(GitHubReviewSchema.safeParse(data).success).toBe(false);
+  });
+
+  it('should reject missing state', () => {
+    const data = {
+      author: { login: 'reviewer' },
+      body: 'LGTM',
+      submittedAt: '2026-01-01T00:00:00Z',
+    };
+    expect(GitHubReviewSchema.safeParse(data).success).toBe(false);
+  });
+
+  it('should reject author without login', () => {
+    const data = {
+      author: {},
+      state: 'APPROVED',
+      body: 'LGTM',
+      submittedAt: '2026-01-01T00:00:00Z',
+    };
+    expect(GitHubReviewSchema.safeParse(data).success).toBe(false);
+  });
+});
+
+describe('GitHubReviewsResponseSchema', () => {
+  it('should accept response with reviews', () => {
+    const data = {
+      reviews: [
+        {
+          author: { login: 'reviewer1' },
+          state: 'APPROVED',
+          body: 'LGTM',
+          submittedAt: '2026-01-01T00:00:00Z',
+        },
+      ],
+    };
+
+    const result = GitHubReviewsResponseSchema.safeParse(data);
+    expect(result.success).toBe(true);
+  });
+
+  it('should accept response without reviews', () => {
+    const result = GitHubReviewsResponseSchema.safeParse({});
+    expect(result.success).toBe(true);
+  });
+
+  it('should accept empty reviews array', () => {
+    const result = GitHubReviewsResponseSchema.safeParse({ reviews: [] });
+    expect(result.success).toBe(true);
+  });
+});
+
+describe('GitHubCheckResultSchema', () => {
+  it('should accept valid check result', () => {
+    const data = { name: 'build', status: 'completed', conclusion: 'success' };
+
+    const result = GitHubCheckResultSchema.safeParse(data);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.name).toBe('build');
+      expect(result.data.conclusion).toBe('success');
+    }
+  });
+
+  it('should accept null conclusion', () => {
+    const data = { name: 'test', status: 'in_progress', conclusion: null };
+
+    const result = GitHubCheckResultSchema.safeParse(data);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.conclusion).toBeNull();
+    }
+  });
+
+  it('should accept without conclusion', () => {
+    const data = { name: 'test', status: 'queued' };
+
+    const result = GitHubCheckResultSchema.safeParse(data);
+    expect(result.success).toBe(true);
+  });
+
+  it('should accept unknown fields (loose mode)', () => {
+    const data = {
+      name: 'build',
+      status: 'completed',
+      conclusion: 'success',
+      detailsUrl: 'https://example.com',
+    };
+
+    const result = GitHubCheckResultSchema.safeParse(data);
+    expect(result.success).toBe(true);
+  });
+
+  it('should reject missing name', () => {
+    const result = GitHubCheckResultSchema.safeParse({ status: 'completed' });
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject missing status', () => {
+    const result = GitHubCheckResultSchema.safeParse({ name: 'build' });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('GitHubCheckResultArraySchema', () => {
+  it('should accept array of check results', () => {
+    const data = [
+      { name: 'build', status: 'completed', conclusion: 'success' },
+      { name: 'lint', status: 'completed', conclusion: 'failure' },
+    ];
+
+    const result = GitHubCheckResultArraySchema.safeParse(data);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toHaveLength(2);
+    }
+  });
+
+  it('should accept empty array', () => {
+    const result = GitHubCheckResultArraySchema.safeParse([]);
+    expect(result.success).toBe(true);
+  });
+});
+
+describe('GitHubRepoInfoSchema', () => {
+  it('should accept valid repo info', () => {
+    const data = { name: 'my-repo', owner: { login: 'owner' } };
+
+    const result = GitHubRepoInfoSchema.safeParse(data);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.name).toBe('my-repo');
+      expect(result.data.owner.login).toBe('owner');
+    }
+  });
+
+  it('should accept full repo info', () => {
+    const data = {
+      name: 'my-repo',
+      owner: { login: 'owner' },
+      isPrivate: true,
+      defaultBranchRef: { name: 'main' },
+      url: 'https://github.com/owner/my-repo',
+    };
+
+    const result = GitHubRepoInfoSchema.safeParse(data);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.isPrivate).toBe(true);
+      expect(result.data.defaultBranchRef?.name).toBe('main');
+    }
+  });
+
+  it('should accept null defaultBranchRef', () => {
+    const data = { name: 'empty-repo', owner: { login: 'owner' }, defaultBranchRef: null };
+
+    const result = GitHubRepoInfoSchema.safeParse(data);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.defaultBranchRef).toBeNull();
+    }
+  });
+
+  it('should accept public repo (isPrivate false)', () => {
+    const data = { name: 'public-repo', owner: { login: 'owner' }, isPrivate: false };
+
+    const result = GitHubRepoInfoSchema.safeParse(data);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.isPrivate).toBe(false);
+    }
+  });
+
+  it('should accept unknown fields (loose mode)', () => {
+    const data = {
+      name: 'my-repo',
+      owner: { login: 'owner' },
+      description: 'A test repo',
+      stargazerCount: 100,
+    };
+
+    const result = GitHubRepoInfoSchema.safeParse(data);
+    expect(result.success).toBe(true);
+  });
+
+  it('should reject missing name', () => {
+    const result = GitHubRepoInfoSchema.safeParse({ owner: { login: 'owner' } });
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject missing owner', () => {
+    const result = GitHubRepoInfoSchema.safeParse({ name: 'my-repo' });
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject owner without login', () => {
+    const result = GitHubRepoInfoSchema.safeParse({ name: 'my-repo', owner: {} });
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject non-object input', () => {
+    expect(GitHubRepoInfoSchema.safeParse(null).success).toBe(false);
+    expect(GitHubRepoInfoSchema.safeParse(undefined).success).toBe(false);
+    expect(GitHubRepoInfoSchema.safeParse('string').success).toBe(false);
+  });
+});
+
+describe('SecurityAuditResultSchema', () => {
+  it('should accept empty result', () => {
+    const result = SecurityAuditResultSchema.safeParse({});
+    expect(result.success).toBe(true);
+  });
+
+  it('should accept result with vulnerabilities', () => {
+    const data = {
+      vulnerabilities: { critical: 1, high: 3, moderate: 5, low: 10, info: 2 },
+    };
+
+    const result = SecurityAuditResultSchema.safeParse(data);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.vulnerabilities?.critical).toBe(1);
+      expect(result.data.vulnerabilities?.high).toBe(3);
+    }
+  });
+
+  it('should apply defaults for missing vulnerability counts', () => {
+    const data = { vulnerabilities: { critical: 2 } };
+
+    const result = SecurityAuditResultSchema.safeParse(data);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.vulnerabilities?.critical).toBe(2);
+      expect(result.data.vulnerabilities?.high).toBe(0);
+      expect(result.data.vulnerabilities?.moderate).toBe(0);
+      expect(result.data.vulnerabilities?.low).toBe(0);
+      expect(result.data.vulnerabilities?.info).toBe(0);
+    }
+  });
+
+  it('should accept unknown fields (loose mode)', () => {
+    const result = SecurityAuditResultSchema.safeParse({
+      vulnerabilities: { critical: 0 },
+      totalDependencies: 150,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('should reject non-number vulnerability counts', () => {
+    const data = { vulnerabilities: { critical: 'many' } };
+    expect(SecurityAuditResultSchema.safeParse(data).success).toBe(false);
+  });
+});
+
+describe('GitHubRunDataSchema', () => {
+  it('should accept minimal run data', () => {
+    const result = GitHubRunDataSchema.safeParse({});
+    expect(result.success).toBe(true);
+  });
+
+  it('should accept full run data', () => {
+    const data = {
+      conclusion: 'success',
+      status: 'completed',
+      jobs: [
+        {
+          name: 'build',
+          conclusion: 'success',
+          steps: [
+            { name: 'Checkout', conclusion: 'success' },
+            { name: 'Install', conclusion: 'success' },
+            { name: 'Build', conclusion: 'success' },
+          ],
+        },
+        {
+          name: 'test',
+          conclusion: 'failure',
+          steps: [
+            { name: 'Checkout', conclusion: 'success' },
+            { name: 'Test', conclusion: 'failure' },
+          ],
+        },
+      ],
+    };
+
+    const result = GitHubRunDataSchema.safeParse(data);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.conclusion).toBe('success');
+      expect(result.data.jobs).toHaveLength(2);
+    }
+  });
+
+  it('should accept null conclusion', () => {
+    const data = { conclusion: null, status: 'in_progress' };
+
+    const result = GitHubRunDataSchema.safeParse(data);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.conclusion).toBeNull();
+    }
+  });
+
+  it('should accept jobs without steps', () => {
+    const data = { jobs: [{ name: 'build', conclusion: 'success' }] };
+
+    const result = GitHubRunDataSchema.safeParse(data);
+    expect(result.success).toBe(true);
+  });
+
+  it('should accept jobs with null step conclusions', () => {
+    const data = {
+      jobs: [
+        {
+          name: 'build',
+          conclusion: null,
+          steps: [{ name: 'Running', conclusion: null }],
+        },
+      ],
+    };
+
+    const result = GitHubRunDataSchema.safeParse(data);
+    expect(result.success).toBe(true);
+  });
+
+  it('should accept unknown fields (loose mode)', () => {
+    const data = { conclusion: 'success', databaseId: 12345, workflowName: 'CI' };
+
+    const result = GitHubRunDataSchema.safeParse(data);
+    expect(result.success).toBe(true);
+  });
+
+  it('should reject jobs with missing name', () => {
+    const data = { jobs: [{ conclusion: 'success' }] };
+    expect(GitHubRunDataSchema.safeParse(data).success).toBe(false);
+  });
+
+  it('should reject non-object input', () => {
+    expect(GitHubRunDataSchema.safeParse(null).success).toBe(false);
+    expect(GitHubRunDataSchema.safeParse('string').success).toBe(false);
+    expect(GitHubRunDataSchema.safeParse(42).success).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Add comprehensive test suites for two previously untested modules.

Part of #590 (Phase 7: Operational Hardening)

## What (Closes #597)

| Test File | Tests | Coverage |
|-----------|-------|----------|
| `tests/repo-detector/RepoDetector.test.ts` | Repository detection, URL parsing, error handling | ~80%+ |
| `tests/schemas/common.test.ts` | Zod validation for common data structures | ~90%+ |
| `tests/schemas/github.test.ts` | GitHub-specific schema validation | ~90%+ |

**Total: 169 new tests across 3 files.**

## How

### Test plan
- [x] `npx vitest run tests/repo-detector tests/schemas` — 169/169 pass
- [x] No regressions in existing tests

Closes #597