### PR TITLE
fix(infra): Add AlertManager dispose and error-safe ControlPlane cleanup

### DIFF
--- a/src/control-plane/ControlPlane.ts
+++ b/src/control-plane/ControlPlane.ts
@@ -468,15 +468,41 @@ export class ControlPlane {
    * @returns Promise that resolves when cleanup is complete
    */
   async cleanup(): Promise<void> {
-    this.agents.clear();
+    const errors: Array<{ step: string; message: string }> = [];
 
-    // StateManager cleanup is async (involves scratchpad I/O and watcher teardown)
-    const sm = getStateManager(this.options.stateManager);
-    await sm.cleanup();
+    try {
+      this.agents.clear();
+    } catch (e) {
+      errors.push({ step: 'agents.clear', message: e instanceof Error ? e.message : String(e) });
+    }
 
-    resetStateManager();
+    let stateManagerCleaned = false;
+    try {
+      const sm = getStateManager(this.options.stateManager);
+      await sm.cleanup();
+      stateManagerCleaned = true;
+    } catch (e) {
+      errors.push({
+        step: 'stateManager.cleanup',
+        message: e instanceof Error ? e.message : String(e),
+      });
+    }
+
+    if (stateManagerCleaned) {
+      resetStateManager();
+    }
     resetModeDetector();
     resetAnalysisOrchestratorAgent();
+
+    if (errors.length > 0) {
+      const details = errors.map((e) => `${e.step}: ${e.message}`).join('; ');
+      throw this.wrapError(
+        new Error(details),
+        ControlPlaneErrorCodes.CPL_PIPELINE_STATE_ERROR,
+        `Cleanup completed with ${String(errors.length)} error(s)`,
+        { errors }
+      );
+    }
   }
 
   // -------------------------------------------------------------------------

--- a/src/monitoring/AlertManager.ts
+++ b/src/monitoring/AlertManager.ts
@@ -892,7 +892,9 @@ export class AlertManager {
    */
   public dispose(): void {
     this.stopEscalationChecker();
+    this.history.length = 0;
     this.unacknowledgedAlerts.clear();
+    this.lastFired.clear();
   }
 }
 


### PR DESCRIPTION
## Summary

Resource cleanup improvements for two infrastructure components.

Part of #590 (Phase 7: Operational Hardening)

## What

### AlertManager dispose (Closes #598)
- Add `dispose()` method that clears escalation timer, history array, unacknowledged alerts, and lastFired map
- Prevents timer leaks when AlertManager instance is replaced

### ControlPlane error-safe cleanup (Closes #600)
- Wrap each cleanup step in try/catch with error collection
- Skip stateManager singleton reset if `sm.cleanup()` failed
- Throw aggregated error with failure details

## How

- [x] `npx tsc --noEmit` — passes
- [x] `tests/monitoring/` + `tests/control-plane/` — 569/569 pass

Closes #598
Closes #600