### PR TITLE
feat(orchestrator): add inter-stage artifact content validation

### DIFF
--- a/src/ad-sdlc-orchestrator/AdsdlcOrchestratorAgent.ts
+++ b/src/ad-sdlc-orchestrator/AdsdlcOrchestratorAgent.ts
@@ -427,7 +427,9 @@ export class AdsdlcOrchestratorAgent implements IAgent {
     }
 
     const stageResults = this.session.stageResults;
-    const completed = stageResults.filter((s) => s.status === 'completed').length;
+    const completed = stageResults.filter(
+      (s) => s.status === 'completed' || s.status === 'degraded'
+    ).length;
     const failed = stageResults.filter((s) => s.status === 'failed').length;
     const skipped = stageResults.filter((s) => s.status === 'skipped').length;
     const running = stageResults.find((s) => s.status === ('running' as PipelineStageStatus));
@@ -630,10 +632,37 @@ export class AdsdlcOrchestratorAgent implements IAgent {
           }
         }
 
-        const result = await this.executeStageWithRetry(stage, session);
+        let result = await this.executeStageWithRetry(stage, session);
+
+        // Post-stage content quality validation for completed stages
+        if (result.status === 'completed') {
+          try {
+            const validator = this.createArtifactValidator(session.projectDir);
+            const contentResult = await validator.validateStageOutput(stage.name, session.mode);
+            if (contentResult.quality === 'degraded') {
+              result = {
+                ...result,
+                status: 'degraded',
+                warnings: [...(result.warnings ?? []), ...contentResult.warnings],
+              };
+              getLogger().warn('Stage output quality degraded', {
+                agent: 'AdsdlcOrchestratorAgent',
+                stage: stage.name,
+                warnings: contentResult.warnings,
+              });
+            }
+          } catch (err) {
+            getLogger().warn('Content validation failed (non-critical)', {
+              agent: 'AdsdlcOrchestratorAgent',
+              stage: stage.name,
+              error: err instanceof Error ? err.message : String(err),
+            });
+          }
+        }
+
         results.push(result);
 
-        if (result.status === 'completed') {
+        if (result.status === 'completed' || result.status === 'degraded') {
           completedStages.add(stage.name);
         }
 
@@ -1150,7 +1179,7 @@ export class AdsdlcOrchestratorAgent implements IAgent {
     if (stages.length === 0) return 'completed';
 
     const hasFailures = stages.some((s) => s.status === 'failed');
-    const hasCompletions = stages.some((s) => s.status === 'completed');
+    const hasCompletions = stages.some((s) => s.status === 'completed' || s.status === 'degraded');
     const allSkipped = stages.every((s) => s.status === 'skipped');
 
     if (allSkipped) return 'failed';

--- a/src/ad-sdlc-orchestrator/ArtifactValidator.ts
+++ b/src/ad-sdlc-orchestrator/ArtifactValidator.ts
@@ -15,6 +15,18 @@ import * as path from 'node:path';
 import type { PipelineMode, StageName } from './types.js';
 
 /**
+ * Result of content-level quality validation for a completed stage's output
+ */
+export interface ContentValidationResult {
+  /** Stage that was validated */
+  readonly stage: StageName;
+  /** Quality assessment: 'good' means fully usable, 'degraded' means downstream may produce poor output */
+  readonly quality: 'good' | 'degraded';
+  /** Human-readable warnings describing detected quality issues */
+  readonly warnings: string[];
+}
+
+/**
  * Specification for a single artifact produced by a pipeline stage
  */
 export interface ArtifactSpec {
@@ -326,6 +338,177 @@ export class ArtifactValidator {
       stage,
       missing,
       found,
+    };
+  }
+
+  /**
+   * Validate the content quality of a completed stage's output artifacts.
+   *
+   * Performs stage-specific quality checks beyond file existence:
+   * - collection: collected_info.yaml has at least 1 FR with title and description
+   * - prd_generation / prd_update: no unsubstituted template variables, min content length
+   * - srs_generation / srs_update: has features section, product name is not a placeholder
+   *
+   * @param stage - The stage that just completed
+   * @param mode - Pipeline mode for artifact path lookup
+   * @returns Content validation result with quality assessment and warnings
+   */
+  async validateStageOutput(
+    stage: StageName,
+    mode: PipelineMode
+  ): Promise<ContentValidationResult> {
+    switch (stage) {
+      case 'collection':
+        return this.validateCollectionOutput(stage, mode);
+      case 'prd_generation':
+      case 'prd_update':
+        return this.validatePRDOutput(stage, mode);
+      case 'srs_generation':
+      case 'srs_update':
+        return this.validateSRSOutput(stage, mode);
+      default:
+        return { stage, quality: 'good', warnings: [] };
+    }
+  }
+
+  /**
+   * Validate collection stage output: collected_info.yaml must have at least one FR
+   * @param stage
+   * @param mode
+   */
+  private async validateCollectionOutput(
+    stage: StageName,
+    mode: PipelineMode
+  ): Promise<ContentValidationResult> {
+    const warnings: string[] = [];
+    const artifactMap = this.getArtifactMap(mode);
+    const entry = artifactMap.find((e) => e.stage === stage);
+    if (!entry) return { stage, quality: 'good', warnings: [] };
+
+    const yamlFiles = await this.resolveGlob(
+      entry.requiredArtifacts[0]?.pathPattern ?? '.ad-sdlc/scratchpad/info/*/collected_info.yaml'
+    );
+
+    if (yamlFiles.length === 0) {
+      warnings.push('collected_info.yaml not found');
+      return { stage, quality: 'degraded', warnings };
+    }
+
+    try {
+      const content = await fs.readFile(yamlFiles[0] as string, 'utf8');
+
+      // Check for functional requirements with non-empty title and description
+      const hasFR = /title:\s*\S/.test(content) && /description:\s*\S/.test(content);
+      if (!hasFR) {
+        warnings.push('No functional requirement with non-empty title and description found');
+      }
+    } catch {
+      warnings.push('Failed to read collected_info.yaml');
+    }
+
+    return {
+      stage,
+      quality: warnings.length > 0 ? 'degraded' : 'good',
+      warnings,
+    };
+  }
+
+  /**
+   * Validate PRD output: no template variables, minimum content length
+   * @param stage
+   * @param _mode
+   */
+  private async validatePRDOutput(
+    stage: StageName,
+    _mode: PipelineMode
+  ): Promise<ContentValidationResult> {
+    const warnings: string[] = [];
+    const prdFiles = await this.resolveGlob('.ad-sdlc/scratchpad/documents/*/prd.md');
+
+    if (prdFiles.length === 0) {
+      warnings.push('PRD document not found in scratchpad');
+      return { stage, quality: 'degraded', warnings };
+    }
+
+    try {
+      const content = await fs.readFile(prdFiles[0] as string, 'utf8');
+
+      // Check for unsubstituted template variables
+      const dollarVars = content.match(/\$\{[^}]+\}/g);
+      const mustacheVars = content.match(/\{\{[^}]+\}\}/g);
+      if (dollarVars !== null || mustacheVars !== null) {
+        const count = (dollarVars?.length ?? 0) + (mustacheVars?.length ?? 0);
+        warnings.push(`PRD contains ${String(count)} unsubstituted template variable(s)`);
+      }
+
+      // Check minimum meaningful content
+      const stripped = content
+        .replace(/^#+\s.*$/gm, '')
+        .replace(/\|.*\|/g, '')
+        .replace(/---+/g, '')
+        .replace(/<!--[\s\S]*?-->/g, '')
+        .replace(/\[Not yet generated\]/g, '')
+        .replace(/\s+/g, ' ')
+        .trim();
+      if (stripped.length < 100) {
+        warnings.push('PRD has insufficient meaningful content (less than 100 characters)');
+      }
+    } catch {
+      warnings.push('Failed to read PRD document');
+    }
+
+    return {
+      stage,
+      quality: warnings.length > 0 ? 'degraded' : 'good',
+      warnings,
+    };
+  }
+
+  /**
+   * Validate SRS output: has features section, product name is not a placeholder
+   * @param stage
+   * @param _mode
+   */
+  private async validateSRSOutput(
+    stage: StageName,
+    _mode: PipelineMode
+  ): Promise<ContentValidationResult> {
+    const warnings: string[] = [];
+    const srsFiles = await this.resolveGlob('.ad-sdlc/scratchpad/documents/*/srs.md');
+
+    if (srsFiles.length === 0) {
+      warnings.push('SRS document not found in scratchpad');
+      return { stage, quality: 'degraded', warnings };
+    }
+
+    try {
+      const content = await fs.readFile(srsFiles[0] as string, 'utf8');
+
+      // Check for features section
+      if (!/##\s*\d*\.?\s*System Features/i.test(content)) {
+        warnings.push('SRS is missing System Features section');
+      }
+
+      // Check product name is not a placeholder
+      const titleMatch = content.match(/^#\s*SRS:\s*(.+)$/m);
+      if (titleMatch !== null && titleMatch[1] !== undefined) {
+        const productName = titleMatch[1].trim();
+        if (
+          productName === 'Unknown Product' ||
+          /\$\{/.test(productName) ||
+          /\{\{/.test(productName)
+        ) {
+          warnings.push(`SRS has placeholder product name: "${productName}"`);
+        }
+      }
+    } catch {
+      warnings.push('Failed to read SRS document');
+    }
+
+    return {
+      stage,
+      quality: warnings.length > 0 ? 'degraded' : 'good',
+      warnings,
     };
   }
 

--- a/src/ad-sdlc-orchestrator/index.ts
+++ b/src/ad-sdlc-orchestrator/index.ts
@@ -24,7 +24,12 @@ export {
   ENHANCEMENT_ARTIFACTS,
 } from './ArtifactValidator.js';
 
-export type { ArtifactSpec, StageArtifactMap, ValidationResult } from './ArtifactValidator.js';
+export type {
+  ArtifactSpec,
+  ContentValidationResult,
+  StageArtifactMap,
+  ValidationResult,
+} from './ArtifactValidator.js';
 
 // Type exports
 export type {

--- a/src/ad-sdlc-orchestrator/types.ts
+++ b/src/ad-sdlc-orchestrator/types.ts
@@ -67,7 +67,13 @@ export type StageName = GreenfieldStageName | EnhancementStageName | ImportStage
 /**
  * Pipeline stage status
  */
-export type PipelineStageStatus = 'pending' | 'running' | 'completed' | 'failed' | 'skipped';
+export type PipelineStageStatus =
+  | 'pending'
+  | 'running'
+  | 'completed'
+  | 'degraded'
+  | 'failed'
+  | 'skipped';
 
 /**
  * Overall pipeline status

--- a/tests/ad-sdlc-orchestrator/ArtifactValidator.test.ts
+++ b/tests/ad-sdlc-orchestrator/ArtifactValidator.test.ts
@@ -206,6 +206,193 @@ describe('ArtifactValidator', () => {
       expect(result.found).toHaveLength(2);
     });
   });
+
+  describe('validateStageOutput (content quality)', () => {
+    describe('collection stage', () => {
+      it('should return good quality when collected_info.yaml has FR with title and description', async () => {
+        const infoDir = path.join(tempDir, '.ad-sdlc', 'scratchpad', 'info', 'session-001');
+        await fs.mkdir(infoDir, { recursive: true });
+        await fs.writeFile(
+          path.join(infoDir, 'collected_info.yaml'),
+          'functional_requirements:\n  - title: User Login\n    description: Users can log in with email and password\n'
+        );
+
+        const result = await validator.validateStageOutput('collection', 'greenfield');
+        expect(result.stage).toBe('collection');
+        expect(result.quality).toBe('good');
+        expect(result.warnings).toHaveLength(0);
+      });
+
+      it('should return degraded when collected_info.yaml has no FR content', async () => {
+        const infoDir = path.join(tempDir, '.ad-sdlc', 'scratchpad', 'info', 'session-001');
+        await fs.mkdir(infoDir, { recursive: true });
+        await fs.writeFile(
+          path.join(infoDir, 'collected_info.yaml'),
+          'functional_requirements:\n  - title:\n    description:\n'
+        );
+
+        const result = await validator.validateStageOutput('collection', 'greenfield');
+        expect(result.quality).toBe('degraded');
+        expect(result.warnings.length).toBeGreaterThan(0);
+      });
+
+      it('should return degraded when collected_info.yaml does not exist', async () => {
+        const result = await validator.validateStageOutput('collection', 'greenfield');
+        expect(result.quality).toBe('degraded');
+        expect(result.warnings).toContain('collected_info.yaml not found');
+      });
+    });
+
+    describe('prd_generation stage', () => {
+      it('should return good quality for a well-formed PRD', async () => {
+        const docsDir = path.join(tempDir, '.ad-sdlc', 'scratchpad', 'documents', 'v1');
+        await fs.mkdir(docsDir, { recursive: true });
+        await fs.writeFile(
+          path.join(docsDir, 'prd.md'),
+          '# PRD: My Project\n\n## Overview\n\nThis is a product requirements document that describes the functional and non-functional requirements for the system in sufficient detail.\n'
+        );
+
+        const result = await validator.validateStageOutput('prd_generation', 'greenfield');
+        expect(result.quality).toBe('good');
+        expect(result.warnings).toHaveLength(0);
+      });
+
+      it('should detect unsubstituted ${...} template variables', async () => {
+        const docsDir = path.join(tempDir, '.ad-sdlc', 'scratchpad', 'documents', 'v1');
+        await fs.mkdir(docsDir, { recursive: true });
+        await fs.writeFile(
+          path.join(docsDir, 'prd.md'),
+          '# PRD: ${PROJECT_NAME}\n\nThis project ${DESCRIPTION} provides enough content to pass the length check for meaningful content in the validator.\n'
+        );
+
+        const result = await validator.validateStageOutput('prd_generation', 'greenfield');
+        expect(result.quality).toBe('degraded');
+        expect(result.warnings.some((w) => w.includes('template variable'))).toBe(true);
+      });
+
+      it('should detect unsubstituted {{...}} mustache variables', async () => {
+        const docsDir = path.join(tempDir, '.ad-sdlc', 'scratchpad', 'documents', 'v1');
+        await fs.mkdir(docsDir, { recursive: true });
+        await fs.writeFile(
+          path.join(docsDir, 'prd.md'),
+          '# PRD: {{PROJECT_NAME}}\n\nThe {{DESCRIPTION}} here provides enough meaningful content to pass the minimum length check for the validator.\n'
+        );
+
+        const result = await validator.validateStageOutput('prd_generation', 'greenfield');
+        expect(result.quality).toBe('degraded');
+        expect(result.warnings.some((w) => w.includes('template variable'))).toBe(true);
+      });
+
+      it('should detect insufficient content length', async () => {
+        const docsDir = path.join(tempDir, '.ad-sdlc', 'scratchpad', 'documents', 'v1');
+        await fs.mkdir(docsDir, { recursive: true });
+        await fs.writeFile(path.join(docsDir, 'prd.md'), '# PRD\n\nShort.\n');
+
+        const result = await validator.validateStageOutput('prd_generation', 'greenfield');
+        expect(result.quality).toBe('degraded');
+        expect(result.warnings.some((w) => w.includes('insufficient meaningful content'))).toBe(
+          true
+        );
+      });
+
+      it('should return degraded when PRD file is missing', async () => {
+        const result = await validator.validateStageOutput('prd_generation', 'greenfield');
+        expect(result.quality).toBe('degraded');
+        expect(result.warnings).toContain('PRD document not found in scratchpad');
+      });
+    });
+
+    describe('srs_generation stage', () => {
+      it('should return good quality for a well-formed SRS', async () => {
+        const docsDir = path.join(tempDir, '.ad-sdlc', 'scratchpad', 'documents', 'v1');
+        await fs.mkdir(docsDir, { recursive: true });
+        await fs.writeFile(
+          path.join(docsDir, 'srs.md'),
+          '# SRS: My Application\n\n## 3. System Features\n\n### 3.1 User Management\n'
+        );
+
+        const result = await validator.validateStageOutput('srs_generation', 'greenfield');
+        expect(result.quality).toBe('good');
+        expect(result.warnings).toHaveLength(0);
+      });
+
+      it('should detect missing System Features section', async () => {
+        const docsDir = path.join(tempDir, '.ad-sdlc', 'scratchpad', 'documents', 'v1');
+        await fs.mkdir(docsDir, { recursive: true });
+        await fs.writeFile(
+          path.join(docsDir, 'srs.md'),
+          '# SRS: My Application\n\n## Introduction\n\nSome intro text.\n'
+        );
+
+        const result = await validator.validateStageOutput('srs_generation', 'greenfield');
+        expect(result.quality).toBe('degraded');
+        expect(result.warnings.some((w) => w.includes('System Features'))).toBe(true);
+      });
+
+      it('should detect placeholder product name "Unknown Product"', async () => {
+        const docsDir = path.join(tempDir, '.ad-sdlc', 'scratchpad', 'documents', 'v1');
+        await fs.mkdir(docsDir, { recursive: true });
+        await fs.writeFile(
+          path.join(docsDir, 'srs.md'),
+          '# SRS: Unknown Product\n\n## 3. System Features\n\n### 3.1 Feature A\n'
+        );
+
+        const result = await validator.validateStageOutput('srs_generation', 'greenfield');
+        expect(result.quality).toBe('degraded');
+        expect(result.warnings.some((w) => w.includes('placeholder product name'))).toBe(true);
+      });
+
+      it('should detect template variable in product name', async () => {
+        const docsDir = path.join(tempDir, '.ad-sdlc', 'scratchpad', 'documents', 'v1');
+        await fs.mkdir(docsDir, { recursive: true });
+        await fs.writeFile(
+          path.join(docsDir, 'srs.md'),
+          '# SRS: ${PROJECT_NAME}\n\n## 3. System Features\n\n### 3.1 Feature A\n'
+        );
+
+        const result = await validator.validateStageOutput('srs_generation', 'greenfield');
+        expect(result.quality).toBe('degraded');
+        expect(result.warnings.some((w) => w.includes('placeholder product name'))).toBe(true);
+      });
+
+      it('should return degraded when SRS file is missing', async () => {
+        const result = await validator.validateStageOutput('srs_generation', 'greenfield');
+        expect(result.quality).toBe('degraded');
+        expect(result.warnings).toContain('SRS document not found in scratchpad');
+      });
+    });
+
+    describe('prd_update and srs_update stages', () => {
+      it('should validate prd_update the same as prd_generation', async () => {
+        const docsDir = path.join(tempDir, '.ad-sdlc', 'scratchpad', 'documents', 'v1');
+        await fs.mkdir(docsDir, { recursive: true });
+        await fs.writeFile(path.join(docsDir, 'prd.md'), '# PRD\n\nShort.\n');
+
+        const result = await validator.validateStageOutput('prd_update', 'enhancement');
+        expect(result.quality).toBe('degraded');
+      });
+
+      it('should validate srs_update the same as srs_generation', async () => {
+        const result = await validator.validateStageOutput('srs_update', 'enhancement');
+        expect(result.quality).toBe('degraded');
+        expect(result.warnings).toContain('SRS document not found in scratchpad');
+      });
+    });
+
+    describe('other stages', () => {
+      it('should return good quality for stages without content validation', async () => {
+        const result = await validator.validateStageOutput('initialization', 'greenfield');
+        expect(result.quality).toBe('good');
+        expect(result.warnings).toHaveLength(0);
+      });
+
+      it('should return good quality for sds_generation (no content check yet)', async () => {
+        const result = await validator.validateStageOutput('sds_generation', 'greenfield');
+        expect(result.quality).toBe('good');
+        expect(result.warnings).toHaveLength(0);
+      });
+    });
+  });
 });
 
 describe('Artifact Map Definitions', () => {


### PR DESCRIPTION
## What

### Summary
Adds post-completion content quality validation for pipeline stages. Stages that produce empty templates, corrupted documents, or garbled YAML are now flagged as `degraded` instead of `completed`, with descriptive warnings.

### Change Type
- [x] Enhancement (new functionality)

### Affected Components
- `src/ad-sdlc-orchestrator/types.ts` — new `degraded` pipeline status
- `src/ad-sdlc-orchestrator/ArtifactValidator.ts` — content validation
- `src/ad-sdlc-orchestrator/AdsdlcOrchestratorAgent.ts` — post-stage validation integration

## Why

### Related Issues
- Closes #693 (Add artifact validation between pipeline stages)

### Problem
In the sample project test, `collection`, `prd_generation`, and `srs_generation` all reported SUCCESS while producing garbled YAML, unfilled templates, and corrupted documents. This gave false confidence.

## How

### Implementation
1. Added `'degraded'` to `PipelineStageStatus` union type
2. Added `validateStageOutput()` with stage-specific content validators:
   - **collection**: checks collected_info.yaml for FRs with title/description
   - **prd_generation**: detects unsubstituted template variables, minimum content length
   - **srs_generation**: checks for System Features section, detects placeholder product names
3. Integrated post-stage validation in `executeStages()` — degraded stages allow downstream execution
4. Updated `determineOverallStatus()` to count degraded as completed

### Testing Done
- [x] 17 new content validation unit tests
- [x] All 37 ArtifactValidator tests pass
- [x] Build clean

### Breaking Changes
New `'degraded'` value in `PipelineStageStatus` type — consumers using exhaustive switches may need to add a case.