### PR TITLE
fix(srs-writer): extract product name from PRD metadata instead of document title

### DIFF
--- a/src/srs-writer/PRDParser.ts
+++ b/src/srs-writer/PRDParser.ts
@@ -145,7 +145,11 @@ export class PRDParser {
       // Strip known document title prefixes
       for (const prefix of PRDParser.DOCUMENT_TITLE_PREFIXES) {
         const stripped = rawTitle.replace(prefix, '').trim();
-        if (stripped.length > 0 && stripped !== rawTitle) {
+        if (stripped.length === 0) {
+          // Entire heading is a document title — fall through to projectId
+          return projectId.length > 0 ? projectId : 'Unknown Product';
+        }
+        if (stripped !== rawTitle) {
           return stripped;
         }
       }

--- a/src/srs-writer/PRDParser.ts
+++ b/src/srs-writer/PRDParser.ts
@@ -57,7 +57,7 @@ export class PRDParser {
    */
   public parse(content: string, projectId: string): ParsedPRD {
     const metadata = this.parseMetadata(content, projectId);
-    const productName = this.extractProductName(content);
+    const productName = this.extractProductName(content, projectId);
     const productDescription = this.extractProductDescription(content);
     const functionalRequirements = this.parseFunctionalRequirements(content);
     const nonFunctionalRequirements = this.parseNonFunctionalRequirements(content);
@@ -100,23 +100,66 @@ export class PRDParser {
   }
 
   /**
+   * Common document title prefixes to strip when extracting product name
+   */
+  private static readonly DOCUMENT_TITLE_PREFIXES = [
+    /^Product\s+Requirements?\s+Document\s*(?:\(PRD\))?\s*[-–:]*\s*/i,
+    /^PRD\s*[-–:]+\s*/i,
+    /^Software\s+Requirements?\s+Specification\s*(?:\(SRS\))?\s*[-–:]*\s*/i,
+    /^SRS\s*[-–:]+\s*/i,
+    /^Requirements?\s+Document\s*[-–:]*\s*/i,
+  ];
+
+  /**
    * Extract product name from PRD
    * @param content - Raw PRD markdown content
-   * @returns Product name extracted from title or metadata table
+   * @param projectId - Project identifier used as fallback
+   * @returns Product name extracted from metadata table, title, or projectId
    */
-  private extractProductName(content: string): string {
-    // Try from title (# PRD: Product Name)
-    const titleMatch = content.match(/^#\s*(?:PRD:?\s*)?(.+)$/m);
-    if (titleMatch !== null && titleMatch[1] !== undefined) {
-      const title = titleMatch[1].trim();
-      // Remove "PRD" prefix if present
-      return title.replace(/^PRD[:\s-]*\s*/i, '').trim();
+  private extractProductName(content: string, projectId: string): string {
+    // 1. Try from metadata table (most explicit source)
+    const productMatch = content.match(
+      /\|\s*\*?\*?(?:Product\s*(?:Name)?|Project)\*?\*?\s*\|\s*([^|]+)\s*\|/i
+    );
+    if (productMatch !== null && productMatch[1] !== undefined) {
+      const value = productMatch[1].trim();
+      if (value.length > 0) {
+        return value;
+      }
     }
 
-    // Try from metadata table
-    const productMatch = content.match(/\|\s*Product\s*(?:Name)?\s*\|\s*([^|]+)\s*\|/i);
-    if (productMatch !== null && productMatch[1] !== undefined) {
-      return productMatch[1].trim();
+    // 2. Try from "# PRD: <name>" format
+    const prdPrefixMatch = content.match(/^#\s*PRD\s*[-–:]+\s*(.+)$/m);
+    if (prdPrefixMatch !== null && prdPrefixMatch[1] !== undefined) {
+      const name = prdPrefixMatch[1].trim();
+      if (name.length > 0) {
+        return name;
+      }
+    }
+
+    // 3. Try heading with common document title prefix stripping
+    const headingMatch = content.match(/^#\s+(.+)$/m);
+    if (headingMatch !== null && headingMatch[1] !== undefined) {
+      const rawTitle = headingMatch[1].trim();
+
+      // Strip known document title prefixes
+      for (const prefix of PRDParser.DOCUMENT_TITLE_PREFIXES) {
+        const stripped = rawTitle.replace(prefix, '').trim();
+        if (stripped.length > 0 && stripped !== rawTitle) {
+          return stripped;
+        }
+      }
+
+      // If no prefix matched, the heading itself may be the product name
+      // But only if it doesn't look like a generic document title
+      if (!/^(?:Product\s+Requirements?\s+Document|PRD|SRS)\s*$/i.test(rawTitle)) {
+        return rawTitle;
+      }
+    }
+
+    // 4. Fallback to projectId
+    if (projectId.length > 0) {
+      return projectId;
     }
 
     return 'Unknown Product';

--- a/tests/srs-writer/PRDParser.test.ts
+++ b/tests/srs-writer/PRDParser.test.ts
@@ -497,4 +497,126 @@ This is not a proper list format
       expect(result.userPersonas[0].goals.length).toBe(2);
     });
   });
+
+  describe('product name extraction', () => {
+    it('should extract name from metadata table with Product Name field', () => {
+      const parser = new PRDParser();
+      const prd = `
+# Product Requirements Document (PRD)
+
+| Field | Value |
+|-------|-------|
+| **Product Name** | TaskTracker Pro |
+| Version | 1.0.0 |
+
+## Functional Requirements
+`;
+      const result = parser.parse(prd, 'task-tracker');
+      expect(result.productName).toBe('TaskTracker Pro');
+    });
+
+    it('should extract name from metadata table with Project field', () => {
+      const parser = new PRDParser();
+      const prd = `
+# Product Requirements Document (PRD)
+
+| Field | Value |
+|-------|-------|
+| **Project** | My App |
+| Version | 1.0.0 |
+
+## Functional Requirements
+`;
+      const result = parser.parse(prd, 'my-app');
+      expect(result.productName).toBe('My App');
+    });
+
+    it('should extract name from PRD: prefix format', () => {
+      const parser = new PRDParser();
+      const prd = `
+# PRD: Task Manager
+
+## Functional Requirements
+`;
+      const result = parser.parse(prd, 'task-mgr');
+      expect(result.productName).toBe('Task Manager');
+    });
+
+    it('should strip "Product Requirements Document (PRD)" from heading', () => {
+      const parser = new PRDParser();
+      const prd = `
+# Product Requirements Document (PRD) - MyProduct
+
+## Functional Requirements
+`;
+      const result = parser.parse(prd, 'my-product');
+      expect(result.productName).toBe('MyProduct');
+    });
+
+    it('should strip "Product Requirements Document" without PRD suffix', () => {
+      const parser = new PRDParser();
+      const prd = `
+# Product Requirements Document: SuperApp
+
+## Functional Requirements
+`;
+      const result = parser.parse(prd, 'super-app');
+      expect(result.productName).toBe('SuperApp');
+    });
+
+    it('should fall back to projectId when heading is generic document title', () => {
+      const parser = new PRDParser();
+      const prd = `
+# Product Requirements Document
+
+## Functional Requirements
+`;
+      const result = parser.parse(prd, 'my-project');
+      expect(result.productName).toBe('my-project');
+    });
+
+    it('should fall back to projectId when heading is just "PRD"', () => {
+      const parser = new PRDParser();
+      const prd = `
+# PRD
+
+## Functional Requirements
+`;
+      const result = parser.parse(prd, 'fallback-name');
+      expect(result.productName).toBe('fallback-name');
+    });
+
+    it('should prefer metadata table over heading', () => {
+      const parser = new PRDParser();
+      const prd = `
+# PRD: Wrong Name
+
+| Field | Value |
+|-------|-------|
+| **Product Name** | Correct Name |
+
+## Functional Requirements
+`;
+      const result = parser.parse(prd, 'proj');
+      expect(result.productName).toBe('Correct Name');
+    });
+
+    it('should use plain heading as product name when no prefix matches', () => {
+      const parser = new PRDParser();
+      const result = parser.parse('# My Product', 'proj');
+      expect(result.productName).toBe('My Product');
+    });
+
+    it('should return projectId when content has no heading or metadata', () => {
+      const parser = new PRDParser();
+      const result = parser.parse('No heading here, just text.', 'some-project');
+      expect(result.productName).toBe('some-project');
+    });
+
+    it('should return Unknown Product when no heading, metadata, or projectId', () => {
+      const parser = new PRDParser();
+      const result = parser.parse('No heading here.', '');
+      expect(result.productName).toBe('Unknown Product');
+    });
+  });
 });

--- a/tests/srs-writer/PRDParser.test.ts
+++ b/tests/srs-writer/PRDParser.test.ts
@@ -575,6 +575,17 @@ This is not a proper list format
       expect(result.productName).toBe('my-project');
     });
 
+    it('should fall back to projectId when heading is "Product Requirements Document (PRD)"', () => {
+      const parser = new PRDParser();
+      const prd = `
+# Product Requirements Document (PRD)
+
+## Functional Requirements
+`;
+      const result = parser.parse(prd, 'my-project');
+      expect(result.productName).toBe('my-project');
+    });
+
     it('should fall back to projectId when heading is just "PRD"', () => {
       const parser = new PRDParser();
       const prd = `


### PR DESCRIPTION
## What

### Summary
Rewrites `PRDParser.extractProductName()` to use priority-based extraction instead of blindly using the first heading, which was the document title.

### Change Type
- [x] Bugfix (fixes an issue)

### Affected Components
- `src/srs-writer/PRDParser.ts` — product name extraction logic

## Why

### Related Issues
- Closes #699 (SRS parser extracts PRD document title as product name)

### Problem
`extractProductName()` extracted the first `# heading` as product name. When PRD started with `# Product Requirements Document (PRD)`, the SRS showed `Product Name: Product Requirements Document (PRD)` instead of the actual project name.

## How

### Implementation
Rewritten `extractProductName(content, projectId)` with priority order:
1. Metadata table (`| **Product Name** |` or `| **Project** |`)
2. `# PRD: <name>` format (strip prefix)
3. Heading with document title prefix stripping (handles full titles with `(PRD)`/`(SRS)` suffixes)
4. `projectId` fallback
5. "Unknown Product" last resort

Key fix: When prefix strip produces empty string (entire heading is a document title), returns `projectId` directly.

### Testing Done
- [x] 12 new tests (40/40 total pass)
- [x] Build clean

### Breaking Changes
None — output improves from incorrect document title to correct product name.