### PR TITLE
feat(sds-writer): generate scaffold SDS when SRS has empty features

### DIFF
--- a/src/sds-writer/SDSWriterAgent.ts
+++ b/src/sds-writer/SDSWriterAgent.ts
@@ -177,10 +177,16 @@ export class SDSWriterAgent implements IAgent {
     const srsContent = fs.readFileSync(srsPath, 'utf-8');
     const parsedSRS = this.srsParser.parse(srsContent);
 
-    // Validate SRS
+    // Validate SRS — only critical errors block session creation
     const validationErrors = this.srsParser.validate(parsedSRS);
     if (validationErrors.length > 0) {
       throw new ValidationError(validationErrors);
+    }
+
+    // Collect non-fatal warnings
+    const warnings: string[] = [];
+    if (parsedSRS.features.length === 0) {
+      warnings.push('No features found in SRS');
     }
 
     // Create session
@@ -191,6 +197,7 @@ export class SDSWriterAgent implements IAgent {
       parsedSRS,
       startedAt: new Date().toISOString(),
       updatedAt: new Date().toISOString(),
+      ...(warnings.length > 0 && { warnings }),
     };
 
     return this.session;
@@ -218,6 +225,11 @@ export class SDSWriterAgent implements IAgent {
       this.updateSession({ status: 'parsing' });
 
       const { parsedSRS } = this.session;
+
+      // When SRS has no features, generate a minimal scaffold SDS
+      if (parsedSRS.features.length === 0) {
+        return await this.generateScaffoldSDS(projectId, parsedSRS, startTime);
+      }
 
       // Design components
       this.updateSession({ status: 'designing' });
@@ -313,6 +325,7 @@ export class SDSWriterAgent implements IAgent {
         publicPath,
         generatedSDS,
         stats,
+        ...(this.session.warnings && { warnings: this.session.warnings }),
       };
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : 'Unknown error';
@@ -322,6 +335,103 @@ export class SDSWriterAgent implements IAgent {
       });
       throw error;
     }
+  }
+
+  /**
+   * Generate a minimal scaffold SDS when SRS has no features.
+   * Returns a valid result with placeholder sections instead of throwing.
+   * @param projectId - Project identifier
+   * @param parsedSRS - Parsed SRS document with no features
+   * @param startTime - Timestamp when generation started (for timing stats)
+   * @returns Generation result with scaffold content and warnings
+   */
+  private async generateScaffoldSDS(
+    projectId: string,
+    parsedSRS: ParsedSRS,
+    startTime: number
+  ): Promise<SDSGenerationResult> {
+    this.updateSession({ status: 'generating' });
+
+    const now = new Date().toISOString().split('T')[0] ?? '';
+    const metadata: SDSMetadata = {
+      documentId: `SDS-${projectId}`,
+      sourceSRS: parsedSRS.metadata.documentId,
+      sourcePRD: parsedSRS.metadata.sourcePRD,
+      version: '0.1.0',
+      status: 'Draft',
+      createdDate: now,
+      updatedDate: now,
+    };
+
+    const scaffoldContent = [
+      `# Software Design Specification: ${parsedSRS.productName}`,
+      '',
+      '| **Document ID** | **Source SRS** | **Version** | **Status** |',
+      '|-----------------|----------------|-------------|------------|',
+      `| ${metadata.documentId} | ${metadata.sourceSRS} | ${metadata.version} | ${metadata.status} |`,
+      '',
+      '> **Note:** This is a scaffold SDS generated from an SRS with no features.',
+      '> Populate the SRS with features and regenerate for a complete design.',
+      '',
+      '## 1. Architecture Overview',
+      '',
+      'Architecture to be determined once features are defined.',
+      '',
+      '## 2. Components',
+      '',
+      '*No components — SRS contains no features to design from.*',
+      '',
+      '## 3. Data Model',
+      '',
+      '*Data model to be determined once features are defined.*',
+      '',
+    ].join('\n');
+
+    const emptyMatrix: TraceabilityMatrix = {
+      entries: [],
+      forwardCoverage: 0,
+      orphanComponents: [],
+      uncoveredFeatures: [],
+    };
+
+    const generatedSDS: GeneratedSDS = {
+      metadata,
+      content: scaffoldContent,
+      components: [],
+      technologyStack: [...this.config.defaultTechnologyStack],
+      apis: [],
+      dataModels: [],
+      traceabilityMatrix: emptyMatrix,
+    };
+
+    this.updateSession({
+      status: 'completed',
+      generatedSDS,
+    });
+
+    const { scratchpadPath, publicPath } = await this.writeOutputFiles(projectId, generatedSDS);
+
+    const warnings = [...(this.session?.warnings ?? [])];
+
+    const stats: SDSGenerationStats = {
+      srsFeatureCount: 0,
+      componentsGenerated: 0,
+      interfacesGenerated: 0,
+      apisGenerated: 0,
+      dataModelsGenerated: 0,
+      traceabilityCoverage: 0,
+      processingTimeMs: Date.now() - startTime,
+    };
+
+    return {
+      success: true,
+      projectId,
+      scratchpadPath,
+      publicPath,
+      generatedSDS,
+      stats,
+      warnings,
+    };
   }
 
   /**

--- a/src/sds-writer/SRSParser.ts
+++ b/src/sds-writer/SRSParser.ts
@@ -869,10 +869,8 @@ export class SRSParser {
       errors.push('Missing document ID in metadata');
     }
 
-    // Check features
-    if (srs.features.length === 0) {
-      errors.push('No features found in SRS');
-    }
+    // Empty features is a quality warning, not a critical error.
+    // The SDS writer will generate a scaffold when features are absent.
 
     // Check for duplicate feature IDs
     const featureIds = new Set<string>();

--- a/src/sds-writer/types.ts
+++ b/src/sds-writer/types.ts
@@ -673,6 +673,8 @@ export interface SDSGenerationSession {
   readonly updatedAt: string;
   /** Error message if failed */
   readonly errorMessage?: string;
+  /** Non-fatal warnings accumulated during generation */
+  readonly warnings?: readonly string[];
 }
 
 /**
@@ -715,6 +717,8 @@ export interface SDSGenerationResult {
   readonly generatedSDS: GeneratedSDS;
   /** Generation statistics */
   readonly stats: SDSGenerationStats;
+  /** Non-fatal warnings from generation (e.g., empty features, degraded quality) */
+  readonly warnings?: readonly string[];
 }
 
 /**

--- a/tests/sds-writer/SDSWriterAgent.test.ts
+++ b/tests/sds-writer/SDSWriterAgent.test.ts
@@ -534,4 +534,72 @@ Must use TypeScript.
       expect(result.stats.traceabilityCoverage).toBe(100);
     });
   });
+
+  describe('graceful degradation', () => {
+    it('should generate scaffold SDS when SRS has no features', async () => {
+      const emptySRS = `
+# Software Requirements Specification: Empty Project
+
+| **Document ID** | SRS-EMPTY |
+| **Source PRD** | PRD-001 |
+| **Version** | 1.0.0 |
+| **Status** | Draft |
+| **Project ID** | empty-project |
+
+---
+
+## 1. Introduction
+
+**Empty Project** has no features yet.
+`;
+      await setupSRSFile('empty-project', emptySRS);
+
+      const agent = new SDSWriterAgent({
+        scratchpadBasePath: testBasePath,
+        publicDocsPath: testDocsPath,
+      });
+
+      const result = await agent.generateFromProject('empty-project');
+
+      // Should succeed instead of throwing
+      expect(result.success).toBe(true);
+      expect(result.projectId).toBe('empty-project');
+
+      // Should include warnings about empty features
+      expect(result.warnings).toBeDefined();
+      expect(result.warnings?.some((w) => w.includes('No features'))).toBe(true);
+
+      // Should have scaffold content
+      expect(result.generatedSDS.content).toContain('scaffold');
+      expect(result.generatedSDS.components).toHaveLength(0);
+      expect(result.generatedSDS.apis).toHaveLength(0);
+      expect(result.generatedSDS.dataModels).toHaveLength(0);
+
+      // Stats should reflect empty generation
+      expect(result.stats.srsFeatureCount).toBe(0);
+      expect(result.stats.componentsGenerated).toBe(0);
+    });
+
+    it('should write scaffold SDS output files', async () => {
+      const emptySRS = `
+# Software Requirements Specification: Empty Project
+
+| **Document ID** | SRS-EMPTY |
+| **Project ID** | empty-project |
+
+---
+`;
+      await setupSRSFile('empty-project', emptySRS);
+
+      const agent = new SDSWriterAgent({
+        scratchpadBasePath: testBasePath,
+        publicDocsPath: testDocsPath,
+      });
+
+      const result = await agent.generateFromProject('empty-project');
+
+      expect(fs.existsSync(result.scratchpadPath)).toBe(true);
+      expect(fs.existsSync(result.publicPath)).toBe(true);
+    });
+  });
 });

--- a/tests/sds-writer/SRSParser.test.ts
+++ b/tests/sds-writer/SRSParser.test.ts
@@ -251,14 +251,15 @@ Must use TypeScript and Node.js.
       expect(errors.some((e) => e.includes('document ID'))).toBe(true);
     });
 
-    it('should detect no features', () => {
+    it('should not treat empty features as a validation error', () => {
       const parser = new SRSParser();
       const srs = parser.parse(`
 | **Document ID** | SRS-001 |
       `);
       const errors = parser.validate(srs);
 
-      expect(errors.some((e) => e.includes('No features'))).toBe(true);
+      // Empty features is a warning handled by SDSWriterAgent, not a validation error
+      expect(errors.some((e) => e.includes('No features'))).toBe(false);
     });
 
     it('should throw in strict mode for invalid SRS', () => {


### PR DESCRIPTION
## What

### Summary
SDS writer now generates a minimal scaffold document when SRS has empty features, instead of throwing a validation error that blocks the entire downstream pipeline.

### Change Type
- [x] Enhancement (new functionality)

### Affected Components
- `src/sds-writer/SDSWriterAgent.ts` — scaffold generation path
- `src/sds-writer/SRSParser.ts` — validation logic
- `src/sds-writer/types.ts` — warnings field

## Why

### Related Issues
- Closes #707 (SDS writer should degrade gracefully on empty SRS features)

### Problem
`SRSParser.validate()` threw `SDSValidationError` on `srs.features.length === 0`, blocking 5 downstream stages (issue_generation through review). In stub mode, empty SRS features are a quality issue, not a fatal error.

## How

### Implementation
1. Removed empty features from `SRSParser.validate()` errors (only critical: missing doc ID, duplicates)
2. Added `generateScaffoldSDS()` in SDSWriterAgent — produces minimal SDS with architecture overview placeholder, empty component/data sections, 0% traceability
3. `generateFromProject()` early-returns to scaffold path when features empty
4. Session warnings propagated through result
5. Added `warnings?: readonly string[]` to SDSGenerationResult and SDSGenerationSession

### Testing Done
- [x] 2 new tests + 1 updated assertion (167/167 total pass)
- [x] Build clean

### Breaking Changes
Behavior change: empty SRS features no longer throws — produces scaffold SDS with warnings instead.