### PR TITLE
fix(bridges): detect CLAUDECODE and CLAUDE_CODE_ENTRYPOINT env vars

### DIFF
--- a/src/agents/BridgeRegistry.ts
+++ b/src/agents/BridgeRegistry.ts
@@ -145,11 +145,18 @@ export function createDefaultBridgeRegistry(): BridgeRegistry {
 
 /**
  * Detect if running inside a Claude Code session.
+ *
+ * Checks four environment variables that Claude Code may set:
+ * - CLAUDE_CODE_SESSION: legacy session marker
+ * - CLAUDE_CODE: legacy presence flag
+ * - CLAUDECODE: runtime flag (set to "1")
+ * - CLAUDE_CODE_ENTRYPOINT: entry point identifier (e.g. "cli")
  */
-function isClaudeCodeSession(): boolean {
+export function isClaudeCodeSession(): boolean {
   return (
-    (process.env['CLAUDE_CODE_SESSION'] !== undefined &&
-      process.env['CLAUDE_CODE_SESSION'] !== '') ||
-    (process.env['CLAUDE_CODE'] !== undefined && process.env['CLAUDE_CODE'] !== '')
+    (process.env['CLAUDE_CODE_SESSION'] ?? '') !== '' ||
+    (process.env['CLAUDE_CODE'] ?? '') !== '' ||
+    process.env['CLAUDECODE'] === '1' ||
+    (process.env['CLAUDE_CODE_ENTRYPOINT'] ?? '') !== ''
   );
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -43,7 +43,7 @@ import {
   ENHANCEMENT_STAGES,
   IMPORT_STAGES,
 } from './ad-sdlc-orchestrator/index.js';
-import { createDefaultBridgeRegistry } from './agents/BridgeRegistry.js';
+import { createDefaultBridgeRegistry, isClaudeCodeSession } from './agents/BridgeRegistry.js';
 import { StatusService } from './status/index.js';
 import type { OutputFormat } from './status/types.js';
 import { initializeProject, isProjectInitialized } from './utils/index.js';
@@ -937,11 +937,7 @@ program
     const registry = createDefaultBridgeRegistry();
     const hasRealBridge = registry.hasRealBridge();
     if (hasRealBridge) {
-      const isClaudeCode =
-        (process.env['CLAUDE_CODE_SESSION'] !== undefined &&
-          process.env['CLAUDE_CODE_SESSION'] !== '') ||
-        (process.env['CLAUDE_CODE'] !== undefined && process.env['CLAUDE_CODE'] !== '');
-      const bridgeLabel = isClaudeCode ? 'Claude Code session' : 'ANTHROPIC_API_KEY';
+      const bridgeLabel = isClaudeCodeSession() ? 'Claude Code session' : 'ANTHROPIC_API_KEY';
       checks.push({ label: 'AI Bridge', ok: true, detail: `${bridgeLabel} detected` });
     } else {
       checks.push({
@@ -1115,12 +1111,8 @@ program
 
       // Show bridge info
       const dryRunRegistry = createDefaultBridgeRegistry();
-      const isClaudeCodeDryRun =
-        (process.env['CLAUDE_CODE_SESSION'] !== undefined &&
-          process.env['CLAUDE_CODE_SESSION'] !== '') ||
-        (process.env['CLAUDE_CODE'] !== undefined && process.env['CLAUDE_CODE'] !== '');
       const bridgeType = dryRunRegistry.hasRealBridge()
-        ? isClaudeCodeDryRun
+        ? isClaudeCodeSession()
           ? 'ClaudeCodeBridge'
           : 'AnthropicApiBridge'
         : 'StubBridge (no real bridge)';

--- a/tests/agents/BridgeRegistry.test.ts
+++ b/tests/agents/BridgeRegistry.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { BridgeRegistry } from '../../src/agents/BridgeRegistry.js';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { BridgeRegistry, isClaudeCodeSession } from '../../src/agents/BridgeRegistry.js';
 import { StubBridge } from '../../src/agents/bridges/StubBridge.js';
 import type { AgentBridge, AgentRequest, AgentResponse } from '../../src/agents/AgentBridge.js';
 
@@ -232,5 +232,82 @@ describe('StubBridge', () => {
   it('should dispose without error', async () => {
     const stub = new StubBridge();
     await expect(stub.dispose()).resolves.toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isClaudeCodeSession tests
+// ---------------------------------------------------------------------------
+
+describe('isClaudeCodeSession', () => {
+  const ENV_KEYS = [
+    'CLAUDE_CODE_SESSION',
+    'CLAUDE_CODE',
+    'CLAUDECODE',
+    'CLAUDE_CODE_ENTRYPOINT',
+  ] as const;
+
+  let savedEnv: Record<string, string | undefined>;
+
+  beforeEach(() => {
+    savedEnv = {};
+    for (const key of ENV_KEYS) {
+      savedEnv[key] = process.env[key];
+      delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    for (const key of ENV_KEYS) {
+      if (savedEnv[key] === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = savedEnv[key];
+      }
+    }
+  });
+
+  it('should return false when no env vars are set', () => {
+    expect(isClaudeCodeSession()).toBe(false);
+  });
+
+  it('should detect CLAUDE_CODE_SESSION', () => {
+    process.env['CLAUDE_CODE_SESSION'] = '1';
+    expect(isClaudeCodeSession()).toBe(true);
+  });
+
+  it('should detect CLAUDE_CODE', () => {
+    process.env['CLAUDE_CODE'] = '1';
+    expect(isClaudeCodeSession()).toBe(true);
+  });
+
+  it('should detect CLAUDECODE=1', () => {
+    process.env['CLAUDECODE'] = '1';
+    expect(isClaudeCodeSession()).toBe(true);
+  });
+
+  it('should not detect CLAUDECODE when not "1"', () => {
+    process.env['CLAUDECODE'] = 'yes';
+    expect(isClaudeCodeSession()).toBe(false);
+  });
+
+  it('should detect CLAUDE_CODE_ENTRYPOINT', () => {
+    process.env['CLAUDE_CODE_ENTRYPOINT'] = 'cli';
+    expect(isClaudeCodeSession()).toBe(true);
+  });
+
+  it('should ignore empty string values for CLAUDE_CODE_SESSION', () => {
+    process.env['CLAUDE_CODE_SESSION'] = '';
+    expect(isClaudeCodeSession()).toBe(false);
+  });
+
+  it('should ignore empty string values for CLAUDE_CODE', () => {
+    process.env['CLAUDE_CODE'] = '';
+    expect(isClaudeCodeSession()).toBe(false);
+  });
+
+  it('should ignore empty string values for CLAUDE_CODE_ENTRYPOINT', () => {
+    process.env['CLAUDE_CODE_ENTRYPOINT'] = '';
+    expect(isClaudeCodeSession()).toBe(false);
   });
 });


### PR DESCRIPTION
## What

### Summary
Fixes Claude Code session detection to recognize `CLAUDECODE=1` and `CLAUDE_CODE_ENTRYPOINT` environment variables set by the Claude Code runtime. Consolidates duplicate inline detection in cli.ts.

### Change Type
- [x] Bugfix (fixes an issue)

### Affected Components
- `src/agents/BridgeRegistry.ts` — `isClaudeCodeSession()` updated and exported
- `src/cli.ts` — duplicate checks replaced with shared function

## Why

### Related Issues
- Closes #712 (Claude Code session detection misses CLAUDECODE environment variable)

### Root Cause
Claude Code runtime sets `CLAUDECODE=1` (no underscore) and `CLAUDE_CODE_ENTRYPOINT=cli`, but detection only checked `CLAUDE_CODE_SESSION` and `CLAUDE_CODE`. This caused bridge auto-detection to fail inside active Claude Code sessions.

## How

### Implementation
1. Added `CLAUDECODE === '1'` and `CLAUDE_CODE_ENTRYPOINT` checks to `isClaudeCodeSession()`
2. Exported function for reuse, replaced 2 inline duplicate checks in cli.ts
3. 9 new tests covering all 4 env var variants and edge cases

### Testing Done
- [x] 9 new tests (31/31 total pass)
- [x] Build clean

### Breaking Changes
None