### PR TITLE
fix(cli): Add runtime defense — global error handlers, API key validation, dep fallback

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -992,6 +992,17 @@ program
       }
     }
 
+    // Validate API credentials before starting (fail fast instead of mid-pipeline)
+    {
+      const preCheckRegistry = createDefaultBridgeRegistry();
+      if (preCheckRegistry.isStub('collector')) {
+        output.error(chalk.red('\n❌ No API credentials configured.'));
+        output.info(chalk.dim('Set ANTHROPIC_API_KEY or run inside a Claude Code session.'));
+        output.info(chalk.dim('Use --dry-run to validate configuration without execution.\n'));
+        process.exit(1);
+      }
+    }
+
     // Display pipeline info
     output.info(chalk.blue('\n🚀 AD-SDLC Pipeline Execution\n'));
     output.info(chalk.dim(`Mode: ${mode}`));
@@ -1104,6 +1115,21 @@ function formatPipelineStatus(status: string): string {
       return chalk.dim(status);
   }
 }
+
+// Global error handlers — catch async errors that escape command handlers
+process.on('uncaughtException', (error: Error) => {
+  output.error(`Fatal: Uncaught exception — ${error.message}`);
+  if (error.stack !== undefined) {
+    output.error(error.stack);
+  }
+  process.exit(1);
+});
+
+process.on('unhandledRejection', (reason: unknown) => {
+  const message = reason instanceof Error ? reason.message : String(reason);
+  output.error(`Fatal: Unhandled promise rejection — ${message}`);
+  process.exit(1);
+});
 
 // Parse command line arguments
 program.parse();

--- a/src/scratchpad/backends/RedisBackend.ts
+++ b/src/scratchpad/backends/RedisBackend.ts
@@ -210,8 +210,15 @@ export class RedisBackend implements IScratchpadBackend {
    */
   async initialize(): Promise<void> {
     try {
-      // Dynamic import of ioredis
-      const IoRedisModule = await import('ioredis');
+      // Dynamic import of ioredis (optional peer dependency)
+      let IoRedisModule;
+      try {
+        IoRedisModule = await import('ioredis');
+      } catch {
+        throw new Error(
+          'ioredis is required for Redis scratchpad backend. Install: npm install ioredis'
+        );
+      }
       const Redis =
         'default' in IoRedisModule
           ? (IoRedisModule.default as unknown as new (options: object) => RedisClient)

--- a/src/scratchpad/backends/SQLiteBackend.ts
+++ b/src/scratchpad/backends/SQLiteBackend.ts
@@ -81,8 +81,15 @@ export class SQLiteBackend implements IScratchpadBackend {
     const dir = path.dirname(this.dbPath);
     await fs.promises.mkdir(dir, { recursive: true });
 
-    // Dynamic import of better-sqlite3
-    const BetterSqlite3Module = await import('better-sqlite3');
+    // Dynamic import of better-sqlite3 (optional peer dependency)
+    let BetterSqlite3Module;
+    try {
+      BetterSqlite3Module = await import('better-sqlite3');
+    } catch {
+      throw new Error(
+        'better-sqlite3 is required for SQLite scratchpad backend. Install: npm install better-sqlite3'
+      );
+    }
     const BetterSqlite3 =
       'default' in BetterSqlite3Module ? BetterSqlite3Module.default : BetterSqlite3Module;
 


### PR DESCRIPTION
## Summary

Add three critical runtime defense patterns that prevent silent crashes and mid-pipeline failures.

Part of #612 (Phase 8: Production Hardening)

## What

### 1. Global error handlers (Closes #613)
- `process.on('uncaughtException')` — catches async errors that escape try-catch
- `process.on('unhandledRejection')` — catches unhandled promise rejections
- Both log error details before `process.exit(1)`

### 2. API credential pre-validation (Closes #614)
- Checks bridge availability **before** pipeline execution in `run` command
- Fails fast with clear instructions: "Set ANTHROPIC_API_KEY or run inside Claude Code"
- Eliminates the scenario where users wait 2+ minutes before discovering no API key

### 3. Optional dependency import protection (Closes #615)
- `better-sqlite3` import wrapped in try-catch with install instructions
- `ioredis` import wrapped in try-catch with install instructions
- RedisBackend already has fallback mechanism (fallbackConfig.enabled)

## Where

| File | Change |
|------|--------|
| `src/cli.ts` | Global handlers + API key check before `run` |
| `src/scratchpad/backends/SQLiteBackend.ts` | try-catch around import |
| `src/scratchpad/backends/RedisBackend.ts` | try-catch around import |

## How

- [x] `npx tsc --noEmit` — passes
- [x] `tests/scratchpad/` — 444 passed, 25 skipped (Redis)
- [x] `tests/ad-sdlc-orchestrator/` — all pass
- [x] Pre-commit hooks (ESLint + Prettier) passed

Closes #613
Closes #614
Closes #615