### PR TITLE
docs: update quickstart and deployment docs for local mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,39 +65,40 @@ GitHub Issues → Issue Reader → Controller → Worker → PR Reviewer
 
 ### Agent Pipeline (25 Agents)
 
-| Phase | Agent | Role |
-|-------|-------|------|
-| **Orchestration** | AD-SDLC Orchestrator | Coordinates the full pipeline lifecycle |
-| | Analysis Orchestrator | Coordinates the analysis sub-pipeline |
-| **Setup** | Mode Detector | Detects Greenfield vs Enhancement vs Import mode |
-| | Project Initializer | Creates `.ad-sdlc` directory structure and config |
-| | Repo Detector | Determines if existing repo or new setup needed |
-| | GitHub Repo Setup | Creates and initializes GitHub repository |
-| **Collection** | Collector | Gathers requirements from text, files, and URLs |
-| | Issue Reader | Imports existing GitHub Issues for Import pipeline |
-| **Documentation** | PRD Writer | Generates Product Requirements Document |
-| | SRS Writer | Generates Software Requirements Specification |
-| | SDS Writer | Generates Software Design Specification |
-| **Planning** | Issue Generator | Creates GitHub Issues from SDS components |
-| **Execution** | Controller | Orchestrates work distribution and monitors progress |
-| | Worker | Implements code based on assigned issues |
-| **Quality** | PR Reviewer | Creates PRs and performs automated code review |
-| | CI Fixer | Automatically diagnoses and fixes CI failures |
-| | Regression Tester | Validates existing functionality after changes |
-| **Enhancement** | Document Reader | Parses existing PRD/SRS/SDS documents |
-| | Code Reader | Extracts source code structure and dependencies |
-| | Codebase Analyzer | Analyzes current architecture and code structure |
-| | Doc-Code Comparator | Detects gaps between documentation and code |
-| | Impact Analyzer | Assesses change implications and risks |
-| | PRD Updater | Incremental PRD updates (delta changes) |
-| | SRS Updater | Incremental SRS updates (delta changes) |
-| | SDS Updater | Incremental SDS updates (delta changes) |
+| Phase             | Agent                 | Role                                                 |
+| ----------------- | --------------------- | ---------------------------------------------------- |
+| **Orchestration** | AD-SDLC Orchestrator  | Coordinates the full pipeline lifecycle              |
+|                   | Analysis Orchestrator | Coordinates the analysis sub-pipeline                |
+| **Setup**         | Mode Detector         | Detects Greenfield vs Enhancement vs Import mode     |
+|                   | Project Initializer   | Creates `.ad-sdlc` directory structure and config    |
+|                   | Repo Detector         | Determines if existing repo or new setup needed      |
+|                   | GitHub Repo Setup     | Creates and initializes GitHub repository            |
+| **Collection**    | Collector             | Gathers requirements from text, files, and URLs      |
+|                   | Issue Reader          | Imports existing GitHub Issues for Import pipeline   |
+| **Documentation** | PRD Writer            | Generates Product Requirements Document              |
+|                   | SRS Writer            | Generates Software Requirements Specification        |
+|                   | SDS Writer            | Generates Software Design Specification              |
+| **Planning**      | Issue Generator       | Creates GitHub Issues from SDS components            |
+| **Execution**     | Controller            | Orchestrates work distribution and monitors progress |
+|                   | Worker                | Implements code based on assigned issues             |
+| **Quality**       | PR Reviewer           | Creates PRs and performs automated code review       |
+|                   | CI Fixer              | Automatically diagnoses and fixes CI failures        |
+|                   | Regression Tester     | Validates existing functionality after changes       |
+| **Enhancement**   | Document Reader       | Parses existing PRD/SRS/SDS documents                |
+|                   | Code Reader           | Extracts source code structure and dependencies      |
+|                   | Codebase Analyzer     | Analyzes current architecture and code structure     |
+|                   | Doc-Code Comparator   | Detects gaps between documentation and code          |
+|                   | Impact Analyzer       | Assesses change implications and risks               |
+|                   | PRD Updater           | Incremental PRD updates (delta changes)              |
+|                   | SRS Updater           | Incremental SRS updates (delta changes)              |
+|                   | SDS Updater           | Incremental SDS updates (delta changes)              |
 
 ## Features
 
 - **Automatic Document Generation**: PRD, SRS, SDS documents from natural language requirements
 - **Enhancement Pipeline**: Incremental updates to existing projects without full rewrites
 - **Import Pipeline**: Process existing GitHub Issues directly, skipping document generation
+- **Local Mode**: Run the full pipeline without GitHub using `--local` (or `AD_SDLC_LOCAL=1`); see [Quickstart](docs/quickstart.md) for details
 - **Mode Detection**: Automatically detects Greenfield, Enhancement, or Import pipeline
 - **Pipeline Resume**: Resume interrupted pipelines from the last completed stage (`--resume`)
 - **Session Persistence**: Automatic state persistence for pipeline recovery
@@ -162,11 +163,11 @@ ad-sdlc init my-project \
 
 ### Template Options
 
-| Template | Workers | Coverage | Features |
-|----------|---------|----------|----------|
-| **minimal** | 2 | 50% | Basic structure |
-| **standard** | 3 | 70% | Token tracking, dashboard |
-| **enterprise** | 5 | 80% | Audit logging, security scanning |
+| Template       | Workers | Coverage | Features                         |
+| -------------- | ------- | -------- | -------------------------------- |
+| **minimal**    | 2       | 50%      | Basic structure                  |
+| **standard**   | 3       | 70%      | Token tracking, dashboard        |
+| **enterprise** | 5       | 80%      | Audit logging, security scanning |
 
 ### Run the Pipeline
 
@@ -332,6 +333,7 @@ your-project/
 ## Agent Definitions
 
 Each agent is defined in `.claude/agents/` with:
+
 - YAML frontmatter (name, description, tools, model)
 - Markdown body with role, responsibilities, schemas, and workflows
 

--- a/docs/deployment/installation.md
+++ b/docs/deployment/installation.md
@@ -2,6 +2,17 @@
 
 > **Purpose**: Installing AD-SDLC
 
+## Prerequisites
+
+| Dependency                  | Required | Notes                                                              |
+| --------------------------- | -------- | ------------------------------------------------------------------ |
+| Node.js 18+                 | Yes      | [Download](https://nodejs.org/)                                    |
+| Git 2.30+                   | Yes      |                                                                    |
+| `ANTHROPIC_API_KEY`         | Yes      | Required for all pipeline modes                                    |
+| `GITHUB_TOKEN` / GitHub CLI | No       | Required for GitHub issue/PR operations; not needed with `--local` |
+
+---
+
 ## Installation Methods
 
 ### Method 1: npm Global Install (Recommended)
@@ -45,7 +56,9 @@ npm run sdlc -- init
 npm run sdlc -- run
 ```
 
-### Method 4: From Source
+### Method 4: Build from Source
+
+Use this method when installing from the GitHub repository directly, or when `npm install -g ad-sdlc` is not available.
 
 ```bash
 # Clone repository
@@ -58,7 +71,7 @@ npm install
 # Build
 npm run build
 
-# Link globally
+# Link globally (makes 'ad-sdlc' available as a system command)
 npm link
 
 # Verify
@@ -75,7 +88,7 @@ ad-sdlc --version
 # Required: Anthropic API Key
 export ANTHROPIC_API_KEY="sk-ant-api03-..."
 
-# Required: GitHub Token (for issue/PR operations)
+# Optional: GitHub Token (required for issue/PR operations; not needed with --local)
 export GITHUB_TOKEN="ghp_..."
 ```
 
@@ -84,7 +97,7 @@ Add to shell profile for persistence:
 ```bash
 # ~/.bashrc or ~/.zshrc
 echo 'export ANTHROPIC_API_KEY="sk-ant-..."' >> ~/.zshrc
-echo 'export GITHUB_TOKEN="ghp_..."' >> ~/.zshrc
+echo 'export GITHUB_TOKEN="ghp_..."' >> ~/.zshrc  # optional
 source ~/.zshrc
 ```
 
@@ -96,6 +109,7 @@ ad-sdlc init
 ```
 
 This creates:
+
 ```
 .ad-sdlc/
 ├── config/
@@ -114,6 +128,7 @@ ad-sdlc doctor
 ```
 
 Expected output:
+
 ```
 AD-SDLC Health Check
 ====================
@@ -125,7 +140,7 @@ Environment:
 
 Authentication:
   ✓ ANTHROPIC_API_KEY configured
-  ✓ GITHUB_TOKEN configured
+  ! GITHUB_TOKEN not configured (GitHub features disabled; use --local to run without GitHub)
 
 Configuration:
   ✓ workflow.yaml valid
@@ -133,6 +148,8 @@ Configuration:
 
 Ready to run!
 ```
+
+`GITHUB_TOKEN` is only required for GitHub issue creation and PR operations. When running with `--local`, it can be omitted.
 
 ---
 
@@ -176,4 +193,4 @@ npx ad-sdlc@1.0.0 run
 
 ---
 
-*Part of [Deployment Guide](./README.md)*
+_Part of [Deployment Guide](./README.md)_

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -21,11 +21,21 @@ This tutorial walks you through creating your first automated feature with AD-SD
 
 Before starting, ensure you have:
 
-- ✅ AD-SDLC CLI installed (`npm install -g ad-sdlc`)
+- ✅ AD-SDLC CLI installed (see below)
 - ✅ API key configured (`export ANTHROPIC_API_KEY="..."`)
-- ✅ GitHub CLI authenticated (`gh auth login`) - *optional but recommended*
+- ✅ GitHub CLI authenticated (`gh auth login`) - _optional; not required for local mode_
 
-Need to install? See the [Installation Guide](installation.md).
+### Install from Source
+
+```bash
+git clone https://github.com/kcenon/claude_code_agent.git
+cd claude_code_agent
+npm install
+npm run build
+npm link  # makes 'ad-sdlc' available globally
+```
+
+Need more options? See the [Installation Guide](installation.md).
 
 ---
 
@@ -84,6 +94,7 @@ claude "Implement a REST API endpoint for user registration with email and passw
 ```
 
 This starts the automated pipeline. Claude will:
+
 1. Collect and clarify requirements
 2. Generate documentation (PRD, SRS, SDS)
 3. Create GitHub issues
@@ -146,11 +157,13 @@ ls src/
 ### Example Output
 
 **Documents Generated:**
+
 - `docs/PRD-001.md` - Product requirements
 - `docs/SRS-001.md` - Functional requirements
 - `docs/SDS-001.md` - Technical design
 
 **Issues Created:**
+
 - #1: Setup project structure
 - #2: Implement user model
 - #3: Create registration endpoint
@@ -158,10 +171,32 @@ ls src/
 - #5: Write unit tests
 
 **Code Implemented:**
+
 - `src/models/user.ts`
 - `src/routes/auth.ts`
 - `src/validators/user.ts`
 - `tests/auth.test.ts`
+
+---
+
+## Local Mode (No GitHub Required)
+
+Run the pipeline without GitHub integration using the `--local` flag:
+
+```bash
+ad-sdlc run "Your requirements" --local
+```
+
+In local mode, the pipeline skips GitHub issue creation and PR operations. Documents and code are generated locally.
+
+You can also enable local mode via environment variable:
+
+```bash
+export AD_SDLC_LOCAL=1
+ad-sdlc run "Your requirements"
+```
+
+For configuration customization, see the example files in [`examples/config/`](../examples/config/).
 
 ---
 
@@ -232,26 +267,26 @@ See [FAQ](faq.md) for more troubleshooting tips.
 
 ### Essential Commands
 
-| Command | Description |
-|---------|-------------|
-| `ad-sdlc init` | Initialize new project |
-| `ad-sdlc status` | Check pipeline status |
+| Command            | Description            |
+| ------------------ | ---------------------- |
+| `ad-sdlc init`     | Initialize new project |
+| `ad-sdlc status`   | Check pipeline status  |
 | `ad-sdlc validate` | Validate configuration |
-| `ad-sdlc resume` | Resume from checkpoint |
-| `ad-sdlc reset` | Reset pipeline state |
+| `ad-sdlc resume`   | Resume from checkpoint |
+| `ad-sdlc reset`    | Reset pipeline state   |
 
 ### Pipeline Stages
 
-| Stage | Agent | Output |
-|-------|-------|--------|
-| Collection | Collector | Requirements data |
-| PRD | PRD Writer | `docs/PRD-*.md` |
-| SRS | SRS Writer | `docs/SRS-*.md` |
-| SDS | SDS Writer | `docs/SDS-*.md` |
-| Issues | Issue Generator | GitHub Issues |
-| Implementation | Worker(s) | `src/*` |
-| Review | PR Reviewer | Pull Requests |
+| Stage          | Agent           | Output            |
+| -------------- | --------------- | ----------------- |
+| Collection     | Collector       | Requirements data |
+| PRD            | PRD Writer      | `docs/PRD-*.md`   |
+| SRS            | SRS Writer      | `docs/SRS-*.md`   |
+| SDS            | SDS Writer      | `docs/SDS-*.md`   |
+| Issues         | Issue Generator | GitHub Issues     |
+| Implementation | Worker(s)       | `src/*`           |
+| Review         | PR Reviewer     | Pull Requests     |
 
 ---
 
-*Part of [AD-SDLC Documentation](../README.md)*
+_Part of [AD-SDLC Documentation](../README.md)_


### PR DESCRIPTION
## Summary
- Replace `npm install -g ad-sdlc` with build-from-source instructions in quickstart
- Add Local Mode section with `--local` flag and `AD_SDLC_LOCAL=1` usage
- Update installation.md with prerequisites table and `ad-sdlc doctor` guidance
- Add Local Mode one-liner to README.md features

Closes #684

## Test plan
- [ ] Quickstart instructions work from scratch (clone, build, init, run)
- [ ] Local mode section is clear and complete
- [ ] No stale references to npm install -g