### PR TITLE
fix(docker): replace eval with array, fix UID variable, harden API keys

### DIFF
--- a/docker/docker-compose.linux.yml
+++ b/docker/docker-compose.linux.yml
@@ -3,12 +3,12 @@
 
 services:
   claude-a:
-    user: "${UID}:${GID}"
+    user: "${HOST_UID}:${HOST_GID}"
     environment:
       - HOME=/home/node
 
   claude-b:
-    user: "${UID}:${GID}"
+    user: "${HOST_UID}:${HOST_GID}"
     environment:
       - HOME=/home/node
 

--- a/docker/install.sh
+++ b/docker/install.sh
@@ -155,7 +155,8 @@ ask_auth_method() {
         for ((i=0; i<CONTAINER_COUNT; i++)); do
             local ltr
             ltr=$(idx_letter $i)
-            read -rp "  API key for container $ltr (Enter to skip): " key
+            read -rsp "  API key for container $ltr (Enter to skip): " key
+            echo  # Print newline after silent input
             API_KEYS[$i]="${key:-}"
         done
     fi
@@ -271,6 +272,7 @@ generate_env() {
             echo ""
         fi
     } > "$SCRIPT_DIR/.env"
+    chmod 600 .env
 
     ok ".env"
 }
@@ -380,7 +382,7 @@ HDR
         for ((i=0; i<CONTAINER_COUNT; i++)); do
             cat <<EOF
   claude-$(idx_letter $i):
-    user: "\${UID}:\${GID}"
+    user: "\${HOST_UID}:\${HOST_GID}"
     environment:
       - HOME=/home/node
 
@@ -537,19 +539,20 @@ build_and_start() {
     docker compose build
 
     info "Starting containers..."
-    local cmd="docker compose -f docker-compose.yml"
+    local -a compose_args=("-f" "docker-compose.yml")
 
     if [[ "$PLATFORM" == "linux" || "$PLATFORM" == "wsl" ]]; then
-        export UID GID
-        UID=$(id -u)
-        GID=$(id -g)
-        cmd="$cmd -f docker-compose.linux.yml"
+        export HOST_UID HOST_GID
+        HOST_UID=$(id -u)
+        HOST_GID=$(id -g)
+        compose_args+=("-f" "docker-compose.linux.yml")
     fi
 
-    [[ "$TIER" == "b" ]] && cmd="$cmd -f docker-compose.worktree.yml"
-    [[ -n "$SOURCES_DIR" ]] && cmd="$cmd -f docker-compose.sources.yml"
+    [[ "$TIER" == "b" ]] && compose_args+=("-f" "docker-compose.worktree.yml")
+    [[ -n "${SOURCES_DIR:-}" ]] && compose_args+=("-f" "docker-compose.sources.yml")
+    [[ "$ENABLE_FIREWALL" == "y" ]] && compose_args+=("-f" "docker-compose.firewall.yml")
 
-    eval "$cmd up -d"
+    docker compose "${compose_args[@]}" up -d
     ok "All containers started"
 }
 
@@ -599,6 +602,7 @@ main() {
     AUTH_METHOD="oauth"
     TIER="a"
     SOURCES_DIR=""
+    ENABLE_FIREWALL="n"
     CLAUDE_VERSION=""
     PLATFORM="unknown"
 
@@ -615,9 +619,9 @@ main() {
     generate_env
     generate_compose
     generate_linux_override
-    generate_worktree_override
-    generate_firewall_override
-    generate_sources_override
+    [[ "$TIER" == "b" ]] && generate_worktree_override
+    [[ "$ENABLE_FIREWALL" == "y" ]] && generate_firewall_override
+    [[ -n "${SOURCES_DIR:-}" ]] && generate_sources_override
 
     # Optional setup steps
     setup_oauth


### PR DESCRIPTION
## Summary
- Replace `eval "$cmd up -d"` with bash array pattern to eliminate shell injection risk
- Rename UID/GID to HOST_UID/HOST_GID to fix bash readonly variable bug
- Add silent input (`read -rsp`) for API key entry
- Add `chmod 600 .env` after file generation
- Wrap override generation in conditionals

## Related Issues
- Closes #659 (replace eval + fix UID readonly)
- Closes #661 (harden API key handling)
- Closes #668 (install.sh robustness)
- Part of #657 (Phase 6 Epic)

## Security
- `eval` completely removed — verified with grep
- API keys never echoed to terminal
- .env file permissions set to 600 (owner-only read/write)

## Test plan
- [x] `grep eval docker/install.sh` returns no results
- [x] `bash -n docker/install.sh` passes syntax check
- [x] docker-compose.linux.yml uses HOST_UID/HOST_GID