### PR TITLE
feat(collector): add multi-round investigation engine for pre-PRD elicitation

### DIFF
--- a/.ad-sdlc/config/workflow.yaml
+++ b/.ad-sdlc/config/workflow.yaml
@@ -44,6 +44,13 @@ global:
     # Import Pipeline stages
     issue_reading: false # After issue import
 
+  # Investigation Configuration (pre-PRD requirements elicitation)
+  investigation:
+    depth: standard # thorough | standard | quick
+    max_questions_per_round: 5 # 1-10 questions per investigation round
+    confidence_target: 0.85 # stop investigation when confidence reaches this threshold
+    early_exit_on_high_confidence: true
+
   # V&V (Verification & Validation) Configuration
   vnv:
     rigor: standard # strict | standard | minimal

--- a/.claude/agents/collector.md
+++ b/.claude/agents/collector.md
@@ -59,16 +59,17 @@ You are the Collector Agent responsible for gathering, analyzing, and structurin
 
 ### Input Sources
 
-| Source Type | Format | Description | Tool Used |
-|-------------|--------|-------------|-----------|
-| Natural Language | Text | Free-form user requirements description | Direct input |
-| Files | .md, .pdf, .docx, .txt | Document files containing requirements | Read |
-| URLs | HTTP/HTTPS | Web pages with relevant information | WebFetch |
-| Search | Query string | Web search for additional context | WebSearch |
+| Source Type      | Format                 | Description                             | Tool Used    |
+| ---------------- | ---------------------- | --------------------------------------- | ------------ |
+| Natural Language | Text                   | Free-form user requirements description | Direct input |
+| Files            | .md, .pdf, .docx, .txt | Document files containing requirements  | Read         |
+| URLs             | HTTP/HTTPS             | Web pages with relevant information     | WebFetch     |
+| Search           | Query string           | Web search for additional context       | WebSearch    |
 
 ### Expected Input Examples
 
 **Good Input (High Confidence)**:
+
 ```
 I need a task management system that allows users to create, edit, and delete tasks.
 Users should be able to assign priorities (P0-P3) to tasks.
@@ -78,6 +79,7 @@ Constraint: Must use PostgreSQL for data storage.
 ```
 
 **Poor Input (Low Confidence, needs clarification)**:
+
 ```
 Make me an app for tasks
 ```
@@ -86,16 +88,16 @@ Make me an app for tasks
 
 ### Output Files
 
-| File | Path | Format | Description |
-|------|------|--------|-------------|
-| Collected Info | `.ad-sdlc/scratchpad/info/{project_id}/collected_info.yaml` | YAML | Structured requirements |
-| Raw Inputs | `.ad-sdlc/scratchpad/info/{project_id}/raw/` | Various | Original input files |
+| File           | Path                                                        | Format  | Description             |
+| -------------- | ----------------------------------------------------------- | ------- | ----------------------- |
+| Collected Info | `.ad-sdlc/scratchpad/info/{project_id}/collected_info.yaml` | YAML    | Structured requirements |
+| Raw Inputs     | `.ad-sdlc/scratchpad/info/{project_id}/raw/`                | Various | Original input files    |
 
 ### Output Schema
 
 ```yaml
 schema:
-  version: "1.0"
+  version: '1.0'
   project_id: string
   created_at: datetime
   updated_at: datetime
@@ -104,37 +106,37 @@ schema:
 project:
   name: string
   description: string
-  version: "1.0.0"
+  version: '1.0.0'
 
 stakeholders:
   - name: string
     role: string
-    contact: string  # Optional
+    contact: string # Optional
 
 requirements:
   functional:
-    - id: "FR-XXX"
+    - id: 'FR-XXX'
       title: string
       description: string
       priority: P0 | P1 | P2 | P3
-      source: string  # Input source (user_input, file:path, url:uri)
+      source: string # Input source (user_input, file:path, url:uri)
       acceptance_criteria:
         - criterion: string
 
   non_functional:
-    - id: "NFR-XXX"
+    - id: 'NFR-XXX'
       category: performance | security | reliability | usability | maintainability
       description: string
-      metric: string  # Optional
-      target: string  # Optional
+      metric: string # Optional
+      target: string # Optional
 
 constraints:
-  - id: "CON-XXX"
+  - id: 'CON-XXX'
     description: string
     reason: string
 
 assumptions:
-  - id: "ASM-XXX"
+  - id: 'ASM-XXX'
     description: string
     risk_if_wrong: string
 
@@ -149,13 +151,13 @@ dependencies:
 
 questions:
   pending:
-    - id: "Q-XXX"
+    - id: 'Q-XXX'
       category: requirement | constraint | assumption | priority
       question: string
       context: string
       required: boolean
   resolved:
-    - id: "Q-XXX"
+    - id: 'Q-XXX'
       question: string
       answer: string
       answered_at: datetime
@@ -188,12 +190,14 @@ Write tool invocation:
 ```
 
 **IMPORTANT**:
+
 - DO NOT use `write_file` - this function does not exist
 - DO NOT use `writeFile` - this function does not exist
 - Always use the `Write` tool with `file_path` and `content` parameters
 - Always use absolute paths (starting with `/`)
 
 **Example for this agent**:
+
 ```
 Write(
   file_path: ".ad-sdlc/scratchpad/info/{project_id}/collected_info.yaml",
@@ -224,17 +228,27 @@ Write(
 |     +-- Calculate confidence score (0.0 - 1.0)               |
 |     +-- Identify gaps and ambiguities                        |
 |                                                              |
-|  5. CLARIFY (if confidence < 0.8)                            |
+|  5. INVESTIGATE (if depth != 'quick')                        |
+|     +-- Multi-round structured investigation                 |
+|     +-- Phase-based focus (vision, users, reqs, NFR, etc.)   |
+|     +-- 7 question formats: free_text, single_select,        |
+|     |   multi_select, yes_no, priority_ranking,              |
+|     |   confirmation, scale_rating                           |
+|     +-- LLM-generated questions with template fallback       |
+|     +-- Answers enrich extraction (priorities, NFRs, etc.)   |
+|     +-- Repeat until confidence target or max rounds         |
+|                                                              |
+|  6. CLARIFY (if remaining questions)                         |
 |     +-- Generate up to 5 clarifying questions                |
 |     +-- Wait for user responses                              |
 |     +-- Integrate answers and recalculate confidence         |
 |                                                              |
-|  6. FINALIZE                                                 |
+|  7. FINALIZE                                                 |
 |     +-- Validate all required fields                         |
 |     +-- Set status to 'completed'                            |
 |     +-- Save to collected_info.yaml                          |
 |                                                              |
-|  7. REPORT                                                   |
+|  8. REPORT                                                   |
 |     +-- Summarize what was collected                         |
 |     +-- List any remaining questions or gaps                 |
 |                                                              |
@@ -244,10 +258,18 @@ Write(
 ### State Transitions
 
 ```
-COLLECTING ──┬── confidence >= 0.8 ───▶ COMPLETED
-             │
-             └── confidence < 0.8 ────▶ CLARIFYING ──▶ COMPLETED
+                              ┌─── depth == 'quick' ──────────┐
+COLLECTING ──▶ INVESTIGATING ─┤                                ▼
+                              └─── rounds complete ──▶ CLARIFYING ──▶ COMPLETED
 ```
+
+### Investigation Depth Levels
+
+| Depth      | Phases                                                                                                                    | Max Rounds | Max Questions | Confidence Target |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------- | ---------- | ------------- | ----------------- |
+| `thorough` | project_vision → user_analysis → functional_deep_dive → nonfunctional_analysis → constraints_risks → validation_synthesis | 6          | 40            | 0.90              |
+| `standard` | core_discovery → requirements_analysis → constraints_validation                                                           | 3          | 20            | 0.80              |
+| `quick`    | basic_clarification (legacy behavior)                                                                                     | 1          | 5             | 0.70              |
 
 ## Clarification Guidelines
 
@@ -259,12 +281,12 @@ COLLECTING ──┬── confidence >= 0.8 ───▶ COMPLETED
 
 ### Question Categories
 
-| Category | When to Ask | Example |
-|----------|-------------|---------|
-| requirement | Missing acceptance criteria | "What are the acceptance criteria for user login?" |
-| constraint | Technology decisions unclear | "Is there a specific database you must use?" |
-| assumption | Unverified assumptions | "Should we assume mobile support is needed?" |
-| priority | Missing priority for critical features | "What is the priority for user authentication?" |
+| Category    | When to Ask                            | Example                                            |
+| ----------- | -------------------------------------- | -------------------------------------------------- |
+| requirement | Missing acceptance criteria            | "What are the acceptance criteria for user login?" |
+| constraint  | Technology decisions unclear           | "Is there a specific database you must use?"       |
+| assumption  | Unverified assumptions                 | "Should we assume mobile support is needed?"       |
+| priority    | Missing priority for critical features | "What is the priority for user authentication?"    |
 
 ### Question Generation Logic
 
@@ -280,7 +302,7 @@ function generateQuestions(info: CollectedInfo): ClarifyingQuestion[] {
         category: 'requirement',
         question: `What are the acceptance criteria for "${req.title}"?`,
         context: req.description,
-        required: false
+        required: false,
       });
     }
   }
@@ -293,7 +315,7 @@ function generateQuestions(info: CollectedInfo): ClarifyingQuestion[] {
         category: 'priority',
         question: `What is the priority (P0-P3) for "${req.title}"?`,
         context: req.description,
-        required: true
+        required: true,
       });
     }
   }
@@ -335,22 +357,22 @@ def evaluate_confidence(info: dict) -> float:
 
 ### Confidence Thresholds
 
-| Confidence | Status | Action |
-|------------|--------|--------|
-| >= 0.8 | High | Proceed to finalization |
-| 0.5 - 0.8 | Medium | Generate clarifying questions |
-| < 0.5 | Low | Request more information |
+| Confidence | Status | Action                        |
+| ---------- | ------ | ----------------------------- |
+| >= 0.8     | High   | Proceed to finalization       |
+| 0.5 - 0.8  | Medium | Generate clarifying questions |
+| < 0.5      | Low    | Request more information      |
 
 ## Error Handling
 
 ### Retry Behavior
 
-| Error Type | Retry Count | Backoff Strategy | Escalation |
-|------------|-------------|------------------|------------|
-| File Read Error | 3 | Exponential | Log and skip file |
-| URL Fetch Error | 3 | Exponential | Log and skip URL |
-| Parse Error | 2 | Linear | Log with details, continue |
-| Write Error | 3 | Exponential | Report to user |
+| Error Type      | Retry Count | Backoff Strategy | Escalation                 |
+| --------------- | ----------- | ---------------- | -------------------------- |
+| File Read Error | 3           | Exponential      | Log and skip file          |
+| URL Fetch Error | 3           | Exponential      | Log and skip URL           |
+| Parse Error     | 2           | Linear           | Log with details, continue |
+| Write Error     | 3           | Exponential      | Report to user             |
 
 ### Common Errors
 
@@ -385,6 +407,7 @@ def evaluate_confidence(info: dict) -> float:
 ### Example 1: Natural Language Input
 
 **Input**:
+
 ```
 I want to build a todo app where users can create tasks, set due dates,
 and mark them as complete. It should work on mobile devices and sync
@@ -392,54 +415,55 @@ across devices. Must use Firebase for backend.
 ```
 
 **Expected Output**:
+
 ```yaml
 project:
-  name: "Todo App"
-  description: "A cross-platform todo application with task management and cloud sync"
+  name: 'Todo App'
+  description: 'A cross-platform todo application with task management and cloud sync'
 
 requirements:
   functional:
-    - id: "FR-001"
-      title: "Task Creation"
-      description: "Users can create new tasks"
+    - id: 'FR-001'
+      title: 'Task Creation'
+      description: 'Users can create new tasks'
       priority: P0
-      source: "user_input"
+      source: 'user_input'
       acceptance_criteria:
-        - criterion: "User can add a new task with title"
-        - criterion: "User can optionally set due date"
-    - id: "FR-002"
-      title: "Due Date Setting"
-      description: "Users can set due dates for tasks"
+        - criterion: 'User can add a new task with title'
+        - criterion: 'User can optionally set due date'
+    - id: 'FR-002'
+      title: 'Due Date Setting'
+      description: 'Users can set due dates for tasks'
       priority: P1
-      source: "user_input"
-    - id: "FR-003"
-      title: "Task Completion"
-      description: "Users can mark tasks as complete"
+      source: 'user_input'
+    - id: 'FR-003'
+      title: 'Task Completion'
+      description: 'Users can mark tasks as complete'
       priority: P0
-      source: "user_input"
-    - id: "FR-004"
-      title: "Cross-device Sync"
-      description: "Tasks sync across all user devices"
+      source: 'user_input'
+    - id: 'FR-004'
+      title: 'Cross-device Sync'
+      description: 'Tasks sync across all user devices'
       priority: P1
-      source: "user_input"
+      source: 'user_input'
 
   non_functional:
-    - id: "NFR-001"
+    - id: 'NFR-001'
       category: usability
-      description: "Mobile-friendly interface"
-      metric: "Responsive design"
-      target: "Works on screens 320px and above"
+      description: 'Mobile-friendly interface'
+      metric: 'Responsive design'
+      target: 'Works on screens 320px and above'
 
 constraints:
-  - id: "CON-001"
-    description: "Must use Firebase for backend"
-    reason: "Specified by user"
+  - id: 'CON-001'
+    description: 'Must use Firebase for backend'
+    reason: 'Specified by user'
 
 dependencies:
   external:
-    - name: "Firebase"
+    - name: 'Firebase'
       type: service
-      version: "latest"
+      version: 'latest'
 ```
 
 ### Example 2: File-based Input
@@ -447,6 +471,7 @@ dependencies:
 **Input**: `requirements.md` containing feature list
 
 **Process**:
+
 1. Read file using `Read` tool
 2. Parse markdown structure
 3. Extract requirements from bullet points
@@ -457,23 +482,24 @@ dependencies:
 **Initial Input**: "Build a chat app"
 
 **Generated Questions**:
+
 ```yaml
 questions:
   pending:
-    - id: "Q-001"
+    - id: 'Q-001'
       category: requirement
-      question: "Should the chat support group conversations or only 1-on-1?"
-      context: "Chat functionality scope unclear"
+      question: 'Should the chat support group conversations or only 1-on-1?'
+      context: 'Chat functionality scope unclear'
       required: true
-    - id: "Q-002"
+    - id: 'Q-002'
       category: requirement
-      question: "Do you need file/image sharing in chat?"
-      context: "Media support not specified"
+      question: 'Do you need file/image sharing in chat?'
+      context: 'Media support not specified'
       required: false
-    - id: "Q-003"
+    - id: 'Q-003'
       category: constraint
-      question: "Are there any specific technology requirements (e.g., WebSocket, Firebase)?"
-      context: "Backend technology not specified"
+      question: 'Are there any specific technology requirements (e.g., WebSocket, Firebase)?'
+      context: 'Backend technology not specified'
       required: true
 ```
 
@@ -489,10 +515,10 @@ questions:
 
 ## Related Agents
 
-| Agent | Relationship | Data Exchange |
-|-------|--------------|---------------|
-| PRD Writer | Downstream | Receives collected_info.yaml |
-| Controller | Upstream | May receive instructions |
+| Agent      | Relationship | Data Exchange                |
+| ---------- | ------------ | ---------------------------- |
+| PRD Writer | Downstream   | Receives collected_info.yaml |
+| Controller | Upstream     | May receive instructions     |
 
 ## Notes
 

--- a/src/collector/CollectorAgent.ts
+++ b/src/collector/CollectorAgent.ts
@@ -35,6 +35,12 @@ import type {
 } from './types.js';
 import { ProjectInitError, MissingInformationError, SessionStateError } from './errors.js';
 import { getLogger } from '../logging/index.js';
+import { InvestigationEngine } from './InvestigationEngine.js';
+import type {
+  InvestigationRound,
+  InvestigationAnswer,
+  InvestigationState,
+} from './investigation-types.js';
 
 /**
  * Default configuration for CollectorAgent
@@ -47,6 +53,7 @@ const DEFAULT_CONFIG: Required<CollectorAgentConfig> = {
   defaultPriority: 'P2',
   detectLanguage: true,
   scratchpadBasePath: '.ad-sdlc/scratchpad',
+  investigationDepth: 'quick',
 };
 
 /**
@@ -66,6 +73,7 @@ export class CollectorAgent implements IAgent {
   private readonly inputParser: InputParser;
   private readonly extractor: InformationExtractor;
   private readonly llmExtractor: LLMExtractor | null;
+  private readonly investigationEngine: InvestigationEngine;
   private session: CollectionSession | null = null;
   private initialized = false;
 
@@ -82,17 +90,33 @@ export class CollectorAgent implements IAgent {
     this.inputParser = new InputParser(parserOptions);
     this.extractor = new InformationExtractor(extractorOptions);
 
-    if (bridge !== undefined && !this.isStubBridge(bridge)) {
-      this.llmExtractor = new LLMExtractor(bridge, this.extractor, this.config.scratchpadBasePath);
+    const effectiveBridge = bridge !== undefined && !this.isStubBridge(bridge) ? bridge : null;
+
+    if (effectiveBridge !== null) {
+      this.llmExtractor = new LLMExtractor(
+        effectiveBridge,
+        this.extractor,
+        this.config.scratchpadBasePath
+      );
     } else {
       this.llmExtractor = null;
     }
+
+    this.investigationEngine = new InvestigationEngine(
+      {
+        depth: this.config.investigationDepth,
+        maxQuestionsPerRound: this.config.maxQuestionsPerRound,
+        enableLLMQuestions: effectiveBridge !== null,
+      },
+      effectiveBridge
+    );
   }
 
   /**
    * Check if a bridge is a StubBridge (no-op fallback).
    * StubBridge always returns `true` from supports() and outputs start with "Stub execution".
    * We detect it by constructor name to avoid a hard import dependency.
+   * @param bridge
    */
   private isStubBridge(bridge: AgentBridge): boolean {
     return bridge.constructor.name === 'StubBridge';
@@ -467,6 +491,172 @@ export class CollectorAgent implements IAgent {
     return this.session;
   }
 
+  // ===========================================================================
+  // Investigation Methods
+  // ===========================================================================
+
+  /**
+   * Start the investigation phase after initial extraction.
+   * Transitions session to 'investigating' state and returns first round of questions.
+   *
+   * @returns The first investigation round with questions
+   */
+  public async startInvestigation(): Promise<InvestigationRound> {
+    if (this.session === null) {
+      throw new SessionStateError('no session', 'collecting', 'start investigation');
+    }
+
+    // Process inputs first if still in collecting state
+    if (this.session.status === 'collecting' && this.session.sources.length > 0) {
+      await this.processInputsAsync();
+    }
+
+    const currentSession = this.session;
+    // After processInputsAsync, status may be 'completed' or 'clarifying' — both are valid
+    // starting points for investigation. Only reject truly invalid states (e.g. already investigating).
+    if (currentSession.status === 'investigating') {
+      throw new SessionStateError(currentSession.status, 'collecting', 'start investigation');
+    }
+
+    this.investigationEngine.initialize(this.config.investigationDepth);
+    const round = await this.investigationEngine.generateNextRound(currentSession.extraction, []);
+
+    this.session = {
+      ...currentSession,
+      status: 'investigating',
+      investigation: this.investigationEngine.getState(),
+      updatedAt: new Date().toISOString(),
+    };
+
+    return round;
+  }
+
+  /**
+   * Submit answers for the current investigation round.
+   * Returns the next round of questions, or null if investigation is complete.
+   *
+   * @param answers - Answers for the current round
+   * @returns Next investigation round, or null if complete
+   */
+  public async submitInvestigationAnswers(
+    answers: readonly InvestigationAnswer[]
+  ): Promise<InvestigationRound | null> {
+    if (this.session === null || this.session.status !== 'investigating') {
+      throw new SessionStateError(
+        this.session?.status ?? 'no session',
+        'investigating',
+        'submit investigation answers'
+      );
+    }
+
+    const state = this.investigationEngine.getState();
+    this.investigationEngine.submitRoundAnswers(state.currentRound, answers);
+
+    // Enrich extraction with answers
+    const enrichedExtraction = this.investigationEngine.enrichExtraction(
+      this.session.extraction,
+      this.investigationEngine.getState()
+    );
+
+    // Check if investigation should end
+    if (this.investigationEngine.isComplete()) {
+      this.session = {
+        ...this.session,
+        extraction: enrichedExtraction,
+        investigation: this.investigationEngine.getState(),
+        pendingQuestions: enrichedExtraction.clarificationQuestions,
+        status: enrichedExtraction.clarificationQuestions.length > 0 ? 'clarifying' : 'completed',
+        updatedAt: new Date().toISOString(),
+      };
+      return null;
+    }
+
+    // Check early exit
+    if (this.investigationEngine.shouldEarlyExit(enrichedExtraction.overallConfidence)) {
+      this.investigationEngine.skipRemaining();
+      this.session = {
+        ...this.session,
+        extraction: enrichedExtraction,
+        investigation: this.investigationEngine.getState(),
+        pendingQuestions: enrichedExtraction.clarificationQuestions,
+        status: enrichedExtraction.clarificationQuestions.length > 0 ? 'clarifying' : 'completed',
+        updatedAt: new Date().toISOString(),
+      };
+      return null;
+    }
+
+    // Generate next round
+    const allAnswers = this.investigationEngine.getState().rounds.flatMap((r) => r.answers);
+    try {
+      const nextRound = await this.investigationEngine.generateNextRound(
+        enrichedExtraction,
+        allAnswers
+      );
+
+      this.session = {
+        ...this.session,
+        extraction: enrichedExtraction,
+        investigation: this.investigationEngine.getState(),
+        updatedAt: new Date().toISOString(),
+      };
+
+      return nextRound;
+    } catch {
+      // If no more rounds can be generated, investigation is complete
+      this.investigationEngine.skipRemaining();
+      this.session = {
+        ...this.session,
+        extraction: enrichedExtraction,
+        investigation: this.investigationEngine.getState(),
+        pendingQuestions: enrichedExtraction.clarificationQuestions,
+        status: enrichedExtraction.clarificationQuestions.length > 0 ? 'clarifying' : 'completed',
+        updatedAt: new Date().toISOString(),
+      };
+      return null;
+    }
+  }
+
+  /**
+   * Skip remaining investigation rounds and proceed to clarification/completion.
+   *
+   * @returns Updated session
+   */
+  public skipInvestigation(): CollectionSession {
+    if (this.session === null || this.session.status !== 'investigating') {
+      throw new SessionStateError(
+        this.session?.status ?? 'no session',
+        'investigating',
+        'skip investigation'
+      );
+    }
+
+    this.investigationEngine.skipRemaining();
+
+    // Enrich extraction with any answers collected so far
+    const enrichedExtraction = this.investigationEngine.enrichExtraction(
+      this.session.extraction,
+      this.investigationEngine.getState()
+    );
+
+    this.session = {
+      ...this.session,
+      extraction: enrichedExtraction,
+      investigation: this.investigationEngine.getState(),
+      pendingQuestions: enrichedExtraction.clarificationQuestions,
+      status: enrichedExtraction.clarificationQuestions.length > 0 ? 'clarifying' : 'completed',
+      updatedAt: new Date().toISOString(),
+    };
+
+    return this.session;
+  }
+
+  /**
+   * Get the current investigation state, or null if not investigating.
+   */
+  public getInvestigationState(): InvestigationState | null {
+    return this.session?.investigation ?? null;
+  }
+
   /**
    * Finalize collection and generate output
    *
@@ -487,6 +677,12 @@ export class CollectorAgent implements IAgent {
     if (currentSession.status === 'collecting' && currentSession.sources.length > 0) {
       await this.processInputsAsync();
       // Re-read session after processInputsAsync call since it updates this.session
+      currentSession = this.session;
+    }
+
+    // If still investigating, skip remaining investigation and enrich extraction
+    if (currentSession.status === 'investigating') {
+      this.skipInvestigation();
       currentSession = this.session;
     }
 
@@ -527,6 +723,9 @@ export class CollectorAgent implements IAgent {
       questionsAsked: extraction.clarificationQuestions.length,
       questionsAnswered: currentSession.answeredQuestions.length,
       processingTimeMs,
+      investigationRounds: currentSession.investigation?.rounds.length ?? 0,
+      investigationQuestionsAsked:
+        currentSession.investigation?.rounds.reduce((sum, r) => sum + r.questions.length, 0) ?? 0,
     };
 
     return {
@@ -643,6 +842,33 @@ export class CollectorAgent implements IAgent {
         extractedAt: s.extractedAt,
         summary: s.summary,
       })),
+      ...(session.investigation !== undefined
+        ? {
+            investigation: {
+              depth: session.investigation.depth,
+              roundsCompleted: session.investigation.rounds.filter(
+                (r) => r.completedAt !== undefined
+              ).length,
+              totalQuestions: session.investigation.rounds.reduce(
+                (sum, r) => sum + r.questions.length,
+                0
+              ),
+              totalAnswers: session.investigation.rounds.reduce(
+                (sum, r) => sum + r.answers.length,
+                0
+              ),
+              confidenceGain:
+                session.investigation.rounds.length > 0
+                  ? (session.investigation.rounds[session.investigation.rounds.length - 1]
+                      ?.confidenceAfter ?? 0) -
+                    (session.investigation.rounds[0]?.confidenceBefore ?? 0)
+                  : 0,
+              phasesCompleted: session.investigation.rounds
+                .filter((r) => r.completedAt !== undefined)
+                .map((r) => r.phase),
+            },
+          }
+        : {}),
       createdAt: session.startedAt,
       updatedAt: now,
       completedAt: now,
@@ -655,7 +881,9 @@ export class CollectorAgent implements IAgent {
    * @param expectedState - The expected state the session must be in to proceed
    * @returns The current session
    */
-  private ensureSession(expectedState: 'collecting' | 'clarifying'): CollectionSession {
+  private ensureSession(
+    expectedState: 'collecting' | 'investigating' | 'clarifying'
+  ): CollectionSession {
     if (this.session === null) {
       throw new SessionStateError('no session', expectedState, 'perform this action');
     }
@@ -666,6 +894,10 @@ export class CollectorAgent implements IAgent {
 
     if (expectedState === 'clarifying' && this.session.status !== 'clarifying') {
       throw new SessionStateError(this.session.status, expectedState, 'answer questions');
+    }
+
+    if (expectedState === 'investigating' && this.session.status !== 'investigating') {
+      throw new SessionStateError(this.session.status, expectedState, 'perform investigation');
     }
 
     return this.session;

--- a/src/collector/InvestigationEngine.ts
+++ b/src/collector/InvestigationEngine.ts
@@ -1,0 +1,837 @@
+/**
+ * InvestigationEngine — Multi-round structured investigation for requirements elicitation
+ *
+ * Manages investigation phases, generates questions (via LLM or templates),
+ * processes answers, and enriches the extraction result.
+ *
+ * @module collector/InvestigationEngine
+ */
+
+import { z } from 'zod';
+import type { AgentBridge } from '../agents/AgentBridge.js';
+import { getLogger } from '../logging/index.js';
+import type {
+  InvestigationDepth,
+  InvestigationPhase,
+  InvestigationQuestion,
+  InvestigationAnswer,
+  InvestigationRound,
+  InvestigationState,
+  InvestigationEngineConfig,
+  InvestigationPhaseConfig,
+} from './investigation-types.js';
+import {
+  getPhasesForDepth,
+  getMaxTotalQuestions,
+  isEarlyExitAllowed,
+  InvestigationQuestionFormatSchema,
+  InvestigationEngineConfigSchema,
+} from './investigation-types.js';
+import { InvestigationTemplates } from './InvestigationTemplates.js';
+import type {
+  ExtractionResult,
+  ExtractedRequirement,
+  ExtractedConstraint,
+  ExtractedAssumption,
+} from './types.js';
+import { InvestigationError } from './errors.js';
+
+// =============================================================================
+// LLM Response Schema
+// =============================================================================
+
+const LLMQuestionResponseSchema = z.object({
+  format: InvestigationQuestionFormatSchema,
+  question: z.string().min(5),
+  context: z.string().optional(),
+  options: z.array(z.string()).optional(),
+  scaleRange: z.tuple([z.number(), z.number()]).optional(),
+  scaleLabels: z.record(z.string(), z.string()).optional(),
+  required: z.boolean(),
+  category: z.string().optional(),
+});
+
+const LLMQuestionsArraySchema = z.array(LLMQuestionResponseSchema);
+
+// =============================================================================
+// InvestigationEngine
+// =============================================================================
+
+/**
+ * Multi-round investigation engine for structured requirements elicitation.
+ *
+ * Conducts phased investigation with configurable depth, generating
+ * context-aware questions via LLM or falling back to predefined templates.
+ */
+export class InvestigationEngine {
+  private readonly config: Required<InvestigationEngineConfig>;
+  private readonly bridge: AgentBridge | null;
+  private readonly templates: InvestigationTemplates;
+  private state: InvestigationState;
+  private questionCounter: number;
+  private totalQuestionsAsked: number;
+  private readonly maxTotalQuestions: number;
+
+  constructor(
+    config: Partial<InvestigationEngineConfig>,
+    bridge: AgentBridge | null,
+    templates?: InvestigationTemplates
+  ) {
+    const parsed = InvestigationEngineConfigSchema.parse(config);
+    this.config = {
+      depth: parsed.depth,
+      maxQuestionsPerRound: parsed.maxQuestionsPerRound,
+      confidenceTarget: parsed.confidenceTarget,
+      earlyExitOnHighConfidence: parsed.earlyExitOnHighConfidence,
+      enableLLMQuestions: parsed.enableLLMQuestions,
+    };
+    this.bridge = bridge;
+    this.templates = templates ?? new InvestigationTemplates();
+    this.questionCounter = 0;
+    this.totalQuestionsAsked = 0;
+    this.maxTotalQuestions = getMaxTotalQuestions(this.config.depth);
+
+    // Initialize default state
+    this.state = {
+      depth: this.config.depth,
+      currentRound: 0,
+      maxRounds: 0,
+      phases: [],
+      rounds: [],
+      status: 'pending',
+    };
+  }
+
+  // ===========================================================================
+  // Lifecycle
+  // ===========================================================================
+
+  /**
+   * Initialize investigation state for the configured depth.
+   * @param depth
+   */
+  public initialize(depth?: InvestigationDepth): InvestigationState {
+    const effectiveDepth = depth ?? this.config.depth;
+    const phaseConfigs = getPhasesForDepth(effectiveDepth);
+
+    this.state = {
+      depth: effectiveDepth,
+      currentRound: 0,
+      maxRounds: phaseConfigs.length,
+      phases: phaseConfigs.map((p) => p.phase),
+      rounds: [],
+      status: 'pending',
+      startedAt: new Date().toISOString(),
+    };
+
+    this.questionCounter = 0;
+    this.totalQuestionsAsked = 0;
+
+    return this.state;
+  }
+
+  /**
+   * Get current investigation state.
+   */
+  public getState(): InvestigationState {
+    return this.state;
+  }
+
+  /**
+   * Check if investigation is complete.
+   */
+  public isComplete(): boolean {
+    return this.state.status === 'completed' || this.state.status === 'skipped';
+  }
+
+  // ===========================================================================
+  // Round Management
+  // ===========================================================================
+
+  /**
+   * Generate questions for the next round based on current extraction.
+   * @param currentExtraction
+   * @param priorAnswers
+   */
+  public async generateNextRound(
+    currentExtraction: ExtractionResult,
+    priorAnswers: readonly InvestigationAnswer[]
+  ): Promise<InvestigationRound> {
+    if (this.isComplete()) {
+      throw new InvestigationError(
+        this.getCurrentPhaseName(),
+        this.state.currentRound,
+        'Investigation is already complete'
+      );
+    }
+
+    const nextRoundNumber = this.state.currentRound + 1;
+    const phaseIndex = nextRoundNumber - 1;
+
+    if (phaseIndex >= this.state.phases.length) {
+      this.completeInvestigation();
+      throw new InvestigationError('none', nextRoundNumber, 'All phases completed');
+    }
+
+    const phase = this.state.phases[phaseIndex];
+    if (phase === undefined) {
+      this.completeInvestigation();
+      throw new InvestigationError('none', nextRoundNumber, 'Phase not found');
+    }
+    const phaseConfig = getPhasesForDepth(this.state.depth).find((p) => p.phase === phase);
+    const maxQForPhase = Math.min(
+      phaseConfig?.maxQuestions ?? this.config.maxQuestionsPerRound,
+      this.maxTotalQuestions - this.totalQuestionsAsked
+    );
+
+    if (maxQForPhase <= 0) {
+      this.completeInvestigation();
+      throw new InvestigationError(phase, nextRoundNumber, 'Maximum total questions reached');
+    }
+
+    // Generate questions
+    let questions: InvestigationQuestion[];
+    if (this.config.enableLLMQuestions && this.bridge !== null) {
+      questions = await this.generateLLMQuestions(
+        phase,
+        currentExtraction,
+        priorAnswers,
+        maxQForPhase,
+        nextRoundNumber
+      );
+    } else {
+      questions = this.generateTemplateQuestions(
+        phase,
+        currentExtraction,
+        priorAnswers,
+        maxQForPhase,
+        nextRoundNumber
+      );
+    }
+
+    const round: InvestigationRound = {
+      roundNumber: nextRoundNumber,
+      phase,
+      questions,
+      answers: [],
+      startedAt: new Date().toISOString(),
+      confidenceBefore: currentExtraction.overallConfidence,
+    };
+
+    this.state = {
+      ...this.state,
+      currentRound: nextRoundNumber,
+      status: 'in_progress',
+      rounds: [...this.state.rounds, round],
+    };
+
+    this.totalQuestionsAsked += questions.length;
+
+    return round;
+  }
+
+  /**
+   * Submit answers for the current round.
+   * Returns updated state.
+   * @param roundNumber
+   * @param answers
+   */
+  public submitRoundAnswers(
+    roundNumber: number,
+    answers: readonly InvestigationAnswer[]
+  ): InvestigationState {
+    const roundIndex = this.state.rounds.findIndex((r) => r.roundNumber === roundNumber);
+    if (roundIndex === -1) {
+      throw new InvestigationError(
+        this.getCurrentPhaseName(),
+        roundNumber,
+        `Round ${String(roundNumber)} not found`
+      );
+    }
+
+    const existingRound = this.state.rounds[roundIndex];
+    if (existingRound === undefined) {
+      throw new InvestigationError(this.getCurrentPhaseName(), roundNumber, 'Round data missing');
+    }
+
+    const updatedRound: InvestigationRound = {
+      ...existingRound,
+      answers: [...answers],
+      completedAt: new Date().toISOString(),
+    };
+
+    const updatedRounds = [...this.state.rounds];
+    updatedRounds[roundIndex] = updatedRound;
+
+    // Check if all phases are done
+    const allPhasesDone = this.state.currentRound >= this.state.phases.length;
+
+    this.state = {
+      ...this.state,
+      rounds: updatedRounds,
+      status: allPhasesDone ? 'completed' : 'in_progress',
+      completedAt: allPhasesDone ? new Date().toISOString() : undefined,
+    };
+
+    return this.state;
+  }
+
+  /**
+   * Skip remaining investigation rounds.
+   */
+  public skipRemaining(): InvestigationState {
+    this.state = {
+      ...this.state,
+      status: 'skipped',
+      completedAt: new Date().toISOString(),
+    };
+    return this.state;
+  }
+
+  /**
+   * Check if early exit is appropriate based on current confidence.
+   * @param currentConfidence
+   */
+  public shouldEarlyExit(currentConfidence: number): boolean {
+    if (!this.config.earlyExitOnHighConfidence) {
+      return false;
+    }
+    if (!isEarlyExitAllowed(this.state.depth)) {
+      return false;
+    }
+    return currentConfidence >= this.config.confidenceTarget;
+  }
+
+  // ===========================================================================
+  // Question Generation - LLM
+  // ===========================================================================
+
+  private async generateLLMQuestions(
+    phase: InvestigationPhase,
+    extraction: ExtractionResult,
+    priorAnswers: readonly InvestigationAnswer[],
+    maxQuestions: number,
+    roundNumber: number
+  ): Promise<InvestigationQuestion[]> {
+    try {
+      const prompt = this.buildLLMPrompt(phase, extraction, priorAnswers, maxQuestions);
+
+      if (this.bridge === null) {
+        return this.generateTemplateQuestions(
+          phase,
+          extraction,
+          priorAnswers,
+          maxQuestions,
+          roundNumber
+        );
+      }
+
+      const response = await this.bridge.execute({
+        agentType: 'collector',
+        input: prompt,
+        scratchpadDir: '',
+        projectDir: '',
+        priorStageOutputs: {},
+      });
+
+      if (!response.success) {
+        getLogger().warn('LLM question generation unsuccessful, falling back to templates', {
+          agent: 'InvestigationEngine',
+          phase,
+        });
+        return this.generateTemplateQuestions(
+          phase,
+          extraction,
+          priorAnswers,
+          maxQuestions,
+          roundNumber
+        );
+      }
+
+      return this.parseLLMQuestions(response.output, phase, roundNumber);
+    } catch (error) {
+      getLogger().warn('LLM question generation failed, falling back to templates', {
+        agent: 'InvestigationEngine',
+        phase,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return this.generateTemplateQuestions(
+        phase,
+        extraction,
+        priorAnswers,
+        maxQuestions,
+        roundNumber
+      );
+    }
+  }
+
+  private buildLLMPrompt(
+    phase: InvestigationPhase,
+    extraction: ExtractionResult,
+    priorAnswers: readonly InvestigationAnswer[],
+    maxQuestions: number
+  ): string {
+    const phaseConfig = this.getPhaseConfig(phase);
+    const phaseDesc = phaseConfig?.description ?? phase;
+    const focusAreas = phaseConfig?.focusAreas.join(', ') ?? '';
+
+    const frCount = String(extraction.functionalRequirements.length);
+    const nfrCount = String(extraction.nonFunctionalRequirements.length);
+    const conCount = String(extraction.constraints.length);
+    const asmCount = String(extraction.assumptions.length);
+    const confidence = String(Math.round(extraction.overallConfidence * 100));
+
+    const qaHistory =
+      priorAnswers.length > 0
+        ? priorAnswers.map((a) => `Q[${a.questionId}]: ${a.answer}`).join('\n')
+        : 'No prior Q&A history.';
+
+    return `You are an expert requirements analyst conducting a structured investigation.
+Current phase: "${phase}" — ${phaseDesc}
+Focus areas: ${focusAreas}
+
+CURRENT EXTRACTION STATE:
+- Project: ${extraction.projectName ?? 'NOT DETECTED'} — ${extraction.projectDescription ?? 'NOT DETECTED'}
+- Functional requirements: ${frCount} (confidence: ${confidence}%)
+- Non-functional requirements: ${nfrCount}
+- Constraints: ${conCount}, Assumptions: ${asmCount}
+
+PRIOR Q&A HISTORY:
+${qaHistory}
+
+Generate ${String(maxQuestions)} investigation questions for this phase.
+Return a JSON array of objects with this shape:
+[
+  {
+    "format": "free_text|single_select|multi_select|yes_no|priority_ranking|confirmation|scale_rating",
+    "question": "The question text",
+    "context": "Why this question matters",
+    "options": ["opt1", "opt2"],
+    "required": true,
+    "category": "requirement|constraint|assumption|priority|scope|architecture|stakeholder|timeline|quality|risk"
+  }
+]
+
+Rules:
+- Use format types: free_text, single_select, multi_select, yes_no, priority_ranking, confirmation, scale_rating
+- Provide "options" for select/ranking formats
+- Questions should be specific to gaps in current extraction
+- Do not repeat questions already answered
+- Focus on information GAPS in current extraction`;
+  }
+
+  private parseLLMQuestions(
+    output: string,
+    phase: InvestigationPhase,
+    roundNumber: number
+  ): InvestigationQuestion[] {
+    const jsonMatch = output.match(/\[[\s\S]*\]/);
+    if (jsonMatch === null) {
+      throw new Error('No JSON array found in LLM output');
+    }
+
+    const parsed: unknown = JSON.parse(jsonMatch[0]);
+    const validated = LLMQuestionsArraySchema.parse(parsed);
+
+    return validated.map((q) => {
+      this.questionCounter++;
+      const qId = `IQ-LLM-${String(this.questionCounter).padStart(3, '0')}`;
+
+      return {
+        id: qId,
+        phase,
+        round: roundNumber,
+        format: q.format,
+        question: q.question,
+        context: q.context ?? '',
+        options: q.options,
+        scaleRange:
+          q.scaleRange !== undefined
+            ? {
+                min: q.scaleRange[0],
+                max: q.scaleRange[1],
+                labels:
+                  q.scaleLabels !== undefined
+                    ? { min: q.scaleLabels['min'] ?? '', max: q.scaleLabels['max'] ?? '' }
+                    : undefined,
+              }
+            : undefined,
+        required: q.required,
+        relatedTo: undefined,
+        category:
+          q.category !== undefined
+            ? (q.category as InvestigationQuestion['category'])
+            : 'requirement',
+      };
+    });
+  }
+
+  // ===========================================================================
+  // Question Generation - Templates
+  // ===========================================================================
+
+  private generateTemplateQuestions(
+    phase: InvestigationPhase,
+    extraction: ExtractionResult,
+    _priorAnswers: readonly InvestigationAnswer[],
+    maxQuestions: number,
+    roundNumber: number
+  ): InvestigationQuestion[] {
+    // Collect tags from already-completed rounds
+    const alreadyAskedTags: string[] = [];
+    for (const round of this.state.rounds) {
+      // Get tags from the templates that were used
+      const phaseTags = this.templates.getTagsForPhases([round.phase]);
+      alreadyAskedTags.push(...phaseTags);
+    }
+
+    const selectedTemplates = this.templates.getTemplatesForPhase(
+      phase,
+      extraction,
+      alreadyAskedTags,
+      maxQuestions
+    );
+
+    return selectedTemplates.map((template) => {
+      this.questionCounter++;
+      const qId = `IQ-TPL-${String(this.questionCounter).padStart(3, '0')}`;
+      return this.templates.templateToQuestion(template, extraction, qId, roundNumber);
+    });
+  }
+
+  // ===========================================================================
+  // Extraction Enrichment
+  // ===========================================================================
+
+  /**
+   * Merge investigation answers back into ExtractionResult.
+   *
+   * Each answer format is processed differently:
+   * - free_text: stored as-is, may become additional requirements
+   * - single_select/multi_select: mapped to fields
+   * - yes_no: boolean field updates
+   * - priority_ranking: requirement priority reassignment
+   * - confirmation: confidence adjustments
+   * - scale_rating: NFR generation
+   * @param extraction
+   * @param state
+   */
+  public enrichExtraction(
+    extraction: ExtractionResult,
+    state: InvestigationState
+  ): ExtractionResult {
+    let enriched = { ...extraction };
+
+    for (const round of state.rounds) {
+      for (const answer of round.answers) {
+        const question = round.questions.find((q) => q.id === answer.questionId);
+        if (question === undefined) {
+          continue;
+        }
+        enriched = this.applyAnswer(enriched, question, answer);
+      }
+    }
+
+    // Recalculate overall confidence
+    enriched = {
+      ...enriched,
+      overallConfidence: this.recalculateConfidence(enriched),
+    };
+
+    return enriched;
+  }
+
+  private applyAnswer(
+    extraction: ExtractionResult,
+    question: InvestigationQuestion,
+    answer: InvestigationAnswer
+  ): ExtractionResult {
+    switch (question.format) {
+      case 'free_text':
+        return this.applyFreeTextAnswer(extraction, question, answer);
+      case 'single_select':
+        return this.applySingleSelectAnswer(extraction, question, answer);
+      case 'multi_select':
+        return this.applyMultiSelectAnswer(extraction, question, answer);
+      case 'yes_no':
+        return this.applyYesNoAnswer(extraction, question, answer);
+      case 'priority_ranking':
+        return this.applyPriorityRankingAnswer(extraction, answer);
+      case 'confirmation':
+        return this.applyConfirmationAnswer(extraction, question, answer);
+      case 'scale_rating':
+        return this.applyScaleRatingAnswer(extraction, question, answer);
+      default:
+        return extraction;
+    }
+  }
+
+  private applyFreeTextAnswer(
+    extraction: ExtractionResult,
+    question: InvestigationQuestion,
+    answer: InvestigationAnswer
+  ): ExtractionResult {
+    // Map to project fields if applicable
+    if (
+      question.category === 'scope' &&
+      question.question.toLowerCase().includes('primary business problem')
+    ) {
+      return {
+        ...extraction,
+        projectDescription: extraction.projectDescription ?? answer.answer,
+      };
+    }
+    // For other free text, store context for later processing
+    return extraction;
+  }
+
+  private applySingleSelectAnswer(
+    extraction: ExtractionResult,
+    _question: InvestigationQuestion,
+    _answer: InvestigationAnswer
+  ): ExtractionResult {
+    // Single select answers are contextual — stored for downstream use
+    return extraction;
+  }
+
+  private applyMultiSelectAnswer(
+    extraction: ExtractionResult,
+    question: InvestigationQuestion,
+    answer: InvestigationAnswer
+  ): ExtractionResult {
+    const selected = answer.selectedOptions ?? [answer.answer];
+
+    // Security measures → NFR entries
+    if (question.category === 'quality' && question.question.toLowerCase().includes('security')) {
+      const newNfrs: ExtractedRequirement[] = selected
+        .filter((s) => s !== 'No constraints')
+        .map((measure, index) => ({
+          id: `NFR-INV-${String(extraction.nonFunctionalRequirements.length + index + 1).padStart(3, '0')}`,
+          title: measure,
+          description: `Security requirement: ${measure}`,
+          priority: 'P1' as const,
+          source: 'investigation',
+          confidence: 0.9,
+          isFunctional: false as const,
+          nfrCategory: 'security' as const,
+        }));
+
+      return {
+        ...extraction,
+        nonFunctionalRequirements: [...extraction.nonFunctionalRequirements, ...newNfrs],
+      };
+    }
+
+    // Technology constraints → constraint entries
+    if (question.category === 'constraint') {
+      const newConstraints: ExtractedConstraint[] = selected
+        .filter((s) => s !== 'No constraints')
+        .map((constraint, index) => ({
+          id: `CON-INV-${String(extraction.constraints.length + index + 1).padStart(3, '0')}`,
+          description: constraint,
+          type: 'technical' as const,
+          source: 'investigation',
+          confidence: 0.9,
+        }));
+
+      return {
+        ...extraction,
+        constraints: [...extraction.constraints, ...newConstraints],
+      };
+    }
+
+    return extraction;
+  }
+
+  private applyYesNoAnswer(
+    extraction: ExtractionResult,
+    question: InvestigationQuestion,
+    answer: InvestigationAnswer
+  ): ExtractionResult {
+    const isYes = answer.answer.toLowerCase() === 'yes';
+
+    // Assumption validation
+    if (question.category === 'assumption' && question.relatedTo !== undefined) {
+      const updatedAssumptions: ExtractedAssumption[] = extraction.assumptions.map((a) => {
+        if (a.id === question.relatedTo) {
+          return { ...a, confidence: isYes ? 1.0 : 0.0 };
+        }
+        return a;
+      });
+      return { ...extraction, assumptions: updatedAssumptions };
+    }
+
+    // Regulatory requirements
+    if (
+      question.category === 'constraint' &&
+      question.question.toLowerCase().includes('regulatory')
+    ) {
+      if (isYes) {
+        const newConstraint: ExtractedConstraint = {
+          id: `CON-INV-${String(extraction.constraints.length + 1).padStart(3, '0')}`,
+          description: 'Regulatory/compliance requirements apply',
+          type: 'regulatory',
+          source: 'investigation',
+          confidence: 0.9,
+        };
+        return { ...extraction, constraints: [...extraction.constraints, newConstraint] };
+      }
+    }
+
+    return extraction;
+  }
+
+  private applyPriorityRankingAnswer(
+    extraction: ExtractionResult,
+    answer: InvestigationAnswer
+  ): ExtractionResult {
+    const rankings = answer.rankings ?? [];
+    if (rankings.length === 0) {
+      return extraction;
+    }
+
+    const updatedFrs = extraction.functionalRequirements.map((fr) => {
+      // Find position in ranking
+      const rankIndex = rankings.findIndex((r) => r.includes(fr.id));
+      if (rankIndex === -1) {
+        return fr;
+      }
+      const position = rankIndex / rankings.length;
+      let priority: 'P0' | 'P1' | 'P2' | 'P3';
+      if (position < 0.25) {
+        priority = 'P0';
+      } else if (position < 0.5) {
+        priority = 'P1';
+      } else if (position < 0.75) {
+        priority = 'P2';
+      } else {
+        priority = 'P3';
+      }
+      return { ...fr, priority };
+    });
+
+    return { ...extraction, functionalRequirements: updatedFrs };
+  }
+
+  private applyConfirmationAnswer(
+    extraction: ExtractionResult,
+    _question: InvestigationQuestion,
+    answer: InvestigationAnswer
+  ): ExtractionResult {
+    const response = answer.answer.toLowerCase();
+
+    if (response === 'agree' || response === 'yes') {
+      // Boost confidence of all requirements
+      const updatedFrs = extraction.functionalRequirements.map((fr) => ({
+        ...fr,
+        confidence: Math.min(1.0, fr.confidence + 0.15),
+      }));
+      return { ...extraction, functionalRequirements: updatedFrs };
+    }
+
+    if (response === 'disagree' || response === 'no') {
+      // Reduce confidence of low-confidence requirements
+      const updatedFrs = extraction.functionalRequirements.map((fr) => {
+        if (fr.confidence < 0.7) {
+          return { ...fr, confidence: Math.max(0, fr.confidence - 0.2) };
+        }
+        return fr;
+      });
+      return { ...extraction, functionalRequirements: updatedFrs };
+    }
+
+    return extraction;
+  }
+
+  private applyScaleRatingAnswer(
+    extraction: ExtractionResult,
+    question: InvestigationQuestion,
+    answer: InvestigationAnswer
+  ): ExtractionResult {
+    const value = answer.scaleValue ?? Number(answer.answer);
+    if (isNaN(value)) {
+      return extraction;
+    }
+
+    // Availability rating → NFR
+    if (question.question.toLowerCase().includes('availability')) {
+      const availabilityMap: Record<number, string> = {
+        1: 'Best effort availability',
+        2: '99% uptime (7.3h downtime/month)',
+        3: '99.9% uptime (43.8m downtime/month)',
+        4: '99.95% uptime (21.9m downtime/month)',
+        5: '99.99% uptime (4.38m downtime/month)',
+      };
+      const description = availabilityMap[value] ?? `Availability level: ${String(value)}`;
+      const nfr: ExtractedRequirement = {
+        id: `NFR-INV-${String(extraction.nonFunctionalRequirements.length + 1).padStart(3, '0')}`,
+        title: 'Availability Requirement',
+        description,
+        priority: value >= 4 ? ('P0' as const) : ('P1' as const),
+        source: 'investigation',
+        confidence: 0.9,
+        isFunctional: false,
+        nfrCategory: 'reliability',
+      };
+      return {
+        ...extraction,
+        nonFunctionalRequirements: [...extraction.nonFunctionalRequirements, nfr],
+      };
+    }
+
+    return extraction;
+  }
+
+  // ===========================================================================
+  // Helpers
+  // ===========================================================================
+
+  private recalculateConfidence(extraction: ExtractionResult): number {
+    const allItems = [
+      ...extraction.functionalRequirements.map((r) => r.confidence),
+      ...extraction.nonFunctionalRequirements.map((r) => r.confidence),
+    ];
+
+    const baseConfidence =
+      allItems.length > 0 ? allItems.reduce((sum, c) => sum + c, 0) / allItems.length : 0.5;
+
+    let coverageBonus = 0;
+    if (extraction.projectName !== undefined && extraction.projectName !== '') {
+      coverageBonus += 0.05;
+    }
+    if (extraction.projectDescription !== undefined && extraction.projectDescription !== '') {
+      coverageBonus += 0.05;
+    }
+    if (extraction.functionalRequirements.length >= 3) {
+      coverageBonus += 0.05;
+    }
+    if (extraction.nonFunctionalRequirements.length >= 2) {
+      coverageBonus += 0.05;
+    }
+    if (extraction.constraints.length >= 1) {
+      coverageBonus += 0.03;
+    }
+
+    return Math.min(1.0, baseConfidence + coverageBonus);
+  }
+
+  private getCurrentPhaseName(): string {
+    const phaseIndex = this.state.currentRound - 1;
+    if (phaseIndex >= 0 && phaseIndex < this.state.phases.length) {
+      return this.state.phases[phaseIndex] ?? 'unknown';
+    }
+    return 'unknown';
+  }
+
+  private getPhaseConfig(phase: InvestigationPhase): InvestigationPhaseConfig | undefined {
+    return getPhasesForDepth(this.state.depth).find((p) => p.phase === phase);
+  }
+
+  private completeInvestigation(): void {
+    this.state = {
+      ...this.state,
+      status: 'completed',
+      completedAt: new Date().toISOString(),
+    };
+  }
+}

--- a/src/collector/InvestigationTemplates.ts
+++ b/src/collector/InvestigationTemplates.ts
@@ -1,0 +1,912 @@
+/**
+ * InvestigationTemplates — Predefined question templates for investigation phases
+ *
+ * Provides the template fallback system when LLM-based question generation
+ * is unavailable. Templates are parameterized with extraction state data.
+ *
+ * @module collector/InvestigationTemplates
+ */
+
+import type {
+  InvestigationPhase,
+  InvestigationQuestionFormat,
+  InvestigationQuestion,
+  InvestigationCategory,
+} from './investigation-types.js';
+import type { ExtractionResult } from './types.js';
+
+// =============================================================================
+// Question Template Interface
+// =============================================================================
+
+/**
+ * Predefined question template with trigger conditions.
+ */
+export interface QuestionTemplate {
+  /** Template ID (e.g., IQ-VIS-001) */
+  readonly id: string;
+  /** Phase this template belongs to */
+  readonly phase: InvestigationPhase;
+  /** Question format */
+  readonly format: InvestigationQuestionFormat;
+  /** Question text with {placeholders} */
+  readonly question: string;
+  /** Context explaining why this question matters */
+  readonly context: string;
+  /** Question category */
+  readonly category: InvestigationCategory;
+  /** Whether this question is required */
+  readonly required: boolean;
+  /** Priority (1-10, higher = ask first) */
+  readonly priority: number;
+  /** Predefined options for select/ranking */
+  readonly options?: readonly string[];
+  /** Scale range for scale_rating */
+  readonly scaleRange?: {
+    readonly min: number;
+    readonly max: number;
+    readonly labels?: { readonly min: string; readonly max: string };
+  };
+  /** Trigger condition name (key in TRIGGER_CONDITIONS) */
+  readonly condition: string;
+  /** Tags for deduplication across phases */
+  readonly tags: readonly string[];
+}
+
+// =============================================================================
+// Trigger Conditions Registry
+// =============================================================================
+
+/**
+ * Named trigger conditions evaluated against ExtractionResult.
+ * Returns true when the question should be included.
+ */
+export const TRIGGER_CONDITIONS: Readonly<
+  Record<string, (extraction: ExtractionResult) => boolean>
+> = {
+  always: () => true,
+  'missing.projectName': (e) => e.projectName === undefined || e.projectName === '',
+  'missing.projectDescription': (e) =>
+    e.projectDescription === undefined || e.projectDescription === '',
+  'missing.nfr.performance': (e) =>
+    !e.nonFunctionalRequirements.some((r) => r.nfrCategory === 'performance'),
+  'missing.nfr.security': (e) =>
+    !e.nonFunctionalRequirements.some((r) => r.nfrCategory === 'security'),
+  'missing.nfr.reliability': (e) =>
+    !e.nonFunctionalRequirements.some((r) => r.nfrCategory === 'reliability'),
+  'missing.nfr.usability': (e) =>
+    !e.nonFunctionalRequirements.some((r) => r.nfrCategory === 'usability'),
+  'missing.constraints': (e) => e.constraints.length === 0,
+  'missing.constraints.business': (e) => !e.constraints.some((c) => c.type === 'business'),
+  'missing.constraints.regulatory': (e) => !e.constraints.some((c) => c.type === 'regulatory'),
+  'missing.dependencies': (e) => e.dependencies.length === 0,
+  'has.assumptions': (e) => e.assumptions.length > 0,
+  'has.lowConfidenceRequirements': (e) => e.functionalRequirements.some((r) => r.confidence < 0.7),
+  'has.multipleRequirements': (e) => e.functionalRequirements.length >= 3,
+  'has.functionalRequirements': (e) => e.functionalRequirements.length > 0,
+  'has.missingAcceptanceCriteria': (e) =>
+    e.functionalRequirements.some(
+      (r) => r.acceptanceCriteria === undefined || r.acceptanceCriteria.length === 0
+    ),
+};
+
+// =============================================================================
+// Phase Templates
+// =============================================================================
+
+const PROJECT_VISION_TEMPLATES: readonly QuestionTemplate[] = [
+  {
+    id: 'IQ-VIS-001',
+    phase: 'project_vision',
+    format: 'free_text',
+    question:
+      'What is the primary business problem or opportunity that this project aims to address?',
+    context: 'Understanding the core problem helps prioritize requirements correctly.',
+    category: 'scope',
+    required: true,
+    priority: 10,
+    condition: 'always',
+    tags: ['project_purpose'],
+  },
+  {
+    id: 'IQ-VIS-002',
+    phase: 'project_vision',
+    format: 'free_text',
+    question:
+      'Who are the key stakeholders for this project? Please list their roles and primary interests.',
+    context: 'Stakeholder identification ensures all perspectives are captured in the PRD.',
+    category: 'stakeholder',
+    required: true,
+    priority: 9,
+    condition: 'always',
+    tags: ['stakeholders'],
+  },
+  {
+    id: 'IQ-VIS-003',
+    phase: 'project_vision',
+    format: 'multi_select',
+    question: 'Which of the following best describes the project type?',
+    context: 'Project type determines applicable architectural patterns and NFR priorities.',
+    category: 'scope',
+    required: false,
+    priority: 8,
+    options: [
+      'Web application',
+      'Mobile application',
+      'API/Backend service',
+      'Desktop application',
+      'CLI tool',
+      'Library/SDK',
+      'Data pipeline',
+      'Infrastructure/DevOps',
+    ],
+    condition: 'always',
+    tags: ['project_type'],
+  },
+  {
+    id: 'IQ-VIS-004',
+    phase: 'project_vision',
+    format: 'free_text',
+    question: 'What does success look like for this project? Describe 2-3 measurable outcomes.',
+    context: 'Success criteria become the basis for acceptance criteria validation.',
+    category: 'scope',
+    required: true,
+    priority: 8,
+    condition: 'always',
+    tags: ['success_criteria'],
+  },
+  {
+    id: 'IQ-VIS-005',
+    phase: 'project_vision',
+    format: 'single_select',
+    question: 'What is the expected timeline for the initial release?',
+    context: 'Timeline affects scope decisions and priority trade-offs.',
+    category: 'timeline',
+    required: false,
+    priority: 7,
+    options: ['1-2 weeks', '1 month', '2-3 months', '3-6 months', '6+ months', 'Not determined'],
+    condition: 'always',
+    tags: ['timeline'],
+  },
+  {
+    id: 'IQ-VIS-006',
+    phase: 'project_vision',
+    format: 'scale_rating',
+    question: "How critical is this project to the organization's strategy?",
+    context: 'Strategic importance drives default priority levels for requirements.',
+    category: 'scope',
+    required: false,
+    priority: 6,
+    scaleRange: { min: 1, max: 5, labels: { min: 'Exploratory', max: 'Mission-critical' } },
+    condition: 'always',
+    tags: ['criticality'],
+  },
+  {
+    id: 'IQ-VIS-007',
+    phase: 'project_vision',
+    format: 'free_text',
+    question:
+      'Are there any existing systems or products that this project will replace, integrate with, or extend?',
+    context: 'Existing system landscape affects architecture and migration requirements.',
+    category: 'scope',
+    required: false,
+    priority: 6,
+    condition: 'always',
+    tags: ['existing_systems'],
+  },
+];
+
+const USER_ANALYSIS_TEMPLATES: readonly QuestionTemplate[] = [
+  {
+    id: 'IQ-USER-001',
+    phase: 'user_analysis',
+    format: 'free_text',
+    question:
+      'Describe the primary end users. What are their technical skill levels and main goals?',
+    context: 'User personas directly inform functional requirements and usability criteria.',
+    category: 'stakeholder',
+    required: true,
+    priority: 10,
+    condition: 'always',
+    tags: ['user_personas'],
+  },
+  {
+    id: 'IQ-USER-002',
+    phase: 'user_analysis',
+    format: 'free_text',
+    question: 'Walk through the most critical user workflow or journey from start to finish.',
+    context: 'Critical user journeys become the backbone of functional requirements.',
+    category: 'requirement',
+    required: true,
+    priority: 9,
+    condition: 'always',
+    tags: ['user_workflow'],
+  },
+  {
+    id: 'IQ-USER-003',
+    phase: 'user_analysis',
+    format: 'multi_select',
+    question: 'Which user interaction patterns are relevant?',
+    context: 'Interaction patterns help identify missing functional requirements.',
+    category: 'requirement',
+    required: false,
+    priority: 8,
+    options: [
+      'CRUD operations',
+      'Search/filter',
+      'Real-time collaboration',
+      'File upload/download',
+      'Notifications/alerts',
+      'Reporting/analytics',
+      'Workflow automation',
+      'Social/messaging',
+    ],
+    condition: 'always',
+    tags: ['interaction_patterns'],
+  },
+  {
+    id: 'IQ-USER-004',
+    phase: 'user_analysis',
+    format: 'yes_no',
+    question: 'Will there be different user roles with different permission levels?',
+    context:
+      'Role-based access control significantly impacts architecture and security requirements.',
+    category: 'requirement',
+    required: true,
+    priority: 8,
+    condition: 'has.functionalRequirements',
+    tags: ['user_roles'],
+  },
+  {
+    id: 'IQ-USER-005',
+    phase: 'user_analysis',
+    format: 'free_text',
+    question:
+      'Are there accessibility requirements (WCAG compliance, screen reader support, keyboard navigation)?',
+    context: 'Accessibility requirements are often overlooked but critical for compliance.',
+    category: 'quality',
+    required: false,
+    priority: 7,
+    condition: 'always',
+    tags: ['accessibility'],
+  },
+  {
+    id: 'IQ-USER-006',
+    phase: 'user_analysis',
+    format: 'scale_rating',
+    question: 'How many concurrent users do you expect at peak?',
+    context: 'User scale drives performance and scalability requirements.',
+    category: 'quality',
+    required: false,
+    priority: 6,
+    scaleRange: { min: 1, max: 5, labels: { min: '< 10 users', max: '10,000+ users' } },
+    condition: 'always',
+    tags: ['user_scale'],
+  },
+];
+
+const FUNCTIONAL_DEEP_DIVE_TEMPLATES: readonly QuestionTemplate[] = [
+  {
+    id: 'IQ-FUNC-001',
+    phase: 'functional_deep_dive',
+    format: 'free_text',
+    question: 'What are the specific acceptance criteria for the highest-priority requirement?',
+    context: 'Acceptance criteria are essential for verification and validation downstream.',
+    category: 'requirement',
+    required: true,
+    priority: 10,
+    condition: 'has.missingAcceptanceCriteria',
+    tags: ['acceptance_criteria'],
+  },
+  {
+    id: 'IQ-FUNC-002',
+    phase: 'functional_deep_dive',
+    format: 'free_text',
+    question: 'What edge cases or error scenarios should be handled for the core features?',
+    context: 'Edge case identification prevents gaps in implementation.',
+    category: 'requirement',
+    required: false,
+    priority: 9,
+    condition: 'has.lowConfidenceRequirements',
+    tags: ['edge_cases'],
+  },
+  {
+    id: 'IQ-FUNC-003',
+    phase: 'functional_deep_dive',
+    format: 'priority_ranking',
+    question: 'Please rank the following functional requirements by business value:',
+    context: 'Priority ranking ensures the most important features are implemented first.',
+    category: 'priority',
+    required: true,
+    priority: 8,
+    condition: 'has.multipleRequirements',
+    tags: ['priority_ranking'],
+  },
+  {
+    id: 'IQ-FUNC-004',
+    phase: 'functional_deep_dive',
+    format: 'yes_no',
+    question:
+      'Do any of the identified requirements depend on other requirements being implemented first?',
+    context: 'Dependency mapping is critical for implementation ordering.',
+    category: 'requirement',
+    required: false,
+    priority: 7,
+    condition: 'has.multipleRequirements',
+    tags: ['requirement_dependencies'],
+  },
+  {
+    id: 'IQ-FUNC-005',
+    phase: 'functional_deep_dive',
+    format: 'free_text',
+    question: "Are there any features you've been considering but are unsure about including?",
+    context: 'Scope boundary discussion prevents feature creep and sets clear expectations.',
+    category: 'scope',
+    required: false,
+    priority: 7,
+    condition: 'always',
+    tags: ['scope_boundary'],
+  },
+  {
+    id: 'IQ-FUNC-006',
+    phase: 'functional_deep_dive',
+    format: 'single_select',
+    question: 'What should happen when data created by a core feature is deleted?',
+    context: 'Data lifecycle decisions affect architecture and compliance requirements.',
+    category: 'requirement',
+    required: false,
+    priority: 6,
+    options: ['Hard delete (permanent)', 'Soft delete (recoverable)', 'Archive', 'Not applicable'],
+    condition: 'has.functionalRequirements',
+    tags: ['data_lifecycle'],
+  },
+  {
+    id: 'IQ-FUNC-007',
+    phase: 'functional_deep_dive',
+    format: 'confirmation',
+    question: 'We extracted the following core requirement. Is this interpretation accurate?',
+    context: 'Confirming extracted requirements prevents misunderstandings early.',
+    category: 'requirement',
+    required: true,
+    priority: 9,
+    condition: 'has.lowConfidenceRequirements',
+    tags: ['requirement_confirmation'],
+  },
+];
+
+const NONFUNCTIONAL_ANALYSIS_TEMPLATES: readonly QuestionTemplate[] = [
+  {
+    id: 'IQ-NFR-001',
+    phase: 'nonfunctional_analysis',
+    format: 'free_text',
+    question:
+      'What are the target response times for key operations? (e.g., page load < 2s, API response < 500ms)',
+    context: 'Measurable performance targets become testable NFR acceptance criteria.',
+    category: 'quality',
+    required: true,
+    priority: 10,
+    condition: 'missing.nfr.performance',
+    tags: ['performance'],
+  },
+  {
+    id: 'IQ-NFR-002',
+    phase: 'nonfunctional_analysis',
+    format: 'multi_select',
+    question: 'Which security measures are required?',
+    context: 'Security requirements must be identified early to influence architecture decisions.',
+    category: 'quality',
+    required: true,
+    priority: 10,
+    options: [
+      'Authentication (login)',
+      'Authorization (role-based access)',
+      'Data encryption at rest',
+      'Data encryption in transit',
+      'Audit logging',
+      'OWASP Top 10 compliance',
+      'SOC 2 compliance',
+      'GDPR compliance',
+      'Input validation/sanitization',
+    ],
+    condition: 'missing.nfr.security',
+    tags: ['security'],
+  },
+  {
+    id: 'IQ-NFR-003',
+    phase: 'nonfunctional_analysis',
+    format: 'scale_rating',
+    question: 'What is the required availability level?',
+    context: 'Availability targets drive infrastructure and redundancy decisions.',
+    category: 'quality',
+    required: false,
+    priority: 8,
+    scaleRange: { min: 1, max: 5, labels: { min: 'Best effort', max: '99.99%+ uptime' } },
+    condition: 'missing.nfr.reliability',
+    tags: ['availability'],
+  },
+  {
+    id: 'IQ-NFR-004',
+    phase: 'nonfunctional_analysis',
+    format: 'single_select',
+    question: 'What is the expected data volume?',
+    context: 'Data volume affects database choices, indexing strategies, and scalability needs.',
+    category: 'quality',
+    required: false,
+    priority: 7,
+    options: ['Small (< 1 GB)', 'Medium (1-100 GB)', 'Large (100 GB - 1 TB)', 'Very large (1+ TB)'],
+    condition: 'always',
+    tags: ['data_volume'],
+  },
+  {
+    id: 'IQ-NFR-005',
+    phase: 'nonfunctional_analysis',
+    format: 'yes_no',
+    question: 'Is internationalization (i18n) or localization (l10n) required?',
+    context: 'i18n requirements must be designed in from the start, not retrofitted.',
+    category: 'quality',
+    required: false,
+    priority: 6,
+    condition: 'missing.nfr.usability',
+    tags: ['i18n'],
+  },
+  {
+    id: 'IQ-NFR-006',
+    phase: 'nonfunctional_analysis',
+    format: 'free_text',
+    question: 'What monitoring, logging, or observability requirements exist?',
+    context: 'Observability requirements affect application architecture and operations.',
+    category: 'quality',
+    required: false,
+    priority: 6,
+    condition: 'always',
+    tags: ['observability'],
+  },
+];
+
+const CONSTRAINTS_RISKS_TEMPLATES: readonly QuestionTemplate[] = [
+  {
+    id: 'IQ-CON-001',
+    phase: 'constraints_risks',
+    format: 'multi_select',
+    question: 'Are there technology stack constraints?',
+    context: 'Technology constraints directly limit architectural options.',
+    category: 'constraint',
+    required: true,
+    priority: 10,
+    options: [
+      'Specific programming language required',
+      'Specific framework required',
+      'Must use existing infrastructure',
+      'Cloud provider locked',
+      'Database technology specified',
+      'No constraints',
+    ],
+    condition: 'missing.constraints',
+    tags: ['tech_constraints'],
+  },
+  {
+    id: 'IQ-CON-002',
+    phase: 'constraints_risks',
+    format: 'free_text',
+    question: 'What are the budget or resource constraints for this project?',
+    context: 'Resource constraints affect scope and timeline decisions.',
+    category: 'constraint',
+    required: false,
+    priority: 9,
+    condition: 'missing.constraints.business',
+    tags: ['budget_constraints'],
+  },
+  {
+    id: 'IQ-CON-003',
+    phase: 'constraints_risks',
+    format: 'confirmation',
+    question:
+      'We identified an assumption from the input. Is this correct, and what is the risk if it proves wrong?',
+    context: 'Unvalidated assumptions are a major source of project risk.',
+    category: 'assumption',
+    required: true,
+    priority: 9,
+    condition: 'has.assumptions',
+    tags: ['assumption_validation'],
+  },
+  {
+    id: 'IQ-CON-004',
+    phase: 'constraints_risks',
+    format: 'free_text',
+    question: 'What are the top 3 risks that could derail this project?',
+    context: 'Early risk identification enables proactive mitigation planning.',
+    category: 'risk',
+    required: false,
+    priority: 8,
+    condition: 'always',
+    tags: ['risks'],
+  },
+  {
+    id: 'IQ-CON-005',
+    phase: 'constraints_risks',
+    format: 'yes_no',
+    question: 'Are there regulatory or compliance requirements (GDPR, HIPAA, PCI-DSS, SOX, etc.)?',
+    context: 'Regulatory requirements create hard constraints on architecture and data handling.',
+    category: 'constraint',
+    required: true,
+    priority: 8,
+    condition: 'missing.constraints.regulatory',
+    tags: ['regulatory'],
+  },
+  {
+    id: 'IQ-CON-006',
+    phase: 'constraints_risks',
+    format: 'free_text',
+    question:
+      'List any third-party services, APIs, or systems that this project must integrate with.',
+    context: 'External dependencies affect architecture, testing, and deployment strategies.',
+    category: 'constraint',
+    required: false,
+    priority: 7,
+    condition: 'missing.dependencies',
+    tags: ['external_dependencies'],
+  },
+];
+
+const VALIDATION_SYNTHESIS_TEMPLATES: readonly QuestionTemplate[] = [
+  {
+    id: 'IQ-VAL-001',
+    phase: 'validation_synthesis',
+    format: 'priority_ranking',
+    question: 'Please confirm the priority order for the collected functional requirements:',
+    context: 'Final priority confirmation ensures alignment before PRD generation.',
+    category: 'priority',
+    required: true,
+    priority: 10,
+    condition: 'has.multipleRequirements',
+    tags: ['final_priority'],
+  },
+  {
+    id: 'IQ-VAL-002',
+    phase: 'validation_synthesis',
+    format: 'multi_select',
+    question: 'Which of the following are explicitly OUT of scope for the initial release?',
+    context: 'Explicit scope exclusions prevent scope creep during implementation.',
+    category: 'scope',
+    required: false,
+    priority: 9,
+    options: [
+      'Admin dashboard',
+      'Analytics/reporting',
+      'Mobile support',
+      'Offline mode',
+      'Multi-language support',
+      'Third-party integrations',
+      'Advanced search',
+      'Real-time features',
+    ],
+    condition: 'always',
+    tags: ['out_of_scope'],
+  },
+  {
+    id: 'IQ-VAL-003',
+    phase: 'validation_synthesis',
+    format: 'confirmation',
+    question:
+      'Based on our investigation, the core purpose of this project has been captured. Does this accurately represent the project?',
+    context: 'Final confirmation of the project description ensures PRD alignment.',
+    category: 'scope',
+    required: true,
+    priority: 9,
+    condition: 'always',
+    tags: ['project_confirmation'],
+  },
+  {
+    id: 'IQ-VAL-004',
+    phase: 'validation_synthesis',
+    format: 'free_text',
+    question:
+      "Is there anything important we haven't discussed that should be part of the requirements?",
+    context: 'Open-ended catch-all prevents critical omissions.',
+    category: 'requirement',
+    required: false,
+    priority: 8,
+    condition: 'always',
+    tags: ['final_gaps'],
+  },
+  {
+    id: 'IQ-VAL-005',
+    phase: 'validation_synthesis',
+    format: 'yes_no',
+    question:
+      "Are you satisfied that we've captured enough detail to begin writing the Product Requirements Document?",
+    context: 'Final approval gate ensures stakeholder buy-in before PRD generation.',
+    category: 'scope',
+    required: true,
+    priority: 10,
+    condition: 'always',
+    tags: ['final_approval'],
+  },
+];
+
+// =============================================================================
+// Helper for safe template derivation
+// =============================================================================
+
+function deriveTemplate(
+  source: readonly QuestionTemplate[],
+  index: number,
+  overrides: Partial<QuestionTemplate>
+): QuestionTemplate {
+  const base = source[index];
+  if (base === undefined) {
+    throw new Error(`Template index ${String(index)} out of range`);
+  }
+  return { ...base, ...overrides };
+}
+
+// =============================================================================
+// Standard Mode Templates (condensed phases)
+// =============================================================================
+
+const CORE_DISCOVERY_TEMPLATES: readonly QuestionTemplate[] = [
+  deriveTemplate(PROJECT_VISION_TEMPLATES, 0, { phase: 'core_discovery', id: 'IQ-CD-001' }),
+  deriveTemplate(PROJECT_VISION_TEMPLATES, 1, { phase: 'core_discovery', id: 'IQ-CD-002' }),
+  deriveTemplate(PROJECT_VISION_TEMPLATES, 2, { phase: 'core_discovery', id: 'IQ-CD-003' }),
+  deriveTemplate(PROJECT_VISION_TEMPLATES, 3, { phase: 'core_discovery', id: 'IQ-CD-004' }),
+  deriveTemplate(USER_ANALYSIS_TEMPLATES, 0, { phase: 'core_discovery', id: 'IQ-CD-005' }),
+  deriveTemplate(USER_ANALYSIS_TEMPLATES, 1, { phase: 'core_discovery', id: 'IQ-CD-006' }),
+  deriveTemplate(USER_ANALYSIS_TEMPLATES, 3, { phase: 'core_discovery', id: 'IQ-CD-007' }),
+];
+
+const REQUIREMENTS_ANALYSIS_TEMPLATES: readonly QuestionTemplate[] = [
+  deriveTemplate(FUNCTIONAL_DEEP_DIVE_TEMPLATES, 0, {
+    phase: 'requirements_analysis',
+    id: 'IQ-RA-001',
+  }),
+  deriveTemplate(FUNCTIONAL_DEEP_DIVE_TEMPLATES, 2, {
+    phase: 'requirements_analysis',
+    id: 'IQ-RA-002',
+  }),
+  deriveTemplate(FUNCTIONAL_DEEP_DIVE_TEMPLATES, 6, {
+    phase: 'requirements_analysis',
+    id: 'IQ-RA-003',
+  }),
+  deriveTemplate(NONFUNCTIONAL_ANALYSIS_TEMPLATES, 0, {
+    phase: 'requirements_analysis',
+    id: 'IQ-RA-004',
+  }),
+  deriveTemplate(NONFUNCTIONAL_ANALYSIS_TEMPLATES, 1, {
+    phase: 'requirements_analysis',
+    id: 'IQ-RA-005',
+  }),
+  deriveTemplate(NONFUNCTIONAL_ANALYSIS_TEMPLATES, 2, {
+    phase: 'requirements_analysis',
+    id: 'IQ-RA-006',
+  }),
+  deriveTemplate(NONFUNCTIONAL_ANALYSIS_TEMPLATES, 3, {
+    phase: 'requirements_analysis',
+    id: 'IQ-RA-007',
+  }),
+];
+
+const CONSTRAINTS_VALIDATION_TEMPLATES: readonly QuestionTemplate[] = [
+  deriveTemplate(CONSTRAINTS_RISKS_TEMPLATES, 0, {
+    phase: 'constraints_validation',
+    id: 'IQ-CV-001',
+  }),
+  deriveTemplate(CONSTRAINTS_RISKS_TEMPLATES, 2, {
+    phase: 'constraints_validation',
+    id: 'IQ-CV-002',
+  }),
+  deriveTemplate(CONSTRAINTS_RISKS_TEMPLATES, 4, {
+    phase: 'constraints_validation',
+    id: 'IQ-CV-003',
+  }),
+  deriveTemplate(VALIDATION_SYNTHESIS_TEMPLATES, 2, {
+    phase: 'constraints_validation',
+    id: 'IQ-CV-004',
+  }),
+  deriveTemplate(VALIDATION_SYNTHESIS_TEMPLATES, 4, {
+    phase: 'constraints_validation',
+    id: 'IQ-CV-005',
+  }),
+];
+
+// =============================================================================
+// Quick Mode Templates
+// =============================================================================
+
+const BASIC_CLARIFICATION_TEMPLATES: readonly QuestionTemplate[] = [
+  deriveTemplate(PROJECT_VISION_TEMPLATES, 0, {
+    phase: 'basic_clarification',
+    id: 'IQ-BC-001',
+    condition: 'missing.projectName',
+  }),
+  deriveTemplate(FUNCTIONAL_DEEP_DIVE_TEMPLATES, 6, {
+    phase: 'basic_clarification',
+    id: 'IQ-BC-002',
+    condition: 'has.lowConfidenceRequirements',
+  }),
+  deriveTemplate(NONFUNCTIONAL_ANALYSIS_TEMPLATES, 1, {
+    phase: 'basic_clarification',
+    id: 'IQ-BC-003',
+    condition: 'missing.nfr.security',
+  }),
+  deriveTemplate(VALIDATION_SYNTHESIS_TEMPLATES, 4, {
+    phase: 'basic_clarification',
+    id: 'IQ-BC-004',
+  }),
+];
+
+// =============================================================================
+// All Templates Registry
+// =============================================================================
+
+const ALL_TEMPLATES: ReadonlyMap<InvestigationPhase, readonly QuestionTemplate[]> = new Map([
+  // Thorough phases
+  ['project_vision', PROJECT_VISION_TEMPLATES],
+  ['user_analysis', USER_ANALYSIS_TEMPLATES],
+  ['functional_deep_dive', FUNCTIONAL_DEEP_DIVE_TEMPLATES],
+  ['nonfunctional_analysis', NONFUNCTIONAL_ANALYSIS_TEMPLATES],
+  ['constraints_risks', CONSTRAINTS_RISKS_TEMPLATES],
+  ['validation_synthesis', VALIDATION_SYNTHESIS_TEMPLATES],
+  // Standard phases
+  ['core_discovery', CORE_DISCOVERY_TEMPLATES],
+  ['requirements_analysis', REQUIREMENTS_ANALYSIS_TEMPLATES],
+  ['constraints_validation', CONSTRAINTS_VALIDATION_TEMPLATES],
+  // Quick phase
+  ['basic_clarification', BASIC_CLARIFICATION_TEMPLATES],
+]);
+
+// =============================================================================
+// InvestigationTemplates Class
+// =============================================================================
+
+/**
+ * Manages predefined question templates for investigation phases.
+ * Provides the fallback question generation when LLM is unavailable.
+ */
+export class InvestigationTemplates {
+  private readonly templates: ReadonlyMap<InvestigationPhase, readonly QuestionTemplate[]>;
+
+  constructor(templates?: ReadonlyMap<InvestigationPhase, readonly QuestionTemplate[]>) {
+    this.templates = templates ?? ALL_TEMPLATES;
+  }
+
+  /**
+   * Get applicable templates for a phase given current extraction state.
+   *
+   * Filters by trigger condition, removes already-asked questions (by tag),
+   * sorts by priority, and limits to maxQuestions.
+   * @param phase
+   * @param extraction
+   * @param alreadyAskedTags
+   * @param maxQuestions
+   */
+  public getTemplatesForPhase(
+    phase: InvestigationPhase,
+    extraction: ExtractionResult,
+    alreadyAskedTags: readonly string[],
+    maxQuestions: number
+  ): QuestionTemplate[] {
+    const phaseTemplates = this.templates.get(phase);
+    if (phaseTemplates === undefined) {
+      return [];
+    }
+
+    const tagSet = new Set(alreadyAskedTags);
+
+    return phaseTemplates
+      .filter((t) => {
+        // Check trigger condition
+        const conditionFn = TRIGGER_CONDITIONS[t.condition];
+        if (conditionFn === undefined) {
+          return false;
+        }
+        if (!conditionFn(extraction)) {
+          return false;
+        }
+        // Check deduplication by tags
+        return !t.tags.some((tag) => tagSet.has(tag));
+      })
+      .sort((a, b) => b.priority - a.priority)
+      .slice(0, maxQuestions);
+  }
+
+  /**
+   * Parameterize a question template with extraction data.
+   * Replaces {placeholders} with actual values from the extraction.
+   * @param template
+   * @param extraction
+   */
+  public parameterizeQuestion(template: QuestionTemplate, extraction: ExtractionResult): string {
+    let question = template.question;
+
+    const projectName = extraction.projectName ?? 'the project';
+    question = question.replace(/\{projectName\}/g, projectName);
+    question = question.replace(
+      /\{projectDescription\}/g,
+      extraction.projectDescription ?? 'not yet described'
+    );
+
+    // For requirement-specific templates, use the first matching requirement
+    if (question.includes('{requirement.')) {
+      const targetReq =
+        template.condition === 'has.lowConfidenceRequirements'
+          ? extraction.functionalRequirements.find((r) => r.confidence < 0.7)
+          : extraction.functionalRequirements[0];
+
+      if (targetReq !== undefined) {
+        question = question.replace(/\{requirement\.title\}/g, targetReq.title);
+        question = question.replace(/\{requirement\.id\}/g, targetReq.id);
+        question = question.replace(/\{requirement\.description\}/g, targetReq.description);
+      }
+    }
+
+    // For assumption-specific templates
+    if (question.includes('{assumption.')) {
+      const firstAssumption = extraction.assumptions[0];
+      if (firstAssumption !== undefined) {
+        question = question.replace(/\{assumption\.description\}/g, firstAssumption.description);
+      }
+    }
+
+    return question;
+  }
+
+  /**
+   * Convert a template to a full InvestigationQuestion with generated ID and round.
+   * @param template
+   * @param extraction
+   * @param questionId
+   * @param round
+   */
+  public templateToQuestion(
+    template: QuestionTemplate,
+    extraction: ExtractionResult,
+    questionId: string,
+    round: number
+  ): InvestigationQuestion {
+    const parameterizedQuestion = this.parameterizeQuestion(template, extraction);
+
+    // Build options for ranking templates from actual requirements
+    let options = template.options !== undefined ? [...template.options] : undefined;
+    if (template.format === 'priority_ranking' && extraction.functionalRequirements.length >= 3) {
+      options = extraction.functionalRequirements.map((r) => `${r.id}: ${r.title}`);
+    }
+
+    return {
+      id: questionId,
+      phase: template.phase,
+      round,
+      format: template.format,
+      question: parameterizedQuestion,
+      context: template.context,
+      options,
+      scaleRange:
+        template.scaleRange !== undefined
+          ? {
+              min: template.scaleRange.min,
+              max: template.scaleRange.max,
+              labels: template.scaleRange.labels,
+            }
+          : undefined,
+      required: template.required,
+      relatedTo: undefined,
+      category: template.category,
+    };
+  }
+
+  /**
+   * Get all tags from templates that have been used for a given phase list.
+   * @param phases
+   */
+  public getTagsForPhases(phases: readonly InvestigationPhase[]): string[] {
+    const tags: string[] = [];
+    for (const phase of phases) {
+      const phaseTemplates = this.templates.get(phase);
+      if (phaseTemplates !== undefined) {
+        for (const t of phaseTemplates) {
+          tags.push(...t.tags);
+        }
+      }
+    }
+    return tags;
+  }
+}

--- a/src/collector/errors.ts
+++ b/src/collector/errors.ts
@@ -144,6 +144,23 @@ export class UnsupportedFileTypeError extends CollectorError {
 }
 
 /**
+ * Error thrown when investigation process fails
+ */
+export class InvestigationError extends CollectorError {
+  /** The investigation phase where the error occurred */
+  public readonly phase: string;
+  /** The round number */
+  public readonly round: number;
+
+  constructor(phase: string, round: number, reason: string) {
+    super(`Investigation failed at phase "${phase}" (round ${String(round)}): ${reason}`);
+    this.name = 'InvestigationError';
+    this.phase = phase;
+    this.round = round;
+  }
+}
+
+/**
  * Error thrown when project initialization fails
  */
 export class ProjectInitError extends CollectorError {

--- a/src/collector/index.ts
+++ b/src/collector/index.ts
@@ -33,6 +33,11 @@ export type { InformationExtractorOptions } from './InformationExtractor.js';
 
 export { LLMExtractor } from './LLMExtractor.js';
 
+// Investigation
+export { InvestigationEngine } from './InvestigationEngine.js';
+export { InvestigationTemplates, TRIGGER_CONDITIONS } from './InvestigationTemplates.js';
+export type { QuestionTemplate } from './InvestigationTemplates.js';
+
 // Error classes
 export {
   CollectorError,
@@ -45,7 +50,35 @@ export {
   SessionStateError,
   UnsupportedFileTypeError,
   ProjectInitError,
+  InvestigationError,
 } from './errors.js';
+
+// Investigation types
+export {
+  type InvestigationDepth,
+  type InvestigationQuestionFormat,
+  type InvestigationPhase,
+  type InvestigationQuestion,
+  type InvestigationAnswer,
+  type InvestigationRound,
+  type InvestigationState,
+  type InvestigationEngineConfig,
+  type InvestigationPhaseConfig,
+  type InvestigationMetadata,
+  InvestigationDepthSchema,
+  InvestigationQuestionFormatSchema,
+  InvestigationPhaseSchema,
+  InvestigationQuestionSchema,
+  InvestigationAnswerSchema,
+  InvestigationRoundSchema,
+  InvestigationStateSchema,
+  InvestigationEngineConfigSchema,
+  InvestigationMetadataSchema,
+  getPhasesForDepth,
+  getMaxTotalQuestions,
+  getDefaultConfidenceTarget,
+  isEarlyExitAllowed,
+} from './investigation-types.js';
 
 // Type exports
 export type {

--- a/src/collector/investigation-types.ts
+++ b/src/collector/investigation-types.ts
@@ -1,0 +1,448 @@
+/**
+ * Investigation Engine Type Definitions and Zod Schemas
+ *
+ * Types for the multi-round investigation system that conducts structured
+ * requirements elicitation before PRD generation.
+ *
+ * @module collector/investigation-types
+ */
+
+import { z } from 'zod';
+
+// =============================================================================
+// Investigation Depth
+// =============================================================================
+
+/**
+ * Investigation depth controlling the number of rounds and phases.
+ *
+ * - `thorough`: 6 phases, up to 40 questions. Full deep-dive investigation.
+ * - `standard`: 3 phases, up to 20 questions. Balanced investigation.
+ * - `quick`:    1 phase, up to 5 questions. Basic clarification (legacy behavior).
+ */
+export const InvestigationDepthSchema = z.enum(['thorough', 'standard', 'quick']);
+export type InvestigationDepth = z.infer<typeof InvestigationDepthSchema>;
+
+// =============================================================================
+// Question Format
+// =============================================================================
+
+/**
+ * Supported question formats for investigation.
+ *
+ * - `free_text`:         Open-ended text answer
+ * - `single_select`:     Choose one from options
+ * - `multi_select`:      Choose multiple from options
+ * - `yes_no`:            Binary yes/no
+ * - `priority_ranking`:  Rank items by priority
+ * - `confirmation`:      Verify extracted data (agree/disagree/modify)
+ * - `scale_rating`:      Rate on a numeric scale
+ */
+export const InvestigationQuestionFormatSchema = z.enum([
+  'free_text',
+  'single_select',
+  'multi_select',
+  'yes_no',
+  'priority_ranking',
+  'confirmation',
+  'scale_rating',
+]);
+export type InvestigationQuestionFormat = z.infer<typeof InvestigationQuestionFormatSchema>;
+
+// =============================================================================
+// Investigation Phase
+// =============================================================================
+
+/**
+ * Investigation phases. Different depth levels use different phase sets.
+ *
+ * Thorough (6): project_vision → user_analysis → functional_deep_dive →
+ *               nonfunctional_analysis → constraints_risks → validation_synthesis
+ * Standard (3): core_discovery → requirements_analysis → constraints_validation
+ * Quick (1):    basic_clarification
+ */
+export const InvestigationPhaseSchema = z.enum([
+  // Thorough phases
+  'project_vision',
+  'user_analysis',
+  'functional_deep_dive',
+  'nonfunctional_analysis',
+  'constraints_risks',
+  'validation_synthesis',
+  // Standard phases
+  'core_discovery',
+  'requirements_analysis',
+  'constraints_validation',
+  // Quick phase
+  'basic_clarification',
+]);
+export type InvestigationPhase = z.infer<typeof InvestigationPhaseSchema>;
+
+// =============================================================================
+// Scale Range
+// =============================================================================
+
+export const ScaleRangeSchema = z.object({
+  min: z.number().int(),
+  max: z.number().int(),
+  labels: z
+    .object({
+      min: z.string(),
+      max: z.string(),
+    })
+    .optional(),
+});
+export type ScaleRange = z.infer<typeof ScaleRangeSchema>;
+
+// =============================================================================
+// Investigation Question Category
+// =============================================================================
+
+export const InvestigationCategorySchema = z.enum([
+  'requirement',
+  'constraint',
+  'assumption',
+  'priority',
+  'scope',
+  'architecture',
+  'stakeholder',
+  'timeline',
+  'quality',
+  'risk',
+]);
+export type InvestigationCategory = z.infer<typeof InvestigationCategorySchema>;
+
+// =============================================================================
+// Investigation Question
+// =============================================================================
+
+export const InvestigationQuestionSchema = z.object({
+  /** Unique question ID (e.g., IQ-VIS-001) */
+  id: z.string().min(1),
+  /** Investigation phase this question belongs to */
+  phase: InvestigationPhaseSchema,
+  /** Round number within the investigation */
+  round: z.number().int().min(1),
+  /** Question format determining answer type */
+  format: InvestigationQuestionFormatSchema,
+  /** The question text */
+  question: z.string().min(1),
+  /** Context explaining why this question matters */
+  context: z.string(),
+  /** Predefined options for select/ranking formats */
+  options: z.array(z.string()).optional(),
+  /** Scale range for scale_rating format */
+  scaleRange: ScaleRangeSchema.optional(),
+  /** Whether this question must be answered */
+  required: z.boolean(),
+  /** Related artifact ID (e.g., FR-001, CON-002) */
+  relatedTo: z.string().optional(),
+  /** Question category */
+  category: InvestigationCategorySchema,
+});
+export type InvestigationQuestion = z.infer<typeof InvestigationQuestionSchema>;
+
+// =============================================================================
+// Investigation Answer
+// =============================================================================
+
+export const InvestigationAnswerSchema = z.object({
+  /** ID of the question being answered */
+  questionId: z.string().min(1),
+  /** Primary text answer (serialized for complex formats) */
+  answer: z.string(),
+  /** Selected options for multi_select format */
+  selectedOptions: z.array(z.string()).optional(),
+  /** Numeric value for scale_rating format */
+  scaleValue: z.number().optional(),
+  /** Ordered items for priority_ranking format */
+  rankings: z.array(z.string()).optional(),
+  /** When the answer was provided */
+  answeredAt: z.string(),
+});
+export type InvestigationAnswer = z.infer<typeof InvestigationAnswerSchema>;
+
+// =============================================================================
+// Investigation Round
+// =============================================================================
+
+export const InvestigationRoundSchema = z.object({
+  /** Round number (1-based) */
+  roundNumber: z.number().int().min(1),
+  /** Phase this round belongs to */
+  phase: InvestigationPhaseSchema,
+  /** Questions generated for this round */
+  questions: z.array(InvestigationQuestionSchema),
+  /** Answers collected for this round */
+  answers: z.array(InvestigationAnswerSchema),
+  /** When this round started */
+  startedAt: z.string(),
+  /** When this round completed */
+  completedAt: z.string().optional(),
+  /** Extraction confidence before this round */
+  confidenceBefore: z.number().min(0).max(1),
+  /** Extraction confidence after this round */
+  confidenceAfter: z.number().min(0).max(1).optional(),
+});
+export type InvestigationRound = z.infer<typeof InvestigationRoundSchema>;
+
+// =============================================================================
+// Investigation Status
+// =============================================================================
+
+export const InvestigationStatusSchema = z.enum(['pending', 'in_progress', 'completed', 'skipped']);
+export type InvestigationStatus = z.infer<typeof InvestigationStatusSchema>;
+
+// =============================================================================
+// Investigation State
+// =============================================================================
+
+export const InvestigationStateSchema = z.object({
+  /** Depth level for this investigation */
+  depth: InvestigationDepthSchema,
+  /** Current round number (0 = not started) */
+  currentRound: z.number().int().min(0),
+  /** Maximum rounds allowed */
+  maxRounds: z.number().int().min(1),
+  /** Ordered list of phases for this depth */
+  phases: z.array(InvestigationPhaseSchema),
+  /** Completed and in-progress rounds */
+  rounds: z.array(InvestigationRoundSchema),
+  /** Current investigation status */
+  status: InvestigationStatusSchema,
+  /** When investigation started */
+  startedAt: z.string().optional(),
+  /** When investigation completed */
+  completedAt: z.string().optional(),
+});
+export type InvestigationState = z.infer<typeof InvestigationStateSchema>;
+
+// =============================================================================
+// Investigation Engine Config
+// =============================================================================
+
+export const InvestigationEngineConfigSchema = z.object({
+  /** Investigation depth level */
+  depth: InvestigationDepthSchema.default('standard'),
+  /** Maximum questions per round */
+  maxQuestionsPerRound: z.number().int().min(1).max(10).default(5),
+  /** Target confidence to stop investigation (if earlyExit enabled) */
+  confidenceTarget: z.number().min(0).max(1).default(0.85),
+  /** Allow early termination when confidence target is met */
+  earlyExitOnHighConfidence: z.boolean().default(true),
+  /** Enable LLM-based question generation (falls back to templates if false) */
+  enableLLMQuestions: z.boolean().default(true),
+});
+export type InvestigationEngineConfig = z.infer<typeof InvestigationEngineConfigSchema>;
+
+// =============================================================================
+// Investigation Phase Config
+// =============================================================================
+
+export const InvestigationPhaseConfigSchema = z.object({
+  /** Phase identifier */
+  phase: InvestigationPhaseSchema,
+  /** Human-readable display name */
+  displayName: z.string(),
+  /** Description of what this phase investigates */
+  description: z.string(),
+  /** Order within the investigation (1-based) */
+  order: z.number().int().min(1),
+  /** Maximum questions for this phase */
+  maxQuestions: z.number().int().min(1).max(10),
+  /** Focus areas for this phase */
+  focusAreas: z.array(z.string()),
+});
+export type InvestigationPhaseConfig = z.infer<typeof InvestigationPhaseConfigSchema>;
+
+// =============================================================================
+// Investigation Metadata (stored in CollectedInfo)
+// =============================================================================
+
+export const InvestigationMetadataSchema = z.object({
+  /** Depth level used */
+  depth: InvestigationDepthSchema,
+  /** Number of rounds completed */
+  roundsCompleted: z.number().int().min(0),
+  /** Total questions asked across all rounds */
+  totalQuestions: z.number().int().min(0),
+  /** Total answers received */
+  totalAnswers: z.number().int().min(0),
+  /** Confidence gain from investigation (after - before) */
+  confidenceGain: z.number().min(0).max(1),
+  /** Phases that were executed */
+  phasesCompleted: z.array(InvestigationPhaseSchema),
+});
+export type InvestigationMetadata = z.infer<typeof InvestigationMetadataSchema>;
+
+// =============================================================================
+// Phase Registry - Maps depth to phases
+// =============================================================================
+
+/** Thorough mode phases (6 rounds) */
+export const THOROUGH_PHASES: readonly InvestigationPhaseConfig[] = [
+  {
+    phase: 'project_vision',
+    displayName: 'Project Vision',
+    description: 'Establish project purpose, stakeholders, and success criteria',
+    order: 1,
+    maxQuestions: 7,
+    focusAreas: ['purpose', 'stakeholders', 'project_type', 'success_metrics', 'timeline'],
+  },
+  {
+    phase: 'user_analysis',
+    displayName: 'User Analysis',
+    description: 'Identify end users, personas, workflows, and interaction patterns',
+    order: 2,
+    maxQuestions: 6,
+    focusAreas: ['user_personas', 'workflows', 'interaction_patterns', 'roles', 'accessibility'],
+  },
+  {
+    phase: 'functional_deep_dive',
+    displayName: 'Functional Deep-Dive',
+    description:
+      'Examine each requirement in detail: acceptance criteria, edge cases, dependencies',
+    order: 3,
+    maxQuestions: 7,
+    focusAreas: ['acceptance_criteria', 'edge_cases', 'priority', 'dependencies', 'scope'],
+  },
+  {
+    phase: 'nonfunctional_analysis',
+    displayName: 'Non-Functional Analysis',
+    description: 'Performance, security, scalability, usability, reliability requirements',
+    order: 4,
+    maxQuestions: 6,
+    focusAreas: [
+      'performance',
+      'security',
+      'scalability',
+      'usability',
+      'reliability',
+      'maintainability',
+    ],
+  },
+  {
+    phase: 'constraints_risks',
+    displayName: 'Constraints & Risks',
+    description:
+      'Technical, business, regulatory constraints; assumption validation; risk identification',
+    order: 5,
+    maxQuestions: 6,
+    focusAreas: [
+      'technical_constraints',
+      'business_constraints',
+      'regulatory',
+      'assumptions',
+      'risks',
+      'dependencies',
+    ],
+  },
+  {
+    phase: 'validation_synthesis',
+    displayName: 'Validation & Synthesis',
+    description:
+      'Final priority confirmation, scope boundaries, conflict resolution, completeness check',
+    order: 6,
+    maxQuestions: 5,
+    focusAreas: [
+      'priority_confirmation',
+      'scope_boundary',
+      'conflicts',
+      'completeness',
+      'final_approval',
+    ],
+  },
+];
+
+/** Standard mode phases (3 rounds) */
+export const STANDARD_PHASES: readonly InvestigationPhaseConfig[] = [
+  {
+    phase: 'core_discovery',
+    displayName: 'Core Discovery',
+    description: 'Project vision, stakeholders, key users, and primary use cases',
+    order: 1,
+    maxQuestions: 7,
+    focusAreas: ['purpose', 'stakeholders', 'users', 'use_cases', 'project_type'],
+  },
+  {
+    phase: 'requirements_analysis',
+    displayName: 'Requirements Analysis',
+    description: 'Functional requirements detail, NFR coverage, acceptance criteria',
+    order: 2,
+    maxQuestions: 7,
+    focusAreas: ['acceptance_criteria', 'priority', 'nfr_coverage', 'edge_cases'],
+  },
+  {
+    phase: 'constraints_validation',
+    displayName: 'Constraints & Validation',
+    description: 'Key constraints, assumption validation, scope confirmation, final gap check',
+    order: 3,
+    maxQuestions: 5,
+    focusAreas: ['constraints', 'assumptions', 'scope', 'completeness', 'final_approval'],
+  },
+];
+
+/** Quick mode phases (1 round) */
+export const QUICK_PHASES: readonly InvestigationPhaseConfig[] = [
+  {
+    phase: 'basic_clarification',
+    displayName: 'Basic Clarification',
+    description: 'Critical missing information and basic clarification only',
+    order: 1,
+    maxQuestions: 5,
+    focusAreas: ['project_name', 'critical_gaps', 'basic_nfr'],
+  },
+];
+
+/**
+ * Get phases configuration for a given depth level.
+ * @param depth
+ */
+export function getPhasesForDepth(depth: InvestigationDepth): readonly InvestigationPhaseConfig[] {
+  switch (depth) {
+    case 'thorough':
+      return THOROUGH_PHASES;
+    case 'standard':
+      return STANDARD_PHASES;
+    case 'quick':
+      return QUICK_PHASES;
+  }
+}
+
+/**
+ * Get maximum total questions for a given depth level.
+ * @param depth
+ */
+export function getMaxTotalQuestions(depth: InvestigationDepth): number {
+  switch (depth) {
+    case 'thorough':
+      return 40;
+    case 'standard':
+      return 20;
+    case 'quick':
+      return 5;
+  }
+}
+
+/**
+ * Get confidence target for a given depth level.
+ * @param depth
+ */
+export function getDefaultConfidenceTarget(depth: InvestigationDepth): number {
+  switch (depth) {
+    case 'thorough':
+      return 0.9;
+    case 'standard':
+      return 0.8;
+    case 'quick':
+      return 0.7;
+  }
+}
+
+/**
+ * Whether early exit is allowed for a given depth level.
+ * @param depth
+ */
+export function isEarlyExitAllowed(depth: InvestigationDepth): boolean {
+  return depth !== 'thorough';
+}

--- a/src/collector/types.ts
+++ b/src/collector/types.ts
@@ -5,6 +5,7 @@
  */
 
 import type { Priority, CollectedInfo } from '../scratchpad/index.js';
+import type { InvestigationDepth, InvestigationState } from './investigation-types.js';
 
 /**
  * Input source types supported by the Collector Agent
@@ -207,7 +208,7 @@ export interface CollectionSession {
   /** Project identifier */
   readonly projectId: string;
   /** Current collection status */
-  readonly status: 'collecting' | 'clarifying' | 'completed';
+  readonly status: 'collecting' | 'investigating' | 'clarifying' | 'completed';
   /** All input sources processed */
   readonly sources: readonly InputSource[];
   /** Current extraction result */
@@ -220,6 +221,8 @@ export interface CollectionSession {
   readonly startedAt: string;
   /** Session last update time */
   readonly updatedAt: string;
+  /** Investigation state (present when investigation is active or completed) */
+  readonly investigation?: InvestigationState | undefined;
 }
 
 /**
@@ -238,6 +241,8 @@ export interface CollectorAgentConfig {
   readonly detectLanguage?: boolean;
   /** Base path for scratchpad (defaults to .ad-sdlc/scratchpad) */
   readonly scratchpadBasePath?: string;
+  /** Investigation depth controlling multi-round investigation behavior */
+  readonly investigationDepth?: InvestigationDepth;
 }
 
 /**
@@ -280,6 +285,10 @@ export interface CollectionStats {
   readonly questionsAnswered: number;
   /** Total processing time in milliseconds */
   readonly processingTimeMs: number;
+  /** Number of investigation rounds completed */
+  readonly investigationRounds: number;
+  /** Number of investigation questions asked */
+  readonly investigationQuestionsAsked: number;
 }
 
 /**

--- a/src/config/schemas.ts
+++ b/src/config/schemas.ts
@@ -150,6 +150,13 @@ const ScratchpadConfigSchema = z.object({
 /**
  * V&V (Verification & Validation) configuration
  */
+const InvestigationConfigSchema = z.object({
+  depth: z.enum(['thorough', 'standard', 'quick']).optional().default('standard'),
+  max_questions_per_round: z.number().int().min(1).max(10).optional().default(5),
+  confidence_target: z.number().min(0).max(1).optional().default(0.85),
+  early_exit_on_high_confidence: z.boolean().optional().default(true),
+});
+
 const VnvConfigSchema = z.object({
   rigor: z.enum(['strict', 'standard', 'minimal']).optional().default('standard'),
   halt_on_verification_failure: z.boolean().optional().default(false),
@@ -173,6 +180,7 @@ const GlobalSettingsSchema = z.object({
   retry_policy: RetryPolicySchema.optional(),
   timeouts: TimeoutsSchema.optional(),
   vnv: VnvConfigSchema.optional(),
+  investigation: InvestigationConfigSchema.optional(),
 });
 
 /**

--- a/src/errors/codes.ts
+++ b/src/errors/codes.ts
@@ -400,6 +400,20 @@ export const VnvErrorCodes = {
 } as const;
 
 /**
+ * Collector module error codes (COL-xxx)
+ *
+ * For investigation engine and collection process errors
+ */
+export const CollectorErrorCodes = {
+  // Investigation errors (001-009)
+  COL_INVESTIGATION_FAILED: 'COL-001',
+  COL_INVESTIGATION_ROUND_FAILED: 'COL-002',
+  COL_INVESTIGATION_LLM_FAILED: 'COL-003',
+  COL_INVESTIGATION_INVALID_ANSWER: 'COL-004',
+  COL_INVESTIGATION_STATE_ERROR: 'COL-005',
+} as const;
+
+/**
  * Extended Security error codes (SEC-xxx)
  *
  * Extends SecurityErrorCodes with more specific security errors
@@ -478,6 +492,7 @@ export const ErrorCodes = {
   ...ExtendedSecurityErrorCodes,
   ...ExternalServiceErrorCodes,
   ...VnvErrorCodes,
+  ...CollectorErrorCodes,
 } as const;
 
 /**
@@ -747,4 +762,11 @@ export const ErrorCodeDescriptions: Record<ErrorCode, string> = {
   [ErrorCodes.VNV_PLAN_GENERATION_ERROR]: 'V&V plan generation failed',
   [ErrorCodes.VNV_CONFIG_ERROR]: 'V&V configuration error',
   [ErrorCodes.VNV_RIGOR_UNSUPPORTED]: 'Unsupported V&V rigor level',
+
+  // Collector
+  [ErrorCodes.COL_INVESTIGATION_FAILED]: 'Investigation process failed',
+  [ErrorCodes.COL_INVESTIGATION_ROUND_FAILED]: 'Investigation round failed',
+  [ErrorCodes.COL_INVESTIGATION_LLM_FAILED]: 'LLM question generation failed',
+  [ErrorCodes.COL_INVESTIGATION_INVALID_ANSWER]: 'Invalid investigation answer',
+  [ErrorCodes.COL_INVESTIGATION_STATE_ERROR]: 'Investigation state error',
 };

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -62,6 +62,7 @@ export {
   ExtendedSecurityErrorCodes,
   ExternalServiceErrorCodes,
   VnvErrorCodes,
+  CollectorErrorCodes,
   ErrorCodeDescriptions,
   type ErrorCode,
 } from './codes.js';

--- a/src/scratchpad/schemas.ts
+++ b/src/scratchpad/schemas.ts
@@ -44,7 +44,12 @@ export type RequirementStatus = z.infer<typeof RequirementStatusSchema>;
 /**
  * Collection status
  */
-export const CollectionStatusSchema = z.enum(['collecting', 'clarifying', 'completed']);
+export const CollectionStatusSchema = z.enum([
+  'collecting',
+  'investigating',
+  'clarifying',
+  'completed',
+]);
 export type CollectionStatus = z.infer<typeof CollectionStatusSchema>;
 
 /**
@@ -204,6 +209,16 @@ export const CollectedInfoSchema = z.object({
   dependencies: z.array(DependencySchema).optional().default([]),
   clarifications: z.array(ClarificationSchema).optional().default([]),
   sources: z.array(SourceReferenceSchema).optional().default([]),
+  investigation: z
+    .object({
+      depth: z.enum(['thorough', 'standard', 'quick']),
+      roundsCompleted: z.number().int().min(0),
+      totalQuestions: z.number().int().min(0),
+      totalAnswers: z.number().int().min(0),
+      confidenceGain: z.number().min(0).max(1),
+      phasesCompleted: z.array(z.string()),
+    })
+    .optional(),
   createdAt: z.iso.datetime(),
   updatedAt: z.iso.datetime(),
   completedAt: z.iso.datetime().optional(),

--- a/src/stage-verifier/rules.ts
+++ b/src/stage-verifier/rules.ts
@@ -318,6 +318,55 @@ const collectionRules: readonly VerificationRule[] = [
       );
     },
   },
+  {
+    checkId: 'VR-COL-INV-001',
+    name: 'Investigation completed for non-quick depth',
+    category: 'content',
+    minRigor: 'standard',
+    severity: 'warning',
+    async check(artifacts): Promise<VerificationCheck> {
+      const artifact = findArtifact(artifacts, 'collected_info');
+      if (artifact === undefined) {
+        return passCheck(this, 'No collected_info artifact — investigation check skipped');
+      }
+      const content = await safeReadFile(artifact);
+      if (content === null) {
+        return passCheck(this, 'Cannot read collected_info — investigation check skipped');
+      }
+      const parsed = safeParseYaml(content);
+      if (!parsed) {
+        return passCheck(this, 'Cannot parse collected_info — investigation check skipped');
+      }
+
+      const investigation = parsed['investigation'] as Record<string, unknown> | undefined;
+      if (investigation === undefined) {
+        return passCheck(this, 'No investigation metadata — likely quick depth');
+      }
+
+      const depth = investigation['depth'] as string | undefined;
+      const roundsCompleted = investigation['roundsCompleted'] as number | undefined;
+
+      if (depth !== 'quick' && (roundsCompleted === undefined || roundsCompleted < 1)) {
+        return failCheck(
+          this,
+          `Investigation depth is "${String(depth)}" but no rounds were completed`,
+          {
+            depth,
+            roundsCompleted: roundsCompleted ?? 0,
+          }
+        );
+      }
+
+      return passCheck(
+        this,
+        `Investigation completed: ${String(roundsCompleted)} round(s) at "${String(depth)}" depth`,
+        {
+          depth,
+          roundsCompleted,
+        }
+      );
+    },
+  },
 ];
 
 // =============================================================================

--- a/tests/collector/InvestigationEngine.test.ts
+++ b/tests/collector/InvestigationEngine.test.ts
@@ -1,0 +1,735 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { InvestigationEngine } from '../../src/collector/InvestigationEngine.js';
+import { InvestigationTemplates } from '../../src/collector/InvestigationTemplates.js';
+import { InvestigationError } from '../../src/collector/errors.js';
+import type { ExtractionResult } from '../../src/collector/types.js';
+import type {
+  InvestigationAnswer,
+  InvestigationState,
+} from '../../src/collector/investigation-types.js';
+
+vi.mock('../../src/logging/index.js', () => ({
+  getLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+function createMockExtraction(overrides: Partial<ExtractionResult> = {}): ExtractionResult {
+  return {
+    projectName: 'TestProject',
+    projectDescription: 'A test project for unit testing',
+    functionalRequirements: [
+      {
+        id: 'FR-001',
+        title: 'User login',
+        description: 'Users can log in with email and password',
+        priority: 'P1',
+        source: 'test',
+        confidence: 0.8,
+        isFunctional: true,
+      },
+      {
+        id: 'FR-002',
+        title: 'User registration',
+        description: 'Users can create an account',
+        priority: 'P1',
+        source: 'test',
+        confidence: 0.7,
+        isFunctional: true,
+      },
+      {
+        id: 'FR-003',
+        title: 'Password reset',
+        description: 'Users can reset their password',
+        priority: 'P2',
+        source: 'test',
+        confidence: 0.6,
+        isFunctional: true,
+      },
+    ],
+    nonFunctionalRequirements: [],
+    constraints: [],
+    assumptions: [],
+    dependencies: [],
+    clarificationQuestions: [],
+    overallConfidence: 0.7,
+    warnings: [],
+    ...overrides,
+  };
+}
+
+function createMockAnswer(
+  questionId: string,
+  answer: string,
+  overrides: Partial<InvestigationAnswer> = {}
+): InvestigationAnswer {
+  return {
+    questionId,
+    answer,
+    answeredAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe('InvestigationEngine', () => {
+  let engine: InvestigationEngine;
+  let templates: InvestigationTemplates;
+
+  beforeEach(() => {
+    templates = new InvestigationTemplates();
+    engine = new InvestigationEngine(
+      { depth: 'standard', enableLLMQuestions: false },
+      null,
+      templates
+    );
+  });
+
+  // ===========================================================================
+  // initialize()
+  // ===========================================================================
+
+  describe('initialize()', () => {
+    it('should set up 6 phases for thorough depth', () => {
+      const thoroughEngine = new InvestigationEngine(
+        { depth: 'thorough', enableLLMQuestions: false },
+        null,
+        templates
+      );
+      const state = thoroughEngine.initialize();
+
+      expect(state.depth).toBe('thorough');
+      expect(state.phases).toHaveLength(6);
+      expect(state.maxRounds).toBe(6);
+      expect(state.phases).toEqual([
+        'project_vision',
+        'user_analysis',
+        'functional_deep_dive',
+        'nonfunctional_analysis',
+        'constraints_risks',
+        'validation_synthesis',
+      ]);
+      expect(state.status).toBe('pending');
+      expect(state.currentRound).toBe(0);
+      expect(state.rounds).toEqual([]);
+      expect(state.startedAt).toBeDefined();
+    });
+
+    it('should set up 3 phases for standard depth', () => {
+      const state = engine.initialize();
+
+      expect(state.depth).toBe('standard');
+      expect(state.phases).toHaveLength(3);
+      expect(state.maxRounds).toBe(3);
+      expect(state.phases).toEqual([
+        'core_discovery',
+        'requirements_analysis',
+        'constraints_validation',
+      ]);
+      expect(state.status).toBe('pending');
+    });
+
+    it('should set up 1 phase for quick depth', () => {
+      const quickEngine = new InvestigationEngine(
+        { depth: 'quick', enableLLMQuestions: false },
+        null,
+        templates
+      );
+      const state = quickEngine.initialize();
+
+      expect(state.depth).toBe('quick');
+      expect(state.phases).toHaveLength(1);
+      expect(state.maxRounds).toBe(1);
+      expect(state.phases).toEqual(['basic_clarification']);
+      expect(state.status).toBe('pending');
+    });
+
+    it('should accept an explicit depth override parameter', () => {
+      const state = engine.initialize('thorough');
+
+      expect(state.depth).toBe('thorough');
+      expect(state.phases).toHaveLength(6);
+    });
+
+    it('should reset counters on re-initialization', () => {
+      engine.initialize();
+      const state = engine.initialize();
+
+      expect(state.currentRound).toBe(0);
+      expect(state.rounds).toEqual([]);
+    });
+  });
+
+  // ===========================================================================
+  // getState()
+  // ===========================================================================
+
+  describe('getState()', () => {
+    it('should return the current state after initialize', () => {
+      engine.initialize();
+      const state = engine.getState();
+
+      expect(state.depth).toBe('standard');
+      expect(state.status).toBe('pending');
+      expect(state.currentRound).toBe(0);
+      expect(state.phases).toHaveLength(3);
+    });
+
+    it('should return default state before initialize', () => {
+      const state = engine.getState();
+
+      expect(state.status).toBe('pending');
+      expect(state.currentRound).toBe(0);
+      expect(state.phases).toEqual([]);
+    });
+  });
+
+  // ===========================================================================
+  // isComplete()
+  // ===========================================================================
+
+  describe('isComplete()', () => {
+    it('should return false after initialize', () => {
+      engine.initialize();
+
+      expect(engine.isComplete()).toBe(false);
+    });
+
+    it('should return true after skipRemaining', () => {
+      engine.initialize();
+      engine.skipRemaining();
+
+      expect(engine.isComplete()).toBe(true);
+    });
+
+    it('should return false when status is in_progress', async () => {
+      engine.initialize();
+      const extraction = createMockExtraction();
+      await engine.generateNextRound(extraction, []);
+
+      expect(engine.isComplete()).toBe(false);
+    });
+  });
+
+  // ===========================================================================
+  // generateNextRound()
+  // ===========================================================================
+
+  describe('generateNextRound()', () => {
+    it('should generate questions for the first phase using templates', async () => {
+      engine.initialize();
+      const extraction = createMockExtraction();
+
+      const round = await engine.generateNextRound(extraction, []);
+
+      expect(round.roundNumber).toBe(1);
+      expect(round.phase).toBe('core_discovery');
+      expect(round.questions.length).toBeGreaterThan(0);
+      expect(round.answers).toEqual([]);
+      expect(round.startedAt).toBeDefined();
+      expect(round.confidenceBefore).toBe(extraction.overallConfidence);
+    });
+
+    it('should assign template-based question IDs (IQ-TPL-XXX)', async () => {
+      engine.initialize();
+      const extraction = createMockExtraction();
+
+      const round = await engine.generateNextRound(extraction, []);
+
+      for (const q of round.questions) {
+        expect(q.id).toMatch(/^IQ-TPL-\d{3}$/);
+      }
+    });
+
+    it('should update state to in_progress after generating a round', async () => {
+      engine.initialize();
+      const extraction = createMockExtraction();
+
+      await engine.generateNextRound(extraction, []);
+      const state = engine.getState();
+
+      expect(state.status).toBe('in_progress');
+      expect(state.currentRound).toBe(1);
+      expect(state.rounds).toHaveLength(1);
+    });
+
+    it('should throw InvestigationError when investigation is already complete', async () => {
+      engine.initialize();
+      engine.skipRemaining();
+
+      const extraction = createMockExtraction();
+
+      await expect(engine.generateNextRound(extraction, [])).rejects.toThrow(InvestigationError);
+    });
+
+    it('should generate subsequent rounds for different phases', async () => {
+      engine.initialize();
+      const extraction = createMockExtraction();
+
+      const round1 = await engine.generateNextRound(extraction, []);
+      expect(round1.phase).toBe('core_discovery');
+
+      const round2 = await engine.generateNextRound(extraction, []);
+      expect(round2.phase).toBe('requirements_analysis');
+      expect(round2.roundNumber).toBe(2);
+    });
+
+    it('should throw when all phases are exhausted', async () => {
+      engine.initialize();
+      const extraction = createMockExtraction();
+
+      // Exhaust all 3 standard phases
+      await engine.generateNextRound(extraction, []);
+      await engine.generateNextRound(extraction, []);
+      await engine.generateNextRound(extraction, []);
+
+      await expect(engine.generateNextRound(extraction, [])).rejects.toThrow(InvestigationError);
+    });
+
+    it('should include questions with correct phase property', async () => {
+      engine.initialize();
+      const extraction = createMockExtraction();
+
+      const round = await engine.generateNextRound(extraction, []);
+
+      for (const q of round.questions) {
+        expect(q.phase).toBe('core_discovery');
+        expect(q.round).toBe(1);
+      }
+    });
+  });
+
+  // ===========================================================================
+  // submitRoundAnswers()
+  // ===========================================================================
+
+  describe('submitRoundAnswers()', () => {
+    it('should submit answers and update the round', async () => {
+      engine.initialize();
+      const extraction = createMockExtraction();
+      const round = await engine.generateNextRound(extraction, []);
+
+      const answers = round.questions.map((q) => createMockAnswer(q.id, 'Test answer'));
+
+      const state = engine.submitRoundAnswers(round.roundNumber, answers);
+
+      expect(state.rounds[0]!.answers).toHaveLength(answers.length);
+      expect(state.rounds[0]!.completedAt).toBeDefined();
+    });
+
+    it('should throw for a non-existent round number', () => {
+      engine.initialize();
+
+      expect(() => engine.submitRoundAnswers(999, [])).toThrow(InvestigationError);
+    });
+
+    it('should set status to completed when all phases are done', async () => {
+      engine.initialize();
+      const extraction = createMockExtraction();
+
+      // Generate and submit all 3 standard rounds
+      for (let i = 0; i < 3; i++) {
+        const round = await engine.generateNextRound(extraction, []);
+        const answers = round.questions.map((q) => createMockAnswer(q.id, 'Test answer'));
+        engine.submitRoundAnswers(round.roundNumber, answers);
+      }
+
+      const state = engine.getState();
+      expect(state.status).toBe('completed');
+      expect(state.completedAt).toBeDefined();
+    });
+
+    it('should keep status as in_progress when phases remain', async () => {
+      engine.initialize();
+      const extraction = createMockExtraction();
+
+      const round = await engine.generateNextRound(extraction, []);
+      const answers = round.questions.map((q) => createMockAnswer(q.id, 'Test answer'));
+      const state = engine.submitRoundAnswers(round.roundNumber, answers);
+
+      expect(state.status).toBe('in_progress');
+    });
+  });
+
+  // ===========================================================================
+  // skipRemaining()
+  // ===========================================================================
+
+  describe('skipRemaining()', () => {
+    it('should set status to skipped', () => {
+      engine.initialize();
+      const state = engine.skipRemaining();
+
+      expect(state.status).toBe('skipped');
+      expect(state.completedAt).toBeDefined();
+    });
+
+    it('should be reflected in isComplete', () => {
+      engine.initialize();
+      engine.skipRemaining();
+
+      expect(engine.isComplete()).toBe(true);
+    });
+
+    it('should preserve existing rounds', async () => {
+      engine.initialize();
+      const extraction = createMockExtraction();
+      await engine.generateNextRound(extraction, []);
+
+      const state = engine.skipRemaining();
+
+      expect(state.rounds).toHaveLength(1);
+      expect(state.status).toBe('skipped');
+    });
+  });
+
+  // ===========================================================================
+  // shouldEarlyExit()
+  // ===========================================================================
+
+  describe('shouldEarlyExit()', () => {
+    it('should return true when confidence meets target for standard depth', () => {
+      engine.initialize();
+
+      // Default confidenceTarget is 0.85
+      expect(engine.shouldEarlyExit(0.9)).toBe(true);
+      expect(engine.shouldEarlyExit(0.85)).toBe(true);
+    });
+
+    it('should return false when confidence is below target', () => {
+      engine.initialize();
+
+      expect(engine.shouldEarlyExit(0.5)).toBe(false);
+      expect(engine.shouldEarlyExit(0.84)).toBe(false);
+    });
+
+    it('should return false for thorough depth even with high confidence', () => {
+      const thoroughEngine = new InvestigationEngine(
+        { depth: 'thorough', enableLLMQuestions: false },
+        null,
+        templates
+      );
+      thoroughEngine.initialize();
+
+      // thorough depth does not allow early exit
+      expect(thoroughEngine.shouldEarlyExit(0.99)).toBe(false);
+    });
+
+    it('should return true for quick depth when confidence is met', () => {
+      const quickEngine = new InvestigationEngine(
+        { depth: 'quick', enableLLMQuestions: false },
+        null,
+        templates
+      );
+      quickEngine.initialize();
+
+      expect(quickEngine.shouldEarlyExit(0.9)).toBe(true);
+    });
+
+    it('should return false when earlyExitOnHighConfidence is disabled', () => {
+      const noExitEngine = new InvestigationEngine(
+        {
+          depth: 'standard',
+          enableLLMQuestions: false,
+          earlyExitOnHighConfidence: false,
+        },
+        null,
+        templates
+      );
+      noExitEngine.initialize();
+
+      expect(noExitEngine.shouldEarlyExit(1.0)).toBe(false);
+    });
+  });
+
+  // ===========================================================================
+  // enrichExtraction()
+  // ===========================================================================
+
+  describe('enrichExtraction()', () => {
+    /**
+     * Helper: build a minimal InvestigationState with one round containing
+     * a single question and its corresponding answer.
+     */
+    function buildStateWithAnswer(
+      question: {
+        id: string;
+        format: string;
+        question: string;
+        category: string;
+        relatedTo?: string;
+      },
+      answer: InvestigationAnswer
+    ): InvestigationState {
+      return {
+        depth: 'standard',
+        currentRound: 1,
+        maxRounds: 3,
+        phases: ['core_discovery', 'requirements_analysis', 'constraints_validation'],
+        rounds: [
+          {
+            roundNumber: 1,
+            phase: 'core_discovery',
+            questions: [
+              {
+                id: question.id,
+                phase: 'core_discovery',
+                round: 1,
+                format: question.format as any,
+                question: question.question,
+                context: 'Test context',
+                required: true,
+                category: question.category as any,
+                relatedTo: question.relatedTo,
+              },
+            ],
+            answers: [answer],
+            startedAt: new Date().toISOString(),
+            confidenceBefore: 0.7,
+          },
+        ],
+        status: 'in_progress',
+      };
+    }
+
+    it('should create NFRs from multi_select security measures', () => {
+      const extraction = createMockExtraction();
+      const state = buildStateWithAnswer(
+        {
+          id: 'IQ-001',
+          format: 'multi_select',
+          question: 'Which security measures are required?',
+          category: 'quality',
+        },
+        createMockAnswer('IQ-001', 'Authentication, Encryption', {
+          selectedOptions: ['Authentication (login)', 'Data encryption at rest'],
+        })
+      );
+
+      const enriched = engine.enrichExtraction(extraction, state);
+
+      expect(enriched.nonFunctionalRequirements.length).toBe(2);
+      expect(enriched.nonFunctionalRequirements[0]!.id).toMatch(/^NFR-INV-/);
+      expect(enriched.nonFunctionalRequirements[0]!.title).toBe('Authentication (login)');
+      expect(enriched.nonFunctionalRequirements[0]!.description).toContain('Security requirement');
+      expect(enriched.nonFunctionalRequirements[0]!.nfrCategory).toBe('security');
+      expect(enriched.nonFunctionalRequirements[0]!.priority).toBe('P1');
+      expect(enriched.nonFunctionalRequirements[1]!.title).toBe('Data encryption at rest');
+    });
+
+    it('should create a constraint from yes_no regulatory answer', () => {
+      const extraction = createMockExtraction();
+      const state = buildStateWithAnswer(
+        {
+          id: 'IQ-002',
+          format: 'yes_no',
+          question: 'Are there regulatory or compliance requirements?',
+          category: 'constraint',
+        },
+        createMockAnswer('IQ-002', 'yes')
+      );
+
+      const enriched = engine.enrichExtraction(extraction, state);
+
+      expect(enriched.constraints.length).toBe(1);
+      expect(enriched.constraints[0]!.id).toMatch(/^CON-INV-/);
+      expect(enriched.constraints[0]!.description).toContain('Regulatory');
+      expect(enriched.constraints[0]!.type).toBe('regulatory');
+    });
+
+    it('should not create a constraint from yes_no regulatory answer when answer is no', () => {
+      const extraction = createMockExtraction();
+      const state = buildStateWithAnswer(
+        {
+          id: 'IQ-002',
+          format: 'yes_no',
+          question: 'Are there regulatory or compliance requirements?',
+          category: 'constraint',
+        },
+        createMockAnswer('IQ-002', 'no')
+      );
+
+      const enriched = engine.enrichExtraction(extraction, state);
+
+      expect(enriched.constraints.length).toBe(0);
+    });
+
+    it('should update FR priorities from priority_ranking answer', () => {
+      const extraction = createMockExtraction();
+      const state = buildStateWithAnswer(
+        {
+          id: 'IQ-003',
+          format: 'priority_ranking',
+          question: 'Please rank the functional requirements:',
+          category: 'priority',
+        },
+        createMockAnswer('IQ-003', 'FR-003,FR-001,FR-002', {
+          rankings: ['FR-003: Password reset', 'FR-001: User login', 'FR-002: User registration'],
+        })
+      );
+
+      const enriched = engine.enrichExtraction(extraction, state);
+
+      // FR-003 is first (position 0/3 = 0.0 < 0.25) → P0
+      const fr3 = enriched.functionalRequirements.find((r) => r.id === 'FR-003');
+      expect(fr3!.priority).toBe('P0');
+
+      // FR-001 is second (position 1/3 ≈ 0.33 < 0.5) → P1
+      const fr1 = enriched.functionalRequirements.find((r) => r.id === 'FR-001');
+      expect(fr1!.priority).toBe('P1');
+
+      // FR-002 is third (position 2/3 ≈ 0.67 < 0.75) → P2
+      const fr2 = enriched.functionalRequirements.find((r) => r.id === 'FR-002');
+      expect(fr2!.priority).toBe('P2');
+    });
+
+    it('should boost FR confidence from confirmation agree answer', () => {
+      const extraction = createMockExtraction();
+      const originalConfidences = extraction.functionalRequirements.map((r) => r.confidence);
+
+      const state = buildStateWithAnswer(
+        {
+          id: 'IQ-004',
+          format: 'confirmation',
+          question: 'Is this interpretation accurate?',
+          category: 'requirement',
+        },
+        createMockAnswer('IQ-004', 'agree')
+      );
+
+      const enriched = engine.enrichExtraction(extraction, state);
+
+      for (let i = 0; i < enriched.functionalRequirements.length; i++) {
+        const expected = Math.min(1.0, originalConfidences[i]! + 0.15);
+        expect(enriched.functionalRequirements[i]!.confidence).toBeCloseTo(expected, 5);
+      }
+    });
+
+    it('should create availability NFR from scale_rating answer', () => {
+      const extraction = createMockExtraction();
+      const state = buildStateWithAnswer(
+        {
+          id: 'IQ-005',
+          format: 'scale_rating',
+          question: 'What is the required availability level?',
+          category: 'quality',
+        },
+        createMockAnswer('IQ-005', '4', {
+          scaleValue: 4,
+        })
+      );
+
+      const enriched = engine.enrichExtraction(extraction, state);
+
+      expect(enriched.nonFunctionalRequirements.length).toBe(1);
+      const nfr = enriched.nonFunctionalRequirements[0]!;
+      expect(nfr.id).toMatch(/^NFR-INV-/);
+      expect(nfr.title).toBe('Availability Requirement');
+      expect(nfr.description).toContain('99.95%');
+      expect(nfr.nfrCategory).toBe('reliability');
+      expect(nfr.priority).toBe('P0'); // value >= 4 → P0
+    });
+
+    it('should assign P1 priority for lower availability scale values', () => {
+      const extraction = createMockExtraction();
+      const state = buildStateWithAnswer(
+        {
+          id: 'IQ-005',
+          format: 'scale_rating',
+          question: 'What is the required availability level?',
+          category: 'quality',
+        },
+        createMockAnswer('IQ-005', '3', {
+          scaleValue: 3,
+        })
+      );
+
+      const enriched = engine.enrichExtraction(extraction, state);
+
+      const nfr = enriched.nonFunctionalRequirements[0]!;
+      expect(nfr.priority).toBe('P1'); // value < 4 → P1
+      expect(nfr.description).toContain('99.9%');
+    });
+
+    it('should recalculate overall confidence after enrichment', () => {
+      const extraction = createMockExtraction({
+        nonFunctionalRequirements: [],
+        overallConfidence: 0.5,
+      });
+      const state = buildStateWithAnswer(
+        {
+          id: 'IQ-004',
+          format: 'confirmation',
+          question: 'Is this interpretation accurate?',
+          category: 'requirement',
+        },
+        createMockAnswer('IQ-004', 'agree')
+      );
+
+      const enriched = engine.enrichExtraction(extraction, state);
+
+      // Confidence should change from the original
+      expect(enriched.overallConfidence).not.toBe(0.5);
+      expect(enriched.overallConfidence).toBeGreaterThan(0);
+      expect(enriched.overallConfidence).toBeLessThanOrEqual(1.0);
+    });
+
+    it('should handle state with no answers gracefully', () => {
+      const extraction = createMockExtraction();
+      const state: InvestigationState = {
+        depth: 'standard',
+        currentRound: 1,
+        maxRounds: 3,
+        phases: ['core_discovery', 'requirements_analysis', 'constraints_validation'],
+        rounds: [
+          {
+            roundNumber: 1,
+            phase: 'core_discovery',
+            questions: [],
+            answers: [],
+            startedAt: new Date().toISOString(),
+            confidenceBefore: 0.7,
+          },
+        ],
+        status: 'in_progress',
+      };
+
+      const enriched = engine.enrichExtraction(extraction, state);
+
+      // Should return a result with recalculated confidence but no structural changes
+      expect(enriched.functionalRequirements).toHaveLength(3);
+      expect(enriched.nonFunctionalRequirements).toHaveLength(0);
+      expect(enriched.constraints).toHaveLength(0);
+    });
+
+    it('should filter out "No constraints" from multi_select security options', () => {
+      const extraction = createMockExtraction();
+      const state = buildStateWithAnswer(
+        {
+          id: 'IQ-010',
+          format: 'multi_select',
+          question: 'Which security measures are required?',
+          category: 'quality',
+        },
+        createMockAnswer('IQ-010', 'No constraints', {
+          selectedOptions: ['No constraints'],
+        })
+      );
+
+      const enriched = engine.enrichExtraction(extraction, state);
+
+      // "No constraints" should be filtered out, resulting in 0 NFRs
+      expect(enriched.nonFunctionalRequirements.length).toBe(0);
+    });
+  });
+});

--- a/tests/collector/InvestigationTemplates.test.ts
+++ b/tests/collector/InvestigationTemplates.test.ts
@@ -1,0 +1,605 @@
+import { describe, it, expect } from 'vitest';
+import {
+  InvestigationTemplates,
+  TRIGGER_CONDITIONS,
+} from '../../src/collector/InvestigationTemplates.js';
+import type { QuestionTemplate } from '../../src/collector/InvestigationTemplates.js';
+import type { ExtractionResult } from '../../src/collector/types.js';
+import type { InvestigationPhase } from '../../src/collector/investigation-types.js';
+
+// =============================================================================
+// Helper: minimal mock ExtractionResult
+// =============================================================================
+
+function createMockExtraction(overrides: Partial<ExtractionResult> = {}): ExtractionResult {
+  return {
+    projectName: 'TestProject',
+    projectDescription: 'A test project description',
+    functionalRequirements: [],
+    nonFunctionalRequirements: [],
+    constraints: [],
+    assumptions: [],
+    dependencies: [],
+    clarificationQuestions: [],
+    overallConfidence: 0.5,
+    warnings: [],
+    ...overrides,
+  };
+}
+
+// =============================================================================
+// 1. TRIGGER_CONDITIONS
+// =============================================================================
+
+describe('TRIGGER_CONDITIONS', () => {
+  describe("'always'", () => {
+    it('returns true regardless of extraction state', () => {
+      const fn = TRIGGER_CONDITIONS['always']!;
+      expect(fn(createMockExtraction())).toBe(true);
+      expect(fn(createMockExtraction({ projectName: undefined }))).toBe(true);
+    });
+  });
+
+  describe("'missing.projectName'", () => {
+    it('returns true when projectName is undefined', () => {
+      const fn = TRIGGER_CONDITIONS['missing.projectName']!;
+      expect(fn(createMockExtraction({ projectName: undefined }))).toBe(true);
+    });
+
+    it('returns true when projectName is empty string', () => {
+      const fn = TRIGGER_CONDITIONS['missing.projectName']!;
+      expect(fn(createMockExtraction({ projectName: '' }))).toBe(true);
+    });
+
+    it('returns false when projectName is present', () => {
+      const fn = TRIGGER_CONDITIONS['missing.projectName']!;
+      expect(fn(createMockExtraction({ projectName: 'MyApp' }))).toBe(false);
+    });
+  });
+
+  describe("'missing.nfr.security'", () => {
+    it('returns true when no security NFR exists', () => {
+      const fn = TRIGGER_CONDITIONS['missing.nfr.security']!;
+      expect(fn(createMockExtraction({ nonFunctionalRequirements: [] }))).toBe(true);
+    });
+
+    it('returns true when NFRs exist but none is security', () => {
+      const fn = TRIGGER_CONDITIONS['missing.nfr.security']!;
+      const extraction = createMockExtraction({
+        nonFunctionalRequirements: [
+          {
+            id: 'NFR-001',
+            title: 'Performance',
+            description: 'Fast response',
+            priority: 'P1',
+            source: 'input',
+            confidence: 0.8,
+            isFunctional: false,
+            nfrCategory: 'performance',
+          },
+        ],
+      });
+      expect(fn(extraction)).toBe(true);
+    });
+
+    it('returns false when a security NFR exists', () => {
+      const fn = TRIGGER_CONDITIONS['missing.nfr.security']!;
+      const extraction = createMockExtraction({
+        nonFunctionalRequirements: [
+          {
+            id: 'NFR-002',
+            title: 'Security',
+            description: 'Auth required',
+            priority: 'P0',
+            source: 'input',
+            confidence: 0.9,
+            isFunctional: false,
+            nfrCategory: 'security',
+          },
+        ],
+      });
+      expect(fn(extraction)).toBe(false);
+    });
+  });
+
+  describe("'missing.constraints'", () => {
+    it('returns true when constraints array is empty', () => {
+      const fn = TRIGGER_CONDITIONS['missing.constraints']!;
+      expect(fn(createMockExtraction({ constraints: [] }))).toBe(true);
+    });
+
+    it('returns false when constraints exist', () => {
+      const fn = TRIGGER_CONDITIONS['missing.constraints']!;
+      const extraction = createMockExtraction({
+        constraints: [
+          {
+            id: 'CON-001',
+            description: 'Must use PostgreSQL',
+            type: 'technical',
+            source: 'input',
+            confidence: 0.9,
+          },
+        ],
+      });
+      expect(fn(extraction)).toBe(false);
+    });
+  });
+
+  describe("'has.assumptions'", () => {
+    it('returns true when assumptions exist', () => {
+      const fn = TRIGGER_CONDITIONS['has.assumptions']!;
+      const extraction = createMockExtraction({
+        assumptions: [
+          {
+            id: 'ASM-001',
+            description: 'Users have modern browsers',
+            source: 'input',
+            confidence: 0.7,
+          },
+        ],
+      });
+      expect(fn(extraction)).toBe(true);
+    });
+
+    it('returns false when assumptions array is empty', () => {
+      const fn = TRIGGER_CONDITIONS['has.assumptions']!;
+      expect(fn(createMockExtraction({ assumptions: [] }))).toBe(false);
+    });
+  });
+
+  describe("'has.lowConfidenceRequirements'", () => {
+    it('returns true when a FR has confidence < 0.7', () => {
+      const fn = TRIGGER_CONDITIONS['has.lowConfidenceRequirements']!;
+      const extraction = createMockExtraction({
+        functionalRequirements: [
+          {
+            id: 'FR-001',
+            title: 'Login',
+            description: 'User login',
+            priority: 'P1',
+            source: 'input',
+            confidence: 0.5,
+            isFunctional: true,
+          },
+        ],
+      });
+      expect(fn(extraction)).toBe(true);
+    });
+
+    it('returns false when all FRs have confidence >= 0.7', () => {
+      const fn = TRIGGER_CONDITIONS['has.lowConfidenceRequirements']!;
+      const extraction = createMockExtraction({
+        functionalRequirements: [
+          {
+            id: 'FR-001',
+            title: 'Login',
+            description: 'User login',
+            priority: 'P1',
+            source: 'input',
+            confidence: 0.9,
+            isFunctional: true,
+          },
+        ],
+      });
+      expect(fn(extraction)).toBe(false);
+    });
+
+    it('returns false when there are no FRs', () => {
+      const fn = TRIGGER_CONDITIONS['has.lowConfidenceRequirements']!;
+      expect(fn(createMockExtraction())).toBe(false);
+    });
+  });
+
+  describe("'has.multipleRequirements'", () => {
+    it('returns true when >= 3 functional requirements', () => {
+      const fn = TRIGGER_CONDITIONS['has.multipleRequirements']!;
+      const makeFR = (n: number) => ({
+        id: `FR-00${n}`,
+        title: `Req ${n}`,
+        description: `Desc ${n}`,
+        priority: 'P1' as const,
+        source: 'input',
+        confidence: 0.8,
+        isFunctional: true,
+      });
+      const extraction = createMockExtraction({
+        functionalRequirements: [makeFR(1), makeFR(2), makeFR(3)],
+      });
+      expect(fn(extraction)).toBe(true);
+    });
+
+    it('returns false when fewer than 3 FRs', () => {
+      const fn = TRIGGER_CONDITIONS['has.multipleRequirements']!;
+      const extraction = createMockExtraction({
+        functionalRequirements: [
+          {
+            id: 'FR-001',
+            title: 'Login',
+            description: 'desc',
+            priority: 'P1',
+            source: 'input',
+            confidence: 0.8,
+            isFunctional: true,
+          },
+        ],
+      });
+      expect(fn(extraction)).toBe(false);
+    });
+  });
+
+  describe("'has.missingAcceptanceCriteria'", () => {
+    it('returns true when a FR has no acceptanceCriteria', () => {
+      const fn = TRIGGER_CONDITIONS['has.missingAcceptanceCriteria']!;
+      const extraction = createMockExtraction({
+        functionalRequirements: [
+          {
+            id: 'FR-001',
+            title: 'Login',
+            description: 'desc',
+            priority: 'P1',
+            source: 'input',
+            confidence: 0.8,
+            isFunctional: true,
+          },
+        ],
+      });
+      expect(fn(extraction)).toBe(true);
+    });
+
+    it('returns true when a FR has empty acceptanceCriteria array', () => {
+      const fn = TRIGGER_CONDITIONS['has.missingAcceptanceCriteria']!;
+      const extraction = createMockExtraction({
+        functionalRequirements: [
+          {
+            id: 'FR-001',
+            title: 'Login',
+            description: 'desc',
+            priority: 'P1',
+            source: 'input',
+            confidence: 0.8,
+            isFunctional: true,
+            acceptanceCriteria: [],
+          },
+        ],
+      });
+      expect(fn(extraction)).toBe(true);
+    });
+
+    it('returns false when all FRs have acceptance criteria', () => {
+      const fn = TRIGGER_CONDITIONS['has.missingAcceptanceCriteria']!;
+      const extraction = createMockExtraction({
+        functionalRequirements: [
+          {
+            id: 'FR-001',
+            title: 'Login',
+            description: 'desc',
+            priority: 'P1',
+            source: 'input',
+            confidence: 0.8,
+            isFunctional: true,
+            acceptanceCriteria: ['User can log in with email/password'],
+          },
+        ],
+      });
+      expect(fn(extraction)).toBe(false);
+    });
+  });
+});
+
+// =============================================================================
+// 2. InvestigationTemplates.getTemplatesForPhase()
+// =============================================================================
+
+describe('InvestigationTemplates.getTemplatesForPhase()', () => {
+  const templates = new InvestigationTemplates();
+  const extraction = createMockExtraction();
+
+  it('returns templates for project_vision phase', () => {
+    const result = templates.getTemplatesForPhase('project_vision', extraction, [], 10);
+    expect(result.length).toBeGreaterThan(0);
+    expect(result.every((t) => t.phase === 'project_vision')).toBe(true);
+  });
+
+  it('filters out templates whose trigger condition is not met', () => {
+    // functional_deep_dive has templates with condition 'has.missingAcceptanceCriteria',
+    // 'has.lowConfidenceRequirements', 'has.multipleRequirements' — none met with empty FRs.
+    const emptyExtraction = createMockExtraction({
+      functionalRequirements: [],
+    });
+    const result = templates.getTemplatesForPhase('functional_deep_dive', emptyExtraction, [], 10);
+    // Only templates with condition 'always' or 'has.functionalRequirements' (false) should pass.
+    // 'always' templates should still be included.
+    for (const t of result) {
+      const condFn = TRIGGER_CONDITIONS[t.condition];
+      expect(condFn).toBeDefined();
+      expect(condFn!(emptyExtraction)).toBe(true);
+    }
+  });
+
+  it('excludes templates with already-asked tags', () => {
+    const result = templates.getTemplatesForPhase(
+      'project_vision',
+      extraction,
+      ['project_purpose', 'stakeholders'],
+      10
+    );
+    for (const t of result) {
+      const hasOverlap = t.tags.some((tag) => ['project_purpose', 'stakeholders'].includes(tag));
+      expect(hasOverlap).toBe(false);
+    }
+  });
+
+  it('limits results by maxQuestions', () => {
+    const result = templates.getTemplatesForPhase('project_vision', extraction, [], 2);
+    expect(result.length).toBeLessThanOrEqual(2);
+  });
+
+  it('sorts by priority (highest first)', () => {
+    const result = templates.getTemplatesForPhase('project_vision', extraction, [], 10);
+    for (let i = 1; i < result.length; i++) {
+      expect(result[i - 1]!.priority).toBeGreaterThanOrEqual(result[i]!.priority);
+    }
+  });
+
+  it('returns empty array for unknown phase', () => {
+    const result = templates.getTemplatesForPhase(
+      'nonexistent_phase' as InvestigationPhase,
+      extraction,
+      [],
+      10
+    );
+    expect(result).toEqual([]);
+  });
+});
+
+// =============================================================================
+// 3. InvestigationTemplates.parameterizeQuestion()
+// =============================================================================
+
+describe('InvestigationTemplates.parameterizeQuestion()', () => {
+  const templates = new InvestigationTemplates();
+
+  it('replaces {projectName} with extraction projectName', () => {
+    const template: QuestionTemplate = {
+      id: 'TEST-001',
+      phase: 'project_vision',
+      format: 'free_text',
+      question: 'What is the goal of {projectName}?',
+      context: 'test',
+      category: 'scope',
+      required: false,
+      priority: 5,
+      condition: 'always',
+      tags: ['test'],
+    };
+    const extraction = createMockExtraction({ projectName: 'SuperApp' });
+    const result = templates.parameterizeQuestion(template, extraction);
+    expect(result).toBe('What is the goal of SuperApp?');
+  });
+
+  it('handles missing projectName gracefully (defaults to "the project")', () => {
+    const template: QuestionTemplate = {
+      id: 'TEST-002',
+      phase: 'project_vision',
+      format: 'free_text',
+      question: 'Describe {projectName} in one sentence.',
+      context: 'test',
+      category: 'scope',
+      required: false,
+      priority: 5,
+      condition: 'always',
+      tags: ['test'],
+    };
+    const extraction = createMockExtraction({ projectName: undefined });
+    const result = templates.parameterizeQuestion(template, extraction);
+    expect(result).toBe('Describe the project in one sentence.');
+  });
+
+  it('replaces {requirement.title} and {requirement.id}', () => {
+    const template: QuestionTemplate = {
+      id: 'TEST-003',
+      phase: 'functional_deep_dive',
+      format: 'confirmation',
+      question: 'Is {requirement.id}: {requirement.title} correctly captured?',
+      context: 'test',
+      category: 'requirement',
+      required: true,
+      priority: 9,
+      condition: 'has.lowConfidenceRequirements',
+      tags: ['test'],
+    };
+    const extraction = createMockExtraction({
+      functionalRequirements: [
+        {
+          id: 'FR-001',
+          title: 'User Authentication',
+          description: 'Login and registration',
+          priority: 'P0',
+          source: 'input',
+          confidence: 0.5,
+          isFunctional: true,
+        },
+      ],
+    });
+    const result = templates.parameterizeQuestion(template, extraction);
+    expect(result).toBe('Is FR-001: User Authentication correctly captured?');
+  });
+
+  it('replaces {assumption.description}', () => {
+    const template: QuestionTemplate = {
+      id: 'TEST-004',
+      phase: 'constraints_risks',
+      format: 'confirmation',
+      question: 'You assumed: {assumption.description}. Is this correct?',
+      context: 'test',
+      category: 'assumption',
+      required: true,
+      priority: 9,
+      condition: 'has.assumptions',
+      tags: ['test'],
+    };
+    const extraction = createMockExtraction({
+      assumptions: [
+        {
+          id: 'ASM-001',
+          description: 'Users have internet access',
+          source: 'input',
+          confidence: 0.8,
+        },
+      ],
+    });
+    const result = templates.parameterizeQuestion(template, extraction);
+    expect(result).toBe('You assumed: Users have internet access. Is this correct?');
+  });
+});
+
+// =============================================================================
+// 4. InvestigationTemplates.templateToQuestion()
+// =============================================================================
+
+describe('InvestigationTemplates.templateToQuestion()', () => {
+  const templates = new InvestigationTemplates();
+
+  it('produces a valid InvestigationQuestion', () => {
+    const template: QuestionTemplate = {
+      id: 'IQ-VIS-001',
+      phase: 'project_vision',
+      format: 'free_text',
+      question: 'What is the goal?',
+      context: 'Understanding the goal is important.',
+      category: 'scope',
+      required: true,
+      priority: 10,
+      condition: 'always',
+      tags: ['project_purpose'],
+    };
+    const extraction = createMockExtraction();
+    const result = templates.templateToQuestion(template, extraction, 'Q-001', 1);
+
+    expect(result).toBeDefined();
+    expect(result.id).toBe('Q-001');
+    expect(result.phase).toBe('project_vision');
+    expect(result.round).toBe(1);
+    expect(result.format).toBe('free_text');
+    expect(result.question).toBe('What is the goal?');
+    expect(result.context).toBe('Understanding the goal is important.');
+    expect(result.required).toBe(true);
+    expect(result.category).toBe('scope');
+    expect(result.relatedTo).toBeUndefined();
+  });
+
+  it('sets correct ID, round, and phase from arguments', () => {
+    const template: QuestionTemplate = {
+      id: 'IQ-USER-001',
+      phase: 'user_analysis',
+      format: 'free_text',
+      question: 'Who are the users?',
+      context: 'context',
+      category: 'stakeholder',
+      required: true,
+      priority: 10,
+      condition: 'always',
+      tags: ['user_personas'],
+    };
+    const extraction = createMockExtraction();
+    const result = templates.templateToQuestion(template, extraction, 'Q-042', 3);
+
+    expect(result.id).toBe('Q-042');
+    expect(result.round).toBe(3);
+    expect(result.phase).toBe('user_analysis');
+  });
+
+  it('generates dynamic options for priority_ranking format', () => {
+    const makeFR = (n: number) => ({
+      id: `FR-00${n}`,
+      title: `Feature ${n}`,
+      description: `Desc ${n}`,
+      priority: 'P1' as const,
+      source: 'input',
+      confidence: 0.8,
+      isFunctional: true,
+    });
+    const template: QuestionTemplate = {
+      id: 'IQ-FUNC-003',
+      phase: 'functional_deep_dive',
+      format: 'priority_ranking',
+      question: 'Rank the following requirements:',
+      context: 'Priority ranking is important.',
+      category: 'priority',
+      required: true,
+      priority: 8,
+      options: ['placeholder'],
+      condition: 'has.multipleRequirements',
+      tags: ['priority_ranking'],
+    };
+    const extraction = createMockExtraction({
+      functionalRequirements: [makeFR(1), makeFR(2), makeFR(3)],
+    });
+    const result = templates.templateToQuestion(template, extraction, 'Q-100', 2);
+
+    expect(result.options).toEqual(['FR-001: Feature 1', 'FR-002: Feature 2', 'FR-003: Feature 3']);
+  });
+
+  it('preserves static options when format is not priority_ranking', () => {
+    const template: QuestionTemplate = {
+      id: 'IQ-VIS-003',
+      phase: 'project_vision',
+      format: 'multi_select',
+      question: 'Which project type?',
+      context: 'context',
+      category: 'scope',
+      required: false,
+      priority: 8,
+      options: ['Web app', 'Mobile app', 'CLI'],
+      condition: 'always',
+      tags: ['project_type'],
+    };
+    const extraction = createMockExtraction();
+    const result = templates.templateToQuestion(template, extraction, 'Q-200', 1);
+
+    expect(result.options).toEqual(['Web app', 'Mobile app', 'CLI']);
+  });
+
+  it('passes through scaleRange when present', () => {
+    const template: QuestionTemplate = {
+      id: 'IQ-VIS-006',
+      phase: 'project_vision',
+      format: 'scale_rating',
+      question: 'How critical is this?',
+      context: 'context',
+      category: 'scope',
+      required: false,
+      priority: 6,
+      scaleRange: { min: 1, max: 5, labels: { min: 'Low', max: 'High' } },
+      condition: 'always',
+      tags: ['criticality'],
+    };
+    const extraction = createMockExtraction();
+    const result = templates.templateToQuestion(template, extraction, 'Q-300', 1);
+
+    expect(result.scaleRange).toEqual({
+      min: 1,
+      max: 5,
+      labels: { min: 'Low', max: 'High' },
+    });
+  });
+
+  it('sets scaleRange to undefined when template has none', () => {
+    const template: QuestionTemplate = {
+      id: 'TEST-005',
+      phase: 'project_vision',
+      format: 'free_text',
+      question: 'Describe the project.',
+      context: 'context',
+      category: 'scope',
+      required: false,
+      priority: 5,
+      condition: 'always',
+      tags: ['test'],
+    };
+    const extraction = createMockExtraction();
+    const result = templates.templateToQuestion(template, extraction, 'Q-400', 1);
+
+    expect(result.scaleRange).toBeUndefined();
+  });
+});

--- a/tests/collector/investigation-integration.test.ts
+++ b/tests/collector/investigation-integration.test.ts
@@ -1,0 +1,479 @@
+/**
+ * Integration tests for the investigation flow through CollectorAgent.
+ *
+ * Validates the full lifecycle: startInvestigation → submitAnswers → skipInvestigation → finalize,
+ * including backward compatibility with 'quick' mode and investigation metadata in CollectedInfo.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Mocks — must be declared before importing the modules under test
+// ---------------------------------------------------------------------------
+
+vi.mock('../../src/logging/index.js', () => ({
+  getLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    child: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }),
+  }),
+}));
+
+vi.mock('node:fs/promises', () => ({
+  readdir: vi.fn().mockResolvedValue([]),
+  rm: vi.fn().mockResolvedValue(undefined),
+  rmdir: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../../src/scratchpad/index.js', () => ({
+  getScratchpad: () => ({
+    generateProjectId: vi.fn().mockResolvedValue('test-inv-001'),
+    initializeProject: vi.fn().mockResolvedValue(undefined),
+    getProjectPath: vi.fn().mockReturnValue('/tmp/test'),
+    getSectionPath: vi.fn().mockReturnValue('/tmp/test'),
+    getCollectedInfoPath: vi.fn().mockReturnValue('/tmp/collected_info.yaml'),
+    writeYaml: vi.fn().mockResolvedValue(undefined),
+  }),
+  resetScratchpad: vi.fn(),
+}));
+
+import { CollectorAgent } from '../../src/collector/CollectorAgent.js';
+import type {
+  InvestigationAnswer,
+  InvestigationRound,
+} from '../../src/collector/investigation-types.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Sample input crafted to produce 'completed' status after extraction (zero clarification
+ * questions). This requires:
+ * - Project name detected ("Project: ...")
+ * - Project description detected ("This project is ...")
+ * - Performance NFR present ("performance", "200ms")
+ * - Security NFR present ("security", "encrypt")
+ * - All requirements high-confidence (strong "must" keyword)
+ * - No assumptions detected
+ */
+const RICH_INPUT = `
+  Project: InvestigationTestApp
+  This project is a web application for managing user accounts and data.
+  - The system must support user authentication with OAuth2
+  - The system must support role-based access control
+  - The system must encrypt all data at rest and in transit for security
+  - Performance: The application must process API requests within 200ms
+  - The system must handle at least 1000 concurrent users
+`;
+
+/**
+ * Minimal input that will trigger clarification questions (no project description).
+ */
+const MINIMAL_INPUT = `
+  Some vague requirements about a system.
+`;
+
+/**
+ * Build InvestigationAnswer entries for every question in a round.
+ */
+function buildAnswersForRound(round: InvestigationRound): InvestigationAnswer[] {
+  return round.questions.map((q) => ({
+    questionId: q.id,
+    answer: `Answer for: ${q.question}`,
+    answeredAt: new Date().toISOString(),
+  }));
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('Investigation integration through CollectorAgent', () => {
+  let agent: CollectorAgent;
+
+  // =========================================================================
+  // 1. Quick mode backward compatibility
+  // =========================================================================
+
+  describe('quick mode backward compatibility', () => {
+    beforeEach(() => {
+      agent = new CollectorAgent({ investigationDepth: 'quick' });
+    });
+
+    it('should process inputs and finalize without investigation state when no investigation is started', async () => {
+      await agent.startSession('QuickProject');
+      agent.addTextInput(RICH_INPUT);
+      agent.processInputs();
+
+      // No investigation was started — state should be null
+      expect(agent.getInvestigationState()).toBeNull();
+
+      const session = agent.getSession();
+      expect(session).not.toBeNull();
+      // Status is either 'clarifying' (questions generated) or 'completed'
+      expect(['clarifying', 'completed']).toContain(session!.status);
+      // The session should have no investigation field
+      expect(session!.investigation).toBeUndefined();
+    });
+
+    it('should finalize successfully without investigation', async () => {
+      await agent.startSession('QuickProject');
+      agent.addTextInput(RICH_INPUT);
+      agent.processInputs();
+
+      // Skip clarification if in that state
+      const session = agent.getSession();
+      if (session!.status === 'clarifying') {
+        agent.skipClarification();
+      }
+
+      const result = await agent.finalize('QuickProject', 'Backward-compat test');
+
+      expect(result.success).toBe(true);
+      expect(result.stats.investigationRounds).toBe(0);
+      expect(result.stats.investigationQuestionsAsked).toBe(0);
+      // CollectedInfo should not have investigation metadata
+      expect((result.collectedInfo as Record<string, unknown>)['investigation']).toBeUndefined();
+    });
+  });
+
+  // =========================================================================
+  // 2. Standard mode investigation flow
+  // =========================================================================
+
+  describe('standard mode investigation flow', () => {
+    beforeEach(() => {
+      agent = new CollectorAgent({ investigationDepth: 'standard' });
+    });
+
+    it('should start investigation and return first round with questions', async () => {
+      await agent.startSession('StandardProject');
+      agent.addTextInput(RICH_INPUT);
+      // Do NOT call processInputs() — let startInvestigation() handle it
+      const round1 = await agent.startInvestigation();
+
+      expect(round1).toBeDefined();
+      expect(round1.roundNumber).toBe(1);
+      expect(round1.phase).toBe('core_discovery');
+      expect(round1.questions.length).toBeGreaterThan(0);
+      expect(round1.answers).toHaveLength(0);
+
+      // Session should be in investigating state
+      const session = agent.getSession();
+      expect(session!.status).toBe('investigating');
+
+      // Investigation state should be populated
+      const invState = agent.getInvestigationState();
+      expect(invState).not.toBeNull();
+      expect(invState!.depth).toBe('standard');
+      expect(invState!.currentRound).toBe(1);
+      expect(invState!.status).toBe('in_progress');
+      expect(invState!.rounds).toHaveLength(1);
+    });
+
+    it('should accept answers and advance or complete investigation', async () => {
+      await agent.startSession('StandardProject');
+      agent.addTextInput(RICH_INPUT);
+
+      // Round 1
+      const round1 = await agent.startInvestigation();
+      const answers1 = buildAnswersForRound(round1);
+      const round2 = await agent.submitInvestigationAnswers(answers1);
+
+      // First round answers should be recorded
+      const invState = agent.getInvestigationState();
+      expect(invState).not.toBeNull();
+      expect(invState!.rounds[0].answers.length).toBe(answers1.length);
+      expect(invState!.rounds[0].completedAt).toBeDefined();
+
+      if (round2 !== null) {
+        // Investigation continued to round 2
+        expect(round2.roundNumber).toBe(2);
+        expect(round2.phase).toBe('requirements_analysis');
+        expect(round2.questions.length).toBeGreaterThan(0);
+        expect(invState!.currentRound).toBe(2);
+        expect(invState!.rounds).toHaveLength(2);
+      } else {
+        // Investigation completed early (early exit due to high confidence)
+        const session = agent.getSession();
+        expect(['clarifying', 'completed']).toContain(session!.status);
+        expect(['completed', 'skipped']).toContain(invState!.status);
+      }
+    });
+
+    it('should complete investigation after all phases answered', async () => {
+      await agent.startSession('StandardProject');
+      agent.addTextInput(RICH_INPUT);
+
+      // Iterate through all rounds until investigation completes
+      let currentRound: InvestigationRound | null = await agent.startInvestigation();
+      let roundCount = 0;
+
+      while (currentRound !== null) {
+        roundCount++;
+        const answers = buildAnswersForRound(currentRound);
+        currentRound = await agent.submitInvestigationAnswers(answers);
+      }
+
+      // Standard mode has 3 phases
+      expect(roundCount).toBeGreaterThanOrEqual(1);
+
+      // Session should transition out of investigating
+      const session = agent.getSession();
+      expect(['clarifying', 'completed']).toContain(session!.status);
+
+      // Investigation state should be complete or skipped
+      const invState = agent.getInvestigationState();
+      expect(invState).not.toBeNull();
+      expect(['completed', 'skipped']).toContain(invState!.status);
+    });
+
+    it('should allow startInvestigation to auto-process inputs from collecting state', async () => {
+      await agent.startSession('AutoProcessProject');
+      agent.addTextInput(RICH_INPUT);
+
+      // Start investigation directly without calling processInputs()
+      const round1 = await agent.startInvestigation();
+
+      expect(round1).toBeDefined();
+      expect(round1.questions.length).toBeGreaterThan(0);
+      expect(agent.getSession()!.status).toBe('investigating');
+    });
+
+    it('should reflect investigation data in getInvestigationState()', async () => {
+      await agent.startSession('StateProject');
+      agent.addTextInput(RICH_INPUT);
+
+      // Before investigation
+      expect(agent.getInvestigationState()).toBeNull();
+
+      // After starting
+      const round1 = await agent.startInvestigation();
+      const state1 = agent.getInvestigationState();
+      expect(state1).not.toBeNull();
+      expect(state1!.depth).toBe('standard');
+      expect(state1!.phases).toEqual([
+        'core_discovery',
+        'requirements_analysis',
+        'constraints_validation',
+      ]);
+      expect(state1!.rounds).toHaveLength(1);
+
+      // After answering round 1
+      const answers = buildAnswersForRound(round1);
+      await agent.submitInvestigationAnswers(answers);
+      const state2 = agent.getInvestigationState();
+      // Investigation may continue (2+ rounds) or complete early (still 1 round)
+      expect(state2!.rounds.length).toBeGreaterThanOrEqual(1);
+      // First round should have answers
+      expect(state2!.rounds[0].answers.length).toBe(answers.length);
+    });
+  });
+
+  // =========================================================================
+  // 3. skipInvestigation()
+  // =========================================================================
+
+  describe('skipInvestigation()', () => {
+    beforeEach(() => {
+      agent = new CollectorAgent({ investigationDepth: 'standard' });
+    });
+
+    it('should skip investigation and transition session to clarifying or completed', async () => {
+      await agent.startSession('SkipProject');
+      agent.addTextInput(RICH_INPUT);
+      await agent.startInvestigation();
+
+      const session = agent.skipInvestigation();
+
+      expect(['clarifying', 'completed']).toContain(session.status);
+      expect(session.investigation).toBeDefined();
+      expect(session.investigation!.status).toBe('skipped');
+    });
+
+    it('should throw SessionStateError when not in investigating state', async () => {
+      await agent.startSession('NotInvestigating');
+      agent.addTextInput(MINIMAL_INPUT);
+      agent.processInputs();
+
+      // Session is in 'clarifying' or 'completed', not 'investigating'
+      expect(() => agent.skipInvestigation()).toThrow();
+    });
+
+    it('should preserve answers collected before skipping', async () => {
+      await agent.startSession('PartialSkipProject');
+      agent.addTextInput(RICH_INPUT);
+
+      const round1 = await agent.startInvestigation();
+      const answers = buildAnswersForRound(round1);
+      await agent.submitInvestigationAnswers(answers);
+
+      // After submitting answers, investigation may still be active or may have
+      // completed early (high-confidence early exit). Skip if still investigating.
+      const sessionBeforeSkip = agent.getSession()!;
+      if (sessionBeforeSkip.status === 'investigating') {
+        const session = agent.skipInvestigation();
+        expect(session.investigation).toBeDefined();
+        expect(session.investigation!.status).toBe('skipped');
+      }
+
+      // In either case, investigation state should have answers from round 1
+      const invState = agent.getInvestigationState();
+      expect(invState).not.toBeNull();
+      const completedRound = invState!.rounds.find((r) => r.answers.length > 0);
+      expect(completedRound).toBeDefined();
+      expect(completedRound!.answers.length).toBe(answers.length);
+    });
+  });
+
+  // =========================================================================
+  // 4. finalize() from investigating state
+  // =========================================================================
+
+  describe('finalize() from investigating state', () => {
+    beforeEach(() => {
+      agent = new CollectorAgent({ investigationDepth: 'standard' });
+    });
+
+    it('should auto-skip investigation and produce valid CollectionResult', async () => {
+      await agent.startSession('FinalizeFromInvestigating');
+      agent.addTextInput(RICH_INPUT);
+      await agent.startInvestigation();
+
+      // Session is in 'investigating' — call finalize() directly
+      const result = await agent.finalize('AutoSkipProject', 'Testing auto-skip on finalize');
+
+      expect(result.success).toBe(true);
+      expect(result.projectId).toBe('test-inv-001');
+      expect(result.collectedInfo.project.name).toBe('AutoSkipProject');
+      expect(result.collectedInfo.project.description).toBe('Testing auto-skip on finalize');
+      expect(result.collectedInfo.status).toBe('completed');
+    });
+
+    it('should include investigation stats even when auto-skipped', async () => {
+      await agent.startSession('StatsProject');
+      agent.addTextInput(RICH_INPUT);
+      await agent.startInvestigation();
+
+      const result = await agent.finalize('StatsProject', 'Stats check');
+
+      // At least 1 round was started before finalize auto-skipped
+      expect(result.stats.investigationRounds).toBeGreaterThanOrEqual(1);
+      expect(result.stats.investigationQuestionsAsked).toBeGreaterThan(0);
+    });
+
+    it('should auto-skip after partial investigation and produce valid result', async () => {
+      await agent.startSession('PartialFinalizeProject');
+      agent.addTextInput(RICH_INPUT);
+
+      const round1 = await agent.startInvestigation();
+      const answers = buildAnswersForRound(round1);
+      await agent.submitInvestigationAnswers(answers);
+
+      // Now in investigating state with round 2 pending — call finalize
+      const session = agent.getSession();
+      if (session!.status === 'investigating') {
+        const result = await agent.finalize('PartialProject', 'Partial investigation');
+
+        expect(result.success).toBe(true);
+        expect(result.stats.investigationRounds).toBeGreaterThanOrEqual(1);
+      }
+    });
+  });
+
+  // =========================================================================
+  // 5. Investigation metadata in CollectedInfo
+  // =========================================================================
+
+  describe('investigation metadata in CollectedInfo', () => {
+    beforeEach(() => {
+      agent = new CollectorAgent({ investigationDepth: 'standard' });
+    });
+
+    it('should include investigation metadata after completing investigation', async () => {
+      await agent.startSession('MetadataProject');
+      agent.addTextInput(RICH_INPUT);
+
+      // Complete at least one round
+      const round1 = await agent.startInvestigation();
+      const answers1 = buildAnswersForRound(round1);
+      await agent.submitInvestigationAnswers(answers1);
+
+      // Skip remaining investigation
+      if (agent.getSession()!.status === 'investigating') {
+        agent.skipInvestigation();
+      }
+
+      // Skip clarification if needed
+      const session = agent.getSession();
+      if (session!.status === 'clarifying') {
+        agent.skipClarification();
+      }
+
+      const result = await agent.finalize('MetadataProject', 'Investigation metadata test');
+
+      expect(result.success).toBe(true);
+
+      // Verify investigation metadata exists in collectedInfo
+      const info = result.collectedInfo as Record<string, unknown>;
+      expect(info['investigation']).toBeDefined();
+
+      const metadata = info['investigation'] as {
+        depth: string;
+        roundsCompleted: number;
+        totalQuestions: number;
+        totalAnswers: number;
+        confidenceGain: number;
+        phasesCompleted: string[];
+      };
+
+      expect(metadata.depth).toBe('standard');
+      expect(metadata.roundsCompleted).toBeGreaterThanOrEqual(1);
+      expect(metadata.totalQuestions).toBeGreaterThan(0);
+      expect(metadata.totalAnswers).toBeGreaterThan(0);
+      expect(typeof metadata.confidenceGain).toBe('number');
+      expect(metadata.phasesCompleted.length).toBeGreaterThanOrEqual(1);
+      expect(metadata.phasesCompleted).toContain('core_discovery');
+    });
+
+    it('should include investigation stats in CollectionStats', async () => {
+      await agent.startSession('StatsMetadataProject');
+      agent.addTextInput(RICH_INPUT);
+
+      const round1 = await agent.startInvestigation();
+      const answers1 = buildAnswersForRound(round1);
+      await agent.submitInvestigationAnswers(answers1);
+
+      // Skip remaining and finalize
+      if (agent.getSession()!.status === 'investigating') {
+        agent.skipInvestigation();
+      }
+      if (agent.getSession()!.status === 'clarifying') {
+        agent.skipClarification();
+      }
+
+      const result = await agent.finalize('StatsMetadataProject', 'Stats check');
+
+      expect(result.stats.investigationRounds).toBeGreaterThanOrEqual(1);
+      expect(result.stats.investigationQuestionsAsked).toBeGreaterThan(0);
+    });
+
+    it('should not include investigation metadata when no investigation was started', async () => {
+      await agent.startSession('NoInvestigation');
+      agent.addTextInput(RICH_INPUT);
+      agent.processInputs();
+
+      if (agent.getSession()!.status === 'clarifying') {
+        agent.skipClarification();
+      }
+
+      const result = await agent.finalize('NoInvestigation', 'No investigation');
+
+      const info = result.collectedInfo as Record<string, unknown>;
+      expect(info['investigation']).toBeUndefined();
+    });
+  });
+});

--- a/tests/collector/investigation-types.test.ts
+++ b/tests/collector/investigation-types.test.ts
@@ -1,0 +1,706 @@
+import { describe, it, expect } from 'vitest';
+import {
+  InvestigationDepthSchema,
+  InvestigationQuestionFormatSchema,
+  InvestigationPhaseSchema,
+  InvestigationQuestionSchema,
+  InvestigationAnswerSchema,
+  InvestigationRoundSchema,
+  InvestigationStateSchema,
+  InvestigationEngineConfigSchema,
+  InvestigationMetadataSchema,
+  getPhasesForDepth,
+  getMaxTotalQuestions,
+  isEarlyExitAllowed,
+  THOROUGH_PHASES,
+  STANDARD_PHASES,
+  QUICK_PHASES,
+} from '../../src/collector/investigation-types.js';
+import type {
+  InvestigationDepth,
+  InvestigationQuestion,
+  InvestigationAnswer,
+  InvestigationRound,
+  InvestigationState,
+} from '../../src/collector/investigation-types.js';
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+function validQuestion(overrides?: Partial<InvestigationQuestion>): InvestigationQuestion {
+  return {
+    id: 'IQ-VIS-001',
+    phase: 'project_vision',
+    round: 1,
+    format: 'free_text',
+    question: 'What is the primary goal of this project?',
+    context: 'Understanding the vision helps shape the requirements.',
+    required: true,
+    category: 'requirement',
+    ...overrides,
+  };
+}
+
+function validAnswer(overrides?: Partial<InvestigationAnswer>): InvestigationAnswer {
+  return {
+    questionId: 'IQ-VIS-001',
+    answer: 'Build a task management app',
+    answeredAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+function validRound(overrides?: Partial<InvestigationRound>): InvestigationRound {
+  return {
+    roundNumber: 1,
+    phase: 'project_vision',
+    questions: [validQuestion()],
+    answers: [validAnswer()],
+    startedAt: new Date().toISOString(),
+    confidenceBefore: 0.3,
+    ...overrides,
+  };
+}
+
+// =============================================================================
+// InvestigationDepthSchema
+// =============================================================================
+
+describe('InvestigationDepthSchema', () => {
+  it.each(['thorough', 'standard', 'quick'] as const)('should accept valid depth "%s"', (value) => {
+    expect(InvestigationDepthSchema.parse(value)).toBe(value);
+  });
+
+  it('should reject invalid string "extreme"', () => {
+    const result = InvestigationDepthSchema.safeParse('extreme');
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject empty string', () => {
+    const result = InvestigationDepthSchema.safeParse('');
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject non-string value (number)', () => {
+    const result = InvestigationDepthSchema.safeParse(123);
+    expect(result.success).toBe(false);
+  });
+});
+
+// =============================================================================
+// InvestigationQuestionFormatSchema
+// =============================================================================
+
+describe('InvestigationQuestionFormatSchema', () => {
+  const validFormats = [
+    'free_text',
+    'single_select',
+    'multi_select',
+    'yes_no',
+    'priority_ranking',
+    'confirmation',
+    'scale_rating',
+  ] as const;
+
+  it.each(validFormats)('should accept valid format "%s"', (value) => {
+    expect(InvestigationQuestionFormatSchema.parse(value)).toBe(value);
+  });
+
+  it('should reject invalid format "other"', () => {
+    const result = InvestigationQuestionFormatSchema.safeParse('other');
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject undefined', () => {
+    const result = InvestigationQuestionFormatSchema.safeParse(undefined);
+    expect(result.success).toBe(false);
+  });
+});
+
+// =============================================================================
+// InvestigationPhaseSchema
+// =============================================================================
+
+describe('InvestigationPhaseSchema', () => {
+  const allPhases = [
+    'project_vision',
+    'user_analysis',
+    'functional_deep_dive',
+    'nonfunctional_analysis',
+    'constraints_risks',
+    'validation_synthesis',
+    'core_discovery',
+    'requirements_analysis',
+    'constraints_validation',
+    'basic_clarification',
+  ] as const;
+
+  it.each(allPhases)('should accept valid phase "%s"', (value) => {
+    expect(InvestigationPhaseSchema.parse(value)).toBe(value);
+  });
+
+  it('should reject invalid phase "planning"', () => {
+    const result = InvestigationPhaseSchema.safeParse('planning');
+    expect(result.success).toBe(false);
+  });
+});
+
+// =============================================================================
+// InvestigationQuestionSchema
+// =============================================================================
+
+describe('InvestigationQuestionSchema', () => {
+  it('should accept a valid question object', () => {
+    const q = validQuestion();
+    const result = InvestigationQuestionSchema.parse(q);
+    expect(result.id).toBe('IQ-VIS-001');
+    expect(result.phase).toBe('project_vision');
+    expect(result.format).toBe('free_text');
+    expect(result.required).toBe(true);
+    expect(result.category).toBe('requirement');
+  });
+
+  it('should accept a question with optional fields', () => {
+    const q = validQuestion({
+      options: ['Option A', 'Option B'],
+      scaleRange: { min: 1, max: 5, labels: { min: 'Low', max: 'High' } },
+      relatedTo: 'FR-001',
+    });
+    const result = InvestigationQuestionSchema.parse(q);
+    expect(result.options).toEqual(['Option A', 'Option B']);
+    expect(result.scaleRange).toEqual({ min: 1, max: 5, labels: { min: 'Low', max: 'High' } });
+    expect(result.relatedTo).toBe('FR-001');
+  });
+
+  it('should accept a question with scaleRange without labels', () => {
+    const q = validQuestion({
+      format: 'scale_rating',
+      scaleRange: { min: 0, max: 10 },
+    });
+    const result = InvestigationQuestionSchema.parse(q);
+    expect(result.scaleRange?.labels).toBeUndefined();
+  });
+
+  it('should reject when required fields are missing', () => {
+    const result = InvestigationQuestionSchema.safeParse({
+      id: 'IQ-001',
+      // missing phase, round, format, question, context, required, category
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject empty id', () => {
+    const result = InvestigationQuestionSchema.safeParse(validQuestion({ id: '' }));
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject invalid format in question', () => {
+    const result = InvestigationQuestionSchema.safeParse({
+      ...validQuestion(),
+      format: 'essay',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject invalid phase in question', () => {
+    const result = InvestigationQuestionSchema.safeParse({
+      ...validQuestion(),
+      phase: 'unknown_phase',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject round less than 1', () => {
+    const result = InvestigationQuestionSchema.safeParse(validQuestion({ round: 0 }));
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject invalid category', () => {
+    const result = InvestigationQuestionSchema.safeParse({
+      ...validQuestion(),
+      category: 'general',
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+// =============================================================================
+// InvestigationAnswerSchema
+// =============================================================================
+
+describe('InvestigationAnswerSchema', () => {
+  it('should accept a valid answer', () => {
+    const a = validAnswer();
+    const result = InvestigationAnswerSchema.parse(a);
+    expect(result.questionId).toBe('IQ-VIS-001');
+    expect(result.answer).toBe('Build a task management app');
+    expect(result.answeredAt).toBeDefined();
+  });
+
+  it('should accept an answer with selectedOptions', () => {
+    const a = validAnswer({
+      selectedOptions: ['Option A', 'Option C'],
+    });
+    const result = InvestigationAnswerSchema.parse(a);
+    expect(result.selectedOptions).toEqual(['Option A', 'Option C']);
+  });
+
+  it('should accept an answer with scaleValue', () => {
+    const a = validAnswer({ scaleValue: 7 });
+    const result = InvestigationAnswerSchema.parse(a);
+    expect(result.scaleValue).toBe(7);
+  });
+
+  it('should accept an answer with rankings', () => {
+    const a = validAnswer({
+      rankings: ['Security', 'Performance', 'Usability'],
+    });
+    const result = InvestigationAnswerSchema.parse(a);
+    expect(result.rankings).toEqual(['Security', 'Performance', 'Usability']);
+  });
+
+  it('should accept an answer with all optional fields', () => {
+    const a = validAnswer({
+      selectedOptions: ['A'],
+      scaleValue: 5,
+      rankings: ['X', 'Y'],
+    });
+    const result = InvestigationAnswerSchema.parse(a);
+    expect(result.selectedOptions).toEqual(['A']);
+    expect(result.scaleValue).toBe(5);
+    expect(result.rankings).toEqual(['X', 'Y']);
+  });
+
+  it('should reject missing questionId', () => {
+    const result = InvestigationAnswerSchema.safeParse({
+      answer: 'Some answer',
+      answeredAt: new Date().toISOString(),
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject empty questionId', () => {
+    const result = InvestigationAnswerSchema.safeParse(validAnswer({ questionId: '' }));
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject missing answer text', () => {
+    const result = InvestigationAnswerSchema.safeParse({
+      questionId: 'IQ-001',
+      answeredAt: new Date().toISOString(),
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject missing answeredAt', () => {
+    const result = InvestigationAnswerSchema.safeParse({
+      questionId: 'IQ-001',
+      answer: 'Some answer',
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+// =============================================================================
+// InvestigationRoundSchema
+// =============================================================================
+
+describe('InvestigationRoundSchema', () => {
+  it('should accept a valid round with questions and answers', () => {
+    const r = validRound();
+    const result = InvestigationRoundSchema.parse(r);
+    expect(result.roundNumber).toBe(1);
+    expect(result.phase).toBe('project_vision');
+    expect(result.questions).toHaveLength(1);
+    expect(result.answers).toHaveLength(1);
+    expect(result.confidenceBefore).toBe(0.3);
+  });
+
+  it('should accept a completed round with confidenceAfter', () => {
+    const r = validRound({
+      completedAt: new Date().toISOString(),
+      confidenceAfter: 0.65,
+    });
+    const result = InvestigationRoundSchema.parse(r);
+    expect(result.completedAt).toBeDefined();
+    expect(result.confidenceAfter).toBe(0.65);
+  });
+
+  it('should accept a round with multiple questions and answers', () => {
+    const q1 = validQuestion({ id: 'IQ-001' });
+    const q2 = validQuestion({ id: 'IQ-002', question: 'Who are the target users?' });
+    const a1 = validAnswer({ questionId: 'IQ-001' });
+    const a2 = validAnswer({ questionId: 'IQ-002', answer: 'Developers' });
+
+    const r = validRound({ questions: [q1, q2], answers: [a1, a2] });
+    const result = InvestigationRoundSchema.parse(r);
+    expect(result.questions).toHaveLength(2);
+    expect(result.answers).toHaveLength(2);
+  });
+
+  it('should accept a round with empty answers (not yet answered)', () => {
+    const r = validRound({ answers: [] });
+    const result = InvestigationRoundSchema.parse(r);
+    expect(result.answers).toHaveLength(0);
+  });
+
+  it('should reject roundNumber less than 1', () => {
+    const result = InvestigationRoundSchema.safeParse(validRound({ roundNumber: 0 }));
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject confidenceBefore outside 0-1 range', () => {
+    const result = InvestigationRoundSchema.safeParse(validRound({ confidenceBefore: 1.5 }));
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject confidenceAfter outside 0-1 range', () => {
+    const result = InvestigationRoundSchema.safeParse(validRound({ confidenceAfter: -0.1 }));
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject missing startedAt', () => {
+    const { startedAt, ...rest } = validRound();
+    const result = InvestigationRoundSchema.safeParse(rest);
+    expect(result.success).toBe(false);
+  });
+});
+
+// =============================================================================
+// InvestigationStateSchema
+// =============================================================================
+
+describe('InvestigationStateSchema', () => {
+  function validState(depth: InvestigationDepth): InvestigationState {
+    const phaseMap: Record<InvestigationDepth, string[]> = {
+      thorough: [
+        'project_vision',
+        'user_analysis',
+        'functional_deep_dive',
+        'nonfunctional_analysis',
+        'constraints_risks',
+        'validation_synthesis',
+      ],
+      standard: ['core_discovery', 'requirements_analysis', 'constraints_validation'],
+      quick: ['basic_clarification'],
+    };
+    const maxRoundsMap: Record<InvestigationDepth, number> = {
+      thorough: 6,
+      standard: 3,
+      quick: 1,
+    };
+
+    return {
+      depth,
+      currentRound: 0,
+      maxRounds: maxRoundsMap[depth],
+      phases: phaseMap[depth] as InvestigationState['phases'],
+      rounds: [],
+      status: 'pending',
+    };
+  }
+
+  it('should accept a valid thorough state', () => {
+    const state = validState('thorough');
+    const result = InvestigationStateSchema.parse(state);
+    expect(result.depth).toBe('thorough');
+    expect(result.phases).toHaveLength(6);
+    expect(result.maxRounds).toBe(6);
+    expect(result.status).toBe('pending');
+  });
+
+  it('should accept a valid standard state', () => {
+    const state = validState('standard');
+    const result = InvestigationStateSchema.parse(state);
+    expect(result.depth).toBe('standard');
+    expect(result.phases).toHaveLength(3);
+  });
+
+  it('should accept a valid quick state', () => {
+    const state = validState('quick');
+    const result = InvestigationStateSchema.parse(state);
+    expect(result.depth).toBe('quick');
+    expect(result.phases).toHaveLength(1);
+  });
+
+  it('should accept a state with startedAt and completedAt', () => {
+    const state = {
+      ...validState('standard'),
+      status: 'completed' as const,
+      startedAt: '2026-03-26T10:00:00Z',
+      completedAt: '2026-03-26T10:15:00Z',
+    };
+    const result = InvestigationStateSchema.parse(state);
+    expect(result.startedAt).toBe('2026-03-26T10:00:00Z');
+    expect(result.completedAt).toBe('2026-03-26T10:15:00Z');
+  });
+
+  it('should accept a state with in_progress status and rounds', () => {
+    const state: InvestigationState = {
+      ...validState('standard'),
+      currentRound: 1,
+      status: 'in_progress',
+      startedAt: '2026-03-26T10:00:00Z',
+      rounds: [
+        validRound({
+          phase: 'core_discovery',
+          confidenceBefore: 0.2,
+          confidenceAfter: 0.5,
+          completedAt: new Date().toISOString(),
+        }),
+      ],
+    };
+    const result = InvestigationStateSchema.parse(state);
+    expect(result.currentRound).toBe(1);
+    expect(result.rounds).toHaveLength(1);
+    expect(result.status).toBe('in_progress');
+  });
+
+  it('should reject invalid depth in state', () => {
+    const result = InvestigationStateSchema.safeParse({
+      ...validState('standard'),
+      depth: 'extreme',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject invalid status', () => {
+    const result = InvestigationStateSchema.safeParse({
+      ...validState('standard'),
+      status: 'cancelled',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject negative currentRound', () => {
+    const result = InvestigationStateSchema.safeParse({
+      ...validState('standard'),
+      currentRound: -1,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject maxRounds less than 1', () => {
+    const result = InvestigationStateSchema.safeParse({
+      ...validState('standard'),
+      maxRounds: 0,
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+// =============================================================================
+// InvestigationEngineConfigSchema
+// =============================================================================
+
+describe('InvestigationEngineConfigSchema', () => {
+  it('should apply defaults when given an empty object', () => {
+    const result = InvestigationEngineConfigSchema.parse({});
+    expect(result.depth).toBe('standard');
+    expect(result.maxQuestionsPerRound).toBe(5);
+    expect(result.confidenceTarget).toBe(0.85);
+    expect(result.earlyExitOnHighConfidence).toBe(true);
+    expect(result.enableLLMQuestions).toBe(true);
+  });
+
+  it('should accept custom values', () => {
+    const config = {
+      depth: 'thorough' as const,
+      maxQuestionsPerRound: 8,
+      confidenceTarget: 0.95,
+      earlyExitOnHighConfidence: false,
+      enableLLMQuestions: false,
+    };
+    const result = InvestigationEngineConfigSchema.parse(config);
+    expect(result.depth).toBe('thorough');
+    expect(result.maxQuestionsPerRound).toBe(8);
+    expect(result.confidenceTarget).toBe(0.95);
+    expect(result.earlyExitOnHighConfidence).toBe(false);
+    expect(result.enableLLMQuestions).toBe(false);
+  });
+
+  it('should accept partial overrides with defaults for the rest', () => {
+    const result = InvestigationEngineConfigSchema.parse({ depth: 'quick' });
+    expect(result.depth).toBe('quick');
+    expect(result.maxQuestionsPerRound).toBe(5); // default
+    expect(result.confidenceTarget).toBe(0.85); // default
+  });
+
+  it('should reject maxQuestionsPerRound less than 1', () => {
+    const result = InvestigationEngineConfigSchema.safeParse({ maxQuestionsPerRound: 0 });
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject maxQuestionsPerRound greater than 10', () => {
+    const result = InvestigationEngineConfigSchema.safeParse({ maxQuestionsPerRound: 11 });
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject confidenceTarget less than 0', () => {
+    const result = InvestigationEngineConfigSchema.safeParse({ confidenceTarget: -0.1 });
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject confidenceTarget greater than 1', () => {
+    const result = InvestigationEngineConfigSchema.safeParse({ confidenceTarget: 1.5 });
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject invalid depth', () => {
+    const result = InvestigationEngineConfigSchema.safeParse({ depth: 'extreme' });
+    expect(result.success).toBe(false);
+  });
+});
+
+// =============================================================================
+// InvestigationMetadataSchema
+// =============================================================================
+
+describe('InvestigationMetadataSchema', () => {
+  it('should accept valid metadata', () => {
+    const metadata = {
+      depth: 'standard' as const,
+      roundsCompleted: 3,
+      totalQuestions: 15,
+      totalAnswers: 14,
+      confidenceGain: 0.45,
+      phasesCompleted: [
+        'core_discovery',
+        'requirements_analysis',
+        'constraints_validation',
+      ] as const,
+    };
+    const result = InvestigationMetadataSchema.parse(metadata);
+    expect(result.depth).toBe('standard');
+    expect(result.roundsCompleted).toBe(3);
+    expect(result.totalQuestions).toBe(15);
+    expect(result.totalAnswers).toBe(14);
+    expect(result.confidenceGain).toBe(0.45);
+    expect(result.phasesCompleted).toHaveLength(3);
+  });
+
+  it('should accept metadata with zero rounds (not started)', () => {
+    const metadata = {
+      depth: 'quick' as const,
+      roundsCompleted: 0,
+      totalQuestions: 0,
+      totalAnswers: 0,
+      confidenceGain: 0,
+      phasesCompleted: [],
+    };
+    const result = InvestigationMetadataSchema.parse(metadata);
+    expect(result.roundsCompleted).toBe(0);
+    expect(result.phasesCompleted).toHaveLength(0);
+  });
+
+  it('should reject negative roundsCompleted', () => {
+    const result = InvestigationMetadataSchema.safeParse({
+      depth: 'standard',
+      roundsCompleted: -1,
+      totalQuestions: 0,
+      totalAnswers: 0,
+      confidenceGain: 0,
+      phasesCompleted: [],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject confidenceGain greater than 1', () => {
+    const result = InvestigationMetadataSchema.safeParse({
+      depth: 'thorough',
+      roundsCompleted: 1,
+      totalQuestions: 5,
+      totalAnswers: 5,
+      confidenceGain: 1.2,
+      phasesCompleted: ['project_vision'],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject invalid phase in phasesCompleted', () => {
+    const result = InvestigationMetadataSchema.safeParse({
+      depth: 'standard',
+      roundsCompleted: 1,
+      totalQuestions: 5,
+      totalAnswers: 5,
+      confidenceGain: 0.2,
+      phasesCompleted: ['nonexistent_phase'],
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+// =============================================================================
+// getPhasesForDepth()
+// =============================================================================
+
+describe('getPhasesForDepth', () => {
+  it('should return THOROUGH_PHASES for "thorough"', () => {
+    const phases = getPhasesForDepth('thorough');
+    expect(phases).toBe(THOROUGH_PHASES);
+    expect(phases).toHaveLength(6);
+    expect(phases[0].phase).toBe('project_vision');
+    expect(phases[5].phase).toBe('validation_synthesis');
+  });
+
+  it('should return STANDARD_PHASES for "standard"', () => {
+    const phases = getPhasesForDepth('standard');
+    expect(phases).toBe(STANDARD_PHASES);
+    expect(phases).toHaveLength(3);
+    expect(phases[0].phase).toBe('core_discovery');
+    expect(phases[2].phase).toBe('constraints_validation');
+  });
+
+  it('should return QUICK_PHASES for "quick"', () => {
+    const phases = getPhasesForDepth('quick');
+    expect(phases).toBe(QUICK_PHASES);
+    expect(phases).toHaveLength(1);
+    expect(phases[0].phase).toBe('basic_clarification');
+  });
+
+  it('should return phases in correct order', () => {
+    for (const depth of ['thorough', 'standard', 'quick'] as const) {
+      const phases = getPhasesForDepth(depth);
+      for (let i = 0; i < phases.length; i++) {
+        expect(phases[i].order).toBe(i + 1);
+      }
+    }
+  });
+});
+
+// =============================================================================
+// getMaxTotalQuestions()
+// =============================================================================
+
+describe('getMaxTotalQuestions', () => {
+  it('should return 40 for "thorough"', () => {
+    expect(getMaxTotalQuestions('thorough')).toBe(40);
+  });
+
+  it('should return 20 for "standard"', () => {
+    expect(getMaxTotalQuestions('standard')).toBe(20);
+  });
+
+  it('should return 5 for "quick"', () => {
+    expect(getMaxTotalQuestions('quick')).toBe(5);
+  });
+});
+
+// =============================================================================
+// isEarlyExitAllowed()
+// =============================================================================
+
+describe('isEarlyExitAllowed', () => {
+  it('should return false for "thorough"', () => {
+    expect(isEarlyExitAllowed('thorough')).toBe(false);
+  });
+
+  it('should return true for "standard"', () => {
+    expect(isEarlyExitAllowed('standard')).toBe(true);
+  });
+
+  it('should return true for "quick"', () => {
+    expect(isEarlyExitAllowed('quick')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- Add **InvestigationEngine** to CollectorAgent for structured, multi-round requirements elicitation before PRD generation
- **3 depth levels**: thorough (6 phases, 40 questions), standard (3 phases, 20), quick (1 phase, 5 — legacy behavior)
- **7 question formats**: free_text, single_select, multi_select, yes_no, priority_ranking, confirmation, scale_rating
- **LLM-driven question generation** via AgentBridge with template fallback (~50 predefined templates)
- **Answer integration**: maps each format to extraction updates (NFR creation, priority reassignment, assumption validation, confidence adjustment)

## New Files

| File | Lines | Description |
|------|-------|-------------|
| `src/collector/investigation-types.ts` | 430 | Types + Zod schemas + phase registry |
| `src/collector/InvestigationTemplates.ts` | 610 | ~50 question templates + trigger conditions |
| `src/collector/InvestigationEngine.ts` | 800 | Core engine: rounds, LLM, enrichment |
| `tests/collector/investigation-types.test.ts` | 84 tests | Schema validation |
| `tests/collector/InvestigationTemplates.test.ts` | 35 tests | Template selection |
| `tests/collector/InvestigationEngine.test.ts` | 39 tests | Engine behavior |
| `tests/collector/investigation-integration.test.ts` | 16 tests | Full flow |

## Modified Files

- `CollectorAgent.ts` — 4 new public methods, `'investigating'` session state
- `types.ts` — `investigationDepth` config, `investigation` session field
- `errors.ts` / `codes.ts` — `InvestigationError`, COL-001~005
- `scratchpad/schemas.ts` — `'investigating'` status, investigation metadata
- `config/schemas.ts` — `InvestigationConfigSchema`
- `stage-verifier/rules.ts` — VR-COL-INV-001 rule
- `workflow.yaml` — `global.investigation` section
- `collector.md` — Updated workflow and state diagrams

## Backward Compatibility

Default `investigationDepth: 'quick'` preserves existing single-round behavior. All existing tests pass unchanged.

## Test plan

- [x] 174 new investigation tests pass
- [x] `npx tsc --noEmit` passes
- [x] ESLint errors resolved
- [x] Pre-commit hooks pass
- [x] CI pipeline passes

Closes #636, closes #637, closes #638, closes #639, closes #640, closes #641, closes #642