### PR TITLE
feat(prd-writer): populate template sections from collected_info

### DIFF
--- a/src/prd-writer/TemplateProcessor.ts
+++ b/src/prd-writer/TemplateProcessor.ts
@@ -128,6 +128,9 @@ export class TemplateProcessor {
     // Clean up template placeholders
     content = this.cleanupPlaceholders(content);
 
+    // Replace HTML comment placeholders with content from collected info
+    content = this.replaceHtmlCommentPlaceholders(content, collectedInfo);
+
     // Add generation footer
     content = this.addGenerationFooter(content);
 
@@ -804,6 +807,66 @@ export class TemplateProcessor {
     }
 
     return lines;
+  }
+
+  /**
+   * Replace HTML comment placeholders with content derived from collected info.
+   *
+   * Lines that consist solely of an HTML comment are either:
+   * - Replaced with relevant source text (for purpose/overview/scope comments)
+   * - Replaced with '[To be elaborated]' (for other placeholder comments)
+   *
+   * @param content - Template content after variable substitution and section generation
+   * @param info - The collected information
+   * @returns Content with HTML comment placeholders replaced
+   */
+  private replaceHtmlCommentPlaceholders(content: string, info: CollectedInfo): string {
+    // Build descriptive text from available sources
+    const sourceText = this.extractSourceText(info);
+
+    // Keywords in comment text that indicate purpose/overview/scope sections
+    const purposeKeywords = ['purpose', 'overview', 'scope', 'describe', 'background', 'context'];
+
+    return content
+      .split('\n')
+      .map((line) => {
+        const trimmed = line.trim();
+        // Only match lines that are entirely an HTML comment
+        if (!/^<!--\s*.+\s*-->$/.test(trimmed)) {
+          return line;
+        }
+
+        const commentText = trimmed.toLowerCase();
+
+        // For purpose/overview/scope placeholders, use source text if available
+        if (sourceText.length > 0 && purposeKeywords.some((kw) => commentText.includes(kw))) {
+          return sourceText;
+        }
+
+        return '[To be elaborated]';
+      })
+      .join('\n');
+  }
+
+  /**
+   * Extract descriptive text from collected info sources or project description.
+   *
+   * @param info - The collected information
+   * @returns Source text suitable for replacing purpose/overview placeholders
+   */
+  private extractSourceText(info: CollectedInfo): string {
+    // Prefer project description
+    if (info.project.description.length > 0) {
+      return info.project.description;
+    }
+
+    // Fall back to first source summary
+    const sources = info.sources ?? [];
+    if (sources.length > 0 && sources[0]?.summary !== undefined && sources[0].summary.length > 0) {
+      return sources[0].summary;
+    }
+
+    return '';
   }
 
   /**

--- a/tests/prd-writer/TemplateProcessor.test.ts
+++ b/tests/prd-writer/TemplateProcessor.test.ts
@@ -473,6 +473,105 @@ Version: \${version}
     });
   });
 
+  describe('HTML comment placeholder replacement', () => {
+    it('should replace purpose/overview comments with project description', async () => {
+      const templateContent = `# \${product_name}
+
+## 1. Purpose
+
+<!-- Describe the purpose of this product -->
+
+## 2. Scope
+
+<!-- Describe the scope of this project -->
+`;
+      await fs.promises.writeFile(testTemplatePath, templateContent);
+
+      const processor = new TemplateProcessor({ templatePath: testTemplatePath });
+      const info = createMinimalCollectedInfo({
+        project: {
+          name: 'Bookmark Manager',
+          description:
+            'A CLI tool for managing bookmarks with add, delete, list, and search commands.',
+        },
+      });
+      const metadata = createMetadata();
+
+      const result = processor.process(info, metadata);
+
+      expect(result.content).not.toContain('<!-- Describe the purpose');
+      expect(result.content).not.toContain('<!-- Describe the scope');
+      expect(result.content).toContain('A CLI tool for managing bookmarks');
+    });
+
+    it('should replace non-purpose comments with [To be elaborated]', async () => {
+      const templateContent = `# \${product_name}
+
+## Timeline
+
+<!-- Add timeline details here -->
+`;
+      await fs.promises.writeFile(testTemplatePath, templateContent);
+
+      const processor = new TemplateProcessor({ templatePath: testTemplatePath });
+      const info = createMinimalCollectedInfo();
+      const metadata = createMetadata();
+
+      const result = processor.process(info, metadata);
+
+      expect(result.content).not.toContain('<!-- Add timeline details here -->');
+      expect(result.content).toContain('[To be elaborated]');
+    });
+
+    it('should not modify inline HTML comments within other content', async () => {
+      const templateContent = `# \${product_name}
+
+Some text <!-- inline comment --> more text
+`;
+      await fs.promises.writeFile(testTemplatePath, templateContent);
+
+      const processor = new TemplateProcessor({ templatePath: testTemplatePath });
+      const info = createMinimalCollectedInfo();
+      const metadata = createMetadata();
+
+      const result = processor.process(info, metadata);
+
+      // Inline comments (not the entire line) should be preserved
+      expect(result.content).toContain('Some text <!-- inline comment --> more text');
+    });
+
+    it('should use source summary when project description is empty', async () => {
+      const templateContent = `# \${product_name}
+
+## Overview
+
+<!-- Describe the overview -->
+`;
+      await fs.promises.writeFile(testTemplatePath, templateContent);
+
+      const processor = new TemplateProcessor({ templatePath: testTemplatePath });
+      const info = createMinimalCollectedInfo({
+        project: {
+          name: 'Test',
+          description: '',
+        },
+        sources: [
+          {
+            type: 'conversation',
+            reference: 'user input',
+            summary: 'Build a task tracking CLI with TypeScript',
+          },
+        ],
+      });
+      const metadata = createMetadata();
+
+      const result = processor.process(info, metadata);
+
+      expect(result.content).toContain('Build a task tracking CLI with TypeScript');
+      expect(result.content).not.toContain('<!-- Describe the overview -->');
+    });
+  });
+
   describe('loadTemplate', () => {
     it('should cache loaded template', async () => {
       const templateContent = '# Test Template';


### PR DESCRIPTION
## What

### Summary
Replaces HTML comment placeholders in PRD templates with actual content from collected_info, making stub-mode PRD output meaningful instead of template-only.

### Change Type
- [x] Enhancement (new functionality)

### Affected Components
- `src/prd-writer/TemplateProcessor.ts` — HTML comment replacement

## Why

### Related Issues
- Closes #701 (PRD Writer should populate template sections from collected_info in stub mode)

### Problem
PRD output contained raw HTML comment placeholders (`<!-- Describe the purpose -->`) instead of actual content, even when project description and source summaries were available in collected_info.

## How

### Implementation
1. Added `replaceHtmlCommentPlaceholders(content, collectedInfo)` called after `cleanupPlaceholders()` in `process()`
2. Purpose/overview/scope comments replaced with `project.description` or `sources[0].summary`
3. Other standalone HTML comments replaced with `[To be elaborated]`
4. Inline HTML comments within content lines are preserved
5. Added `extractSourceText()` helper with priority: description → source summary → empty string

### Testing Done
- [x] 4 new tests (25/25 total pass)
- [x] Build clean

### Breaking Changes
Behavior change: HTML comment placeholders in PRD templates are now replaced with content or descriptive text instead of being preserved.