### PR TITLE
fix(orchestrator): resolve repo_detection projectDir propagation in local mode

### DIFF
--- a/src/agents/AgentDispatcher.ts
+++ b/src/agents/AgentDispatcher.ts
@@ -518,11 +518,15 @@ export class AgentDispatcher {
     // SDS Writer: generateFromProject(projectId)
     this.callAdapters.set('sds-writer', this.createProjectIdAdapter('generateFromProject'));
 
-    // Repo Detector: startSession + detect + finalize pattern
+    // Repo Detector: startSession(projectId, rootPath) + detect + finalize pattern
     this.callAdapters.set('repo-detector', async (agent, _stage, session) => {
       const a = toRecord(agent);
       if (typeof a['startSession'] === 'function') {
-        await (a['startSession'] as (dir: string) => Promise<unknown>)(session.projectDir);
+        const projectId = path.basename(session.projectDir);
+        await (a['startSession'] as (id: string, dir: string) => Promise<unknown>)(
+          projectId,
+          session.projectDir
+        );
       }
       if (typeof a['detect'] === 'function') {
         const result = await (a['detect'] as () => Promise<unknown>)();
@@ -534,11 +538,15 @@ export class AgentDispatcher {
       return this.defaultAdapter(agent, _stage, session);
     });
 
-    // GitHub Repo Setup: similar session pattern
+    // GitHub Repo Setup: startSession(projectName, rootPath) + setup + finalize pattern
     this.callAdapters.set('github-repo-setup', async (agent, _stage, session) => {
       const a = toRecord(agent);
       if (typeof a['startSession'] === 'function') {
-        await (a['startSession'] as (dir: string) => Promise<unknown>)(session.projectDir);
+        const projectName = path.basename(session.projectDir);
+        await (a['startSession'] as (name: string, dir: string) => Promise<unknown>)(
+          projectName,
+          session.projectDir
+        );
       }
       if (typeof a['setup'] === 'function') {
         const result = await (a['setup'] as () => Promise<unknown>)();
@@ -566,11 +574,15 @@ export class AgentDispatcher {
       return this.defaultAdapter(agent, _stage, session);
     });
 
-    // Codebase Analyzer: startSession + analyze + finalize
+    // Codebase Analyzer: startSession(projectId, rootPath) + analyze + finalize
     this.callAdapters.set('codebase-analyzer', async (agent, _stage, session) => {
       const a = toRecord(agent);
       if (typeof a['startSession'] === 'function') {
-        await (a['startSession'] as (dir: string) => Promise<unknown>)(session.projectDir);
+        const projectId = path.basename(session.projectDir);
+        await (a['startSession'] as (id: string, dir: string) => Promise<unknown>)(
+          projectId,
+          session.projectDir
+        );
       }
       if (typeof a['analyze'] === 'function') {
         const result = await (a['analyze'] as () => Promise<unknown>)();

--- a/tests/agents/AgentDispatcher.test.ts
+++ b/tests/agents/AgentDispatcher.test.ts
@@ -77,8 +77,8 @@ function createCollectorAgent(): MockAgent & {
 function createSessionAgent(agentId: string, name: string, primaryMethod: string): MockAgent {
   const agent = new MockAgent(agentId, name);
   const a = agent as Record<string, unknown>;
-  a['startSession'] = async (dir: string) => {
-    agent.calls.push({ method: 'startSession', args: [dir] });
+  a['startSession'] = async (...args: unknown[]) => {
+    agent.calls.push({ method: 'startSession', args });
   };
   a[primaryMethod] = async () => {
     agent.calls.push({ method: primaryMethod, args: [] });
@@ -265,9 +265,27 @@ describe('AgentDispatcher', () => {
       expect(parsed.result).toBe('detect');
       expect(agent.calls).toHaveLength(3);
       expect(agent.calls[0]!.method).toBe('startSession');
-      expect(agent.calls[0]!.args[0]).toBe('/test/repo');
+      expect(agent.calls[0]!.args[0]).toBe('repo');
+      expect(agent.calls[0]!.args[1]).toBe('/test/repo');
       expect(agent.calls[1]!.method).toBe('detect');
       expect(agent.calls[2]!.method).toBe('finalize');
+    });
+
+    it('should pass projectId and rootPath to repo-detector startSession', async () => {
+      const agent = createSessionAgent('repo-detector-agent', 'Repo Detector', 'detect');
+      dispatcher.setAgent('repo-detector', agent);
+
+      const stage = createStage({
+        name: 'repo_detection',
+        agentType: 'repo-detector',
+      });
+      const session = createSession({ projectDir: '/home/user/my-app' });
+
+      await dispatcher.dispatch(stage, session);
+
+      expect(agent.calls[0]!.method).toBe('startSession');
+      expect(agent.calls[0]!.args[0]).toBe('my-app');
+      expect(agent.calls[0]!.args[1]).toBe('/home/user/my-app');
     });
 
     it('should dispatch github-repo-setup agent with startSession/setup/finalize', async () => {
@@ -284,6 +302,9 @@ describe('AgentDispatcher', () => {
       const parsed = JSON.parse(result);
 
       expect(parsed.result).toBe('setup');
+      expect(agent.calls[0]!.method).toBe('startSession');
+      expect(agent.calls[0]!.args[0]).toBe('repo');
+      expect(agent.calls[0]!.args[1]).toBe('/test/repo');
       expect(agent.calls.map((c) => c.method)).toEqual(['startSession', 'setup', 'finalize']);
     });
 


### PR DESCRIPTION
## What

### Summary
Fixes `repo_detection` stage failure in `--local` mode caused by incorrect `startSession()` argument count in 3 AgentDispatcher adapters.

### Change Type
- [x] Bugfix (fixes an issue)

### Affected Components
- `src/agents/AgentDispatcher.ts` — 3 adapter `startSession` calls

## Why

### Related Issues
- Closes #698 (repo_detection fails in local mode with undefined projectDir)

### Root Cause
The `repo-detector` adapter called `startSession(session.projectDir)` with 1 argument, but `RepoDetector.startSession(projectId, rootPath)` expects 2 arguments. This caused `rootPath` to be `undefined`, producing the error `Project path not found: undefined`. Same mismatch existed in `github-repo-setup` and `codebase-analyzer` adapters.

## How

### Implementation
Fixed all 3 adapters to pass both arguments:
- `projectId` = `path.basename(session.projectDir)`
- `rootPath` = `session.projectDir`

This pattern is consistent with `createProjectIdAdapter()` used by doc writers.

### Testing Done
- [x] 35/35 AgentDispatcher tests pass (1 new)
- [x] 58/58 repo-detector tests pass
- [x] Build clean

### Breaking Changes
None