### PR TITLE
feat(orchestrator): implement mid-stage checkpoint and resume for pipeline crash recovery

### DIFF
--- a/src/ad-sdlc-orchestrator/AdsdlcOrchestratorAgent.ts
+++ b/src/ad-sdlc-orchestrator/AdsdlcOrchestratorAgent.ts
@@ -18,9 +18,12 @@ import { BridgeRegistry, createDefaultBridgeRegistry } from '../agents/BridgeReg
 import { bootstrapAgents } from '../agents/bootstrapAgents.js';
 import type { IAgent } from '../agents/types.js';
 import { Semaphore } from '../utilities/Semaphore.js';
+import { getLogger } from '../logging/index.js';
+import { PipelineCheckpointManager } from './PipelineCheckpointManager.js';
 import type {
   AgentInvocation,
   ApprovalDecision,
+  CheckpointConfig,
   ExecutionStrategy,
   OrchestratorConfig,
   OrchestratorSession,
@@ -83,6 +86,7 @@ export class AdsdlcOrchestratorAgent implements IAgent {
   private abortController: AbortController | null = null;
   private _dispatcher: AgentDispatcher | null = null;
   private _bridgeRegistry: BridgeRegistry | null = null;
+  private readonly checkpointManager: PipelineCheckpointManager | null;
 
   constructor(config: OrchestratorConfig = {}) {
     this.config = {
@@ -93,6 +97,8 @@ export class AdsdlcOrchestratorAgent implements IAgent {
         ...config.timeouts,
       },
     };
+    const ckptConfig: CheckpointConfig = this.config.checkpoint;
+    this.checkpointManager = ckptConfig.enabled ? new PipelineCheckpointManager(ckptConfig) : null;
   }
 
   /**
@@ -181,6 +187,35 @@ export class AdsdlcOrchestratorAgent implements IAgent {
 
     // Resume from prior session if requested
     if (request.resumeSessionId !== undefined && request.resumeSessionId !== '') {
+      // Try checkpoint-based resume first (more recent than session YAML)
+      if (this.checkpointManager !== null && this.checkpointManager.isEnabled()) {
+        const scratchpadDir = path.resolve(request.projectDir, this.config.scratchpadDir);
+        const checkpoint = await this.checkpointManager.loadLatestCheckpoint(
+          request.resumeSessionId,
+          scratchpadDir
+        );
+        if (checkpoint && checkpoint.completedStageNames.length > 0) {
+          getLogger().info('Resuming from pipeline checkpoint', {
+            agent: 'AdsdlcOrchestratorAgent',
+            sessionId: request.resumeSessionId,
+            completedStages: checkpoint.completedStageNames.length,
+          });
+          // Feed checkpoint's completed stages into the existing resume path
+          // by overriding preCompletedStages after loadPriorSession resolves
+          const prior = await this.loadPriorSession(request.resumeSessionId, request.projectDir);
+          if (prior) {
+            this.session = {
+              ...prior,
+              status: 'running',
+              preCompletedStages: checkpoint.completedStageNames,
+              stageResults: checkpoint.completedStageResults,
+            };
+            this.abortController = new AbortController();
+            return this.session;
+          }
+        }
+      }
+
       const prior = await this.loadPriorSession(request.resumeSessionId, request.projectDir);
       if (prior) {
         this.session = { ...prior, status: 'running' };
@@ -302,6 +337,18 @@ export class AdsdlcOrchestratorAgent implements IAgent {
       this.session = { ...this.session, status: overallStatus, stageResults };
 
       await this.persistState(session, result);
+
+      // Clean up checkpoints after successful persistence
+      if (this.checkpointManager !== null && this.checkpointManager.isEnabled()) {
+        try {
+          await this.checkpointManager.deleteSessionCheckpoints(
+            session.sessionId,
+            session.scratchpadDir
+          );
+        } catch {
+          // Best-effort cleanup
+        }
+      }
 
       if (overallStatus === 'failed') {
         throw new PipelineFailedError(
@@ -483,6 +530,26 @@ export class AdsdlcOrchestratorAgent implements IAgent {
             completedStages.add(result.name);
           }
         }
+
+        // Save checkpoint after stage completion
+        if (this.checkpointManager !== null && this.checkpointManager.isEnabled()) {
+          try {
+            await this.checkpointManager.saveCheckpoint(
+              session.sessionId,
+              session.mode,
+              session.projectDir,
+              session.userRequest,
+              session.scratchpadDir,
+              results,
+              [...completedStages]
+            );
+          } catch (err) {
+            getLogger().warn('Checkpoint save failed (non-critical)', {
+              agent: 'AdsdlcOrchestratorAgent',
+              error: err instanceof Error ? err.message : String(err),
+            });
+          }
+        }
       } else if (parallelGroup.length === 1) {
         // Single parallel stage — run sequentially
         const singleStage = parallelGroup[0];
@@ -521,6 +588,26 @@ export class AdsdlcOrchestratorAgent implements IAgent {
 
         if (result.status === 'completed') {
           completedStages.add(stage.name);
+        }
+
+        // Save checkpoint after stage completion
+        if (this.checkpointManager !== null && this.checkpointManager.isEnabled()) {
+          try {
+            await this.checkpointManager.saveCheckpoint(
+              session.sessionId,
+              session.mode,
+              session.projectDir,
+              session.userRequest,
+              session.scratchpadDir,
+              results,
+              [...completedStages]
+            );
+          } catch (err) {
+            getLogger().warn('Checkpoint save failed (non-critical)', {
+              agent: 'AdsdlcOrchestratorAgent',
+              error: err instanceof Error ? err.message : String(err),
+            });
+          }
         }
       }
 

--- a/src/ad-sdlc-orchestrator/PipelineCheckpointManager.ts
+++ b/src/ad-sdlc-orchestrator/PipelineCheckpointManager.ts
@@ -1,0 +1,215 @@
+/**
+ * PipelineCheckpointManager - Mid-stage checkpoint persistence for pipeline resume
+ *
+ * Saves checkpoint files after each completed stage so that interrupted
+ * pipelines can resume from the last checkpoint instead of restarting.
+ *
+ * Storage: {scratchpadDir}/pipeline/checkpoints/{sessionId}-ckpt-{timestamp}.yaml
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as yaml from 'js-yaml';
+import { getLogger } from '../logging/index.js';
+import type {
+  CheckpointConfig,
+  PipelineCheckpoint,
+  PipelineMode,
+  StageName,
+  StageResult,
+} from './types.js';
+
+const logger = getLogger();
+
+/**
+ * Default checkpoint configuration
+ */
+const DEFAULT_CONFIG: Required<CheckpointConfig> = {
+  enabled: true,
+  maxCheckpoints: 5,
+};
+
+/**
+ * Manages pipeline checkpoint persistence for crash recovery.
+ */
+export class PipelineCheckpointManager {
+  private readonly config: Required<CheckpointConfig>;
+
+  constructor(config?: Partial<CheckpointConfig>) {
+    this.config = { ...DEFAULT_CONFIG, ...config };
+  }
+
+  /**
+   * Whether checkpointing is enabled
+   */
+  public isEnabled(): boolean {
+    return this.config.enabled;
+  }
+
+  /**
+   * Save a checkpoint after a stage completes.
+   *
+   * @param sessionId - Current session ID
+   * @param mode - Pipeline mode
+   * @param projectDir - Project directory
+   * @param userRequest - User request text
+   * @param scratchpadDir - Scratchpad directory
+   * @param completedResults - Stage results accumulated so far
+   * @param completedNames - Names of completed stages
+   */
+  public async saveCheckpoint(
+    sessionId: string,
+    mode: PipelineMode,
+    projectDir: string,
+    userRequest: string,
+    scratchpadDir: string,
+    completedResults: readonly StageResult[],
+    completedNames: readonly StageName[]
+  ): Promise<string> {
+    const checkpointDir = this.getCheckpointDir(scratchpadDir);
+    await fs.promises.mkdir(checkpointDir, { recursive: true });
+
+    const timestamp = Date.now();
+    const filename = `${sessionId}-ckpt-${String(timestamp)}.yaml`;
+    const filePath = path.join(checkpointDir, filename);
+
+    const checkpoint: PipelineCheckpoint = {
+      version: 1,
+      sessionId,
+      mode,
+      projectDir,
+      userRequest,
+      createdAt: new Date().toISOString(),
+      completedStageResults: completedResults,
+      completedStageNames: completedNames,
+    };
+
+    await fs.promises.writeFile(filePath, yaml.dump(checkpoint), 'utf-8');
+
+    // Prune old checkpoints
+    await this.pruneCheckpoints(sessionId, scratchpadDir);
+
+    logger.debug('Pipeline checkpoint saved', {
+      agent: 'PipelineCheckpointManager',
+      sessionId,
+      completedStages: completedNames.length,
+      file: filename,
+    });
+
+    return filename;
+  }
+
+  /**
+   * Load the most recent checkpoint for a session.
+   *
+   * @param sessionId - Session ID to load checkpoint for
+   * @param scratchpadDir - Scratchpad directory
+   * @returns Latest checkpoint or null if none exists
+   */
+  public async loadLatestCheckpoint(
+    sessionId: string,
+    scratchpadDir: string
+  ): Promise<PipelineCheckpoint | null> {
+    const checkpointDir = this.getCheckpointDir(scratchpadDir);
+
+    try {
+      const files = await fs.promises.readdir(checkpointDir);
+      const sessionFiles = files
+        .filter((f) => f.startsWith(`${sessionId}-ckpt-`) && f.endsWith('.yaml'))
+        .sort()
+        .reverse();
+
+      if (sessionFiles.length === 0) {
+        return null;
+      }
+
+      const latestFile = sessionFiles[0];
+      if (latestFile === undefined) {
+        return null;
+      }
+      const content = await fs.promises.readFile(path.join(checkpointDir, latestFile), 'utf-8');
+      const raw = yaml.load(content) as Record<string, unknown>;
+
+      if (raw['version'] !== 1 || raw['sessionId'] !== sessionId) {
+        logger.warn('Invalid checkpoint data', {
+          agent: 'PipelineCheckpointManager',
+          file: latestFile,
+        });
+        return null;
+      }
+
+      return raw as unknown as PipelineCheckpoint;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+        return null;
+      }
+      logger.warn('Failed to load checkpoint', {
+        agent: 'PipelineCheckpointManager',
+        sessionId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return null;
+    }
+  }
+
+  /**
+   * Delete all checkpoints for a session (called after successful completion).
+   * @param sessionId
+   * @param scratchpadDir
+   */
+  public async deleteSessionCheckpoints(sessionId: string, scratchpadDir: string): Promise<void> {
+    const checkpointDir = this.getCheckpointDir(scratchpadDir);
+
+    try {
+      const files = await fs.promises.readdir(checkpointDir);
+      const sessionFiles = files.filter(
+        (f) => f.startsWith(`${sessionId}-ckpt-`) && f.endsWith('.yaml')
+      );
+      await Promise.all(
+        sessionFiles.map((f) =>
+          fs.promises.unlink(path.join(checkpointDir, f)).catch(() => {
+            // Best-effort cleanup
+          })
+        )
+      );
+    } catch {
+      // Directory may not exist — that's fine
+    }
+  }
+
+  /**
+   * Keep only the most recent N checkpoints for a session.
+   * @param sessionId
+   * @param scratchpadDir
+   */
+  private async pruneCheckpoints(sessionId: string, scratchpadDir: string): Promise<void> {
+    const checkpointDir = this.getCheckpointDir(scratchpadDir);
+
+    try {
+      const files = await fs.promises.readdir(checkpointDir);
+      const sessionFiles = files
+        .filter((f) => f.startsWith(`${sessionId}-ckpt-`) && f.endsWith('.yaml'))
+        .sort()
+        .reverse();
+
+      const toDelete = sessionFiles.slice(this.config.maxCheckpoints);
+      await Promise.all(
+        toDelete.map((f) =>
+          fs.promises.unlink(path.join(checkpointDir, f)).catch(() => {
+            // Best-effort
+          })
+        )
+      );
+    } catch {
+      // Directory may not exist yet
+    }
+  }
+
+  /**
+   * Get the checkpoint directory path.
+   * @param scratchpadDir
+   */
+  private getCheckpointDir(scratchpadDir: string): string {
+    return path.join(scratchpadDir, 'pipeline', 'checkpoints');
+  }
+}

--- a/src/ad-sdlc-orchestrator/index.ts
+++ b/src/ad-sdlc-orchestrator/index.ts
@@ -14,6 +14,9 @@ export {
   ADSDLC_ORCHESTRATOR_AGENT_ID,
 } from './AdsdlcOrchestratorAgent.js';
 
+// Pipeline checkpoint manager
+export { PipelineCheckpointManager } from './PipelineCheckpointManager.js';
+
 // Artifact validation
 export {
   ArtifactValidator,
@@ -50,6 +53,9 @@ export type {
   // Configuration types
   OrchestratorConfig,
   StageTimeoutConfig,
+  CheckpointConfig,
+  // Checkpoint types
+  PipelineCheckpoint,
   // Approval and monitoring types
   ApprovalDecision,
   PipelineMonitorSnapshot,

--- a/src/ad-sdlc-orchestrator/types.ts
+++ b/src/ad-sdlc-orchestrator/types.ts
@@ -260,6 +260,18 @@ export interface OrchestratorConfig {
   readonly maxParallelAgents?: number;
   /** Log level */
   readonly logLevel?: 'DEBUG' | 'INFO' | 'WARN' | 'ERROR';
+  /** Checkpoint configuration for mid-stage persistence */
+  readonly checkpoint?: CheckpointConfig;
+}
+
+/**
+ * Checkpoint configuration for the orchestrator
+ */
+export interface CheckpointConfig {
+  /** Enable mid-stage checkpointing (default: true) */
+  readonly enabled: boolean;
+  /** Maximum number of checkpoints to retain per session (default: 5) */
+  readonly maxCheckpoints: number;
 }
 
 /**
@@ -276,6 +288,10 @@ export const DEFAULT_ORCHESTRATOR_CONFIG: Required<OrchestratorConfig> = {
   maxRetries: 3,
   maxParallelAgents: 3,
   logLevel: 'INFO',
+  checkpoint: {
+    enabled: true,
+    maxCheckpoints: 5,
+  },
 };
 
 /**
@@ -607,4 +623,27 @@ export interface StageSummary {
   readonly status: PipelineStageStatus;
   readonly durationMs: number;
   readonly retryCount: number;
+}
+
+/**
+ * Pipeline checkpoint capturing progress between stages.
+ * Written to disk after each stage completes for crash recovery.
+ */
+export interface PipelineCheckpoint {
+  /** Checkpoint format version */
+  readonly version: 1;
+  /** Session ID this checkpoint belongs to */
+  readonly sessionId: string;
+  /** Pipeline mode */
+  readonly mode: PipelineMode;
+  /** Project directory */
+  readonly projectDir: string;
+  /** User request text */
+  readonly userRequest: string;
+  /** Checkpoint creation timestamp */
+  readonly createdAt: string;
+  /** Stage results accumulated so far */
+  readonly completedStageResults: readonly StageResult[];
+  /** Names of stages confirmed completed */
+  readonly completedStageNames: readonly StageName[];
 }

--- a/tests/ad-sdlc-orchestrator/AdsdlcOrchestratorAgent.test.ts
+++ b/tests/ad-sdlc-orchestrator/AdsdlcOrchestratorAgent.test.ts
@@ -248,7 +248,8 @@ describe('AdsdlcOrchestratorAgent', () => {
       const result = await stubAgent.executePipeline(tempDir, 'test');
 
       const stateDir = path.join(tempDir, '.ad-sdlc', 'scratchpad', 'pipeline');
-      const files = await fs.readdir(stateDir);
+      const entries = await fs.readdir(stateDir, { withFileTypes: true });
+      const files = entries.filter((e) => e.isFile()).map((e) => e.name);
       expect(files.length).toBeGreaterThan(0);
 
       const stateFile = path.join(stateDir, files[0]!);


### PR DESCRIPTION
## Summary

Implements mid-stage checkpoint persistence so interrupted pipelines can resume from the last completed stage instead of restarting from scratch.

Previously, pipeline state was only persisted at the very end of `executePipeline()`. A crash between stages meant total loss of progress. Now, a checkpoint file is written after each stage completes.

## Changes

| File | Change |
|------|--------|
| `src/ad-sdlc-orchestrator/PipelineCheckpointManager.ts` | **New**: save/load/delete/prune checkpoint YAML files |
| `src/ad-sdlc-orchestrator/types.ts` | `PipelineCheckpoint`, `CheckpointConfig` types; `checkpoint` field in `OrchestratorConfig` |
| `src/ad-sdlc-orchestrator/AdsdlcOrchestratorAgent.ts` | Wire checkpoint manager; save after each stage; load on resume; cleanup on success |
| `src/ad-sdlc-orchestrator/index.ts` | Export new types and class |
| `tests/ad-sdlc-orchestrator/AdsdlcOrchestratorAgent.test.ts` | Fix pipeline state test to filter directories |

## Design

- Checkpoints are **best-effort** — save failures are logged, not thrown
- Stored at `{scratchpadDir}/pipeline/checkpoints/{sessionId}-ckpt-{timestamp}.yaml`
- Automatic pruning keeps only last 5 checkpoints per session
- Resume prefers checkpoint data over stale session YAML
- Enabled by default (`checkpoint.enabled: true` in config)

## Test plan

- [x] `npm run build` — 0 errors
- [x] `npm test` — 219/219 passed, 0 failed
- [x] CI passes on Ubuntu and Windows

Closes #649
Part of #644