### PR TITLE
feat(cli): add --local flag for GitHub-free pipeline execution

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -951,7 +951,17 @@ program
       });
     }
 
-    // 5. Config files
+    // 5. Local mode
+    const localModeActive = process.env['AD_SDLC_LOCAL'] === '1';
+    checks.push({
+      label: 'Local Mode',
+      ok: true,
+      detail: localModeActive
+        ? 'active (AD_SDLC_LOCAL=1)'
+        : 'available (use --local flag or AD_SDLC_LOCAL=1)',
+    });
+
+    // 6. Config files
     const configResult = configFilesExist(resolve(projectDir, '.ad-sdlc', 'config'));
     if (configResult.workflow && configResult.agents) {
       checks.push({ label: 'Config files', ok: true, detail: 'workflow.yaml + agents.yaml found' });
@@ -969,7 +979,7 @@ program
       });
     }
 
-    // 6. Disk space
+    // 7. Disk space
     try {
       const { statfsSync } = await import('node:fs');
       const stats = statfsSync(projectDir);
@@ -1023,6 +1033,7 @@ program
     false
   )
   .option('--resume <session-id>', 'Resume a previously interrupted pipeline session')
+  .option('-L, --local', 'Run in local mode without GitHub dependency')
   .action(async (requirements: string, cmdOptions: Record<string, unknown>) => {
     const modeInput = typeof cmdOptions['mode'] === 'string' ? cmdOptions['mode'] : 'greenfield';
     const stopAfter =
@@ -1035,6 +1046,7 @@ program
     const allowStub = cmdOptions['allowStub'] === true;
     const resumeSessionId =
       typeof cmdOptions['resume'] === 'string' ? cmdOptions['resume'] : undefined;
+    const localMode = cmdOptions['local'] === true || process.env['AD_SDLC_LOCAL'] === '1';
 
     // Validate mode
     const validModes = ['greenfield', 'enhancement', 'import'];
@@ -1162,6 +1174,9 @@ program
     if (stopAfter !== undefined) {
       output.info(chalk.dim(`Stop after: ${stopAfter}`));
     }
+    if (localMode) {
+      output.info(chalk.dim('Local mode: enabled (GitHub integration disabled)'));
+    }
     output.blank();
 
     const agent = getAdsdlcOrchestratorAgent();
@@ -1172,6 +1187,7 @@ program
         projectDir,
         userRequest: requirements,
         overrideMode: mode,
+        localMode,
         ...(resumeSessionId !== undefined && {
           resumeMode: 'resume' as const,
           resumeSessionId,

--- a/tests/cli/localFlag.test.ts
+++ b/tests/cli/localFlag.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Tests for the --local CLI flag and AD_SDLC_LOCAL env var.
+ *
+ * Requires a prior build (`npm run build`) since it executes dist/cli.js.
+ * Automatically skipped when dist/cli.js does not exist.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { execFile } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { promisify } from 'node:util';
+import { resolve } from 'node:path';
+
+const execFileAsync = promisify(execFile);
+const cliPath = resolve(__dirname, '../../dist/cli.js');
+const cliBuilt = existsSync(cliPath);
+
+async function runCli(
+  args: string[],
+  env?: Record<string, string>
+): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  try {
+    const result = await execFileAsync('node', [cliPath, ...args], {
+      timeout: 10000,
+      env: { ...process.env, NODE_NO_WARNINGS: '1', ...env },
+    });
+    return { stdout: result.stdout, stderr: result.stderr, exitCode: 0 };
+  } catch (error: unknown) {
+    const execError = error as { stdout?: string; stderr?: string; code?: number };
+    return {
+      stdout: execError.stdout ?? '',
+      stderr: execError.stderr ?? '',
+      exitCode: execError.code ?? 1,
+    };
+  }
+}
+
+describe.skipIf(!cliBuilt)('CLI --local flag', () => {
+  it('should show --local option in run command help', async () => {
+    const result = await runCli(['run', '--help']);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('--local');
+    expect(result.stdout).toContain('-L');
+  });
+
+  it('should show Local Mode in doctor output', async () => {
+    const result = await runCli(['doctor']);
+    expect(result.stdout).toContain('Local Mode');
+    expect(result.stdout).toContain('available');
+  });
+
+  it('should detect AD_SDLC_LOCAL=1 in doctor output', async () => {
+    const result = await runCli(['doctor'], { AD_SDLC_LOCAL: '1' });
+    expect(result.stdout).toContain('Local Mode');
+    expect(result.stdout).toContain('active');
+  });
+});


### PR DESCRIPTION
## Summary
- Add `-L, --local` option to `ad-sdlc run` command
- Check `AD_SDLC_LOCAL=1` env var as fallback
- Pass `localMode: true` to PipelineRequest
- Add Local Mode check to `ad-sdlc doctor`
- Add unit tests for flag parsing

Closes #682

## Test plan
- [ ] `ad-sdlc run "test" --local` activates local mode
- [ ] `AD_SDLC_LOCAL=1 ad-sdlc run "test"` also works
- [ ] `ad-sdlc doctor` shows Local Mode status
- [ ] Unit tests pass