### PR TITLE
feat(bridges): add ClaudeCliSubprocessBridge for subscription execution

### DIFF
--- a/src/agents/BridgeRegistry.ts
+++ b/src/agents/BridgeRegistry.ts
@@ -8,10 +8,12 @@
  * @packageDocumentation
  */
 
+import { execFileSync } from 'node:child_process';
 import type { AgentBridge } from './AgentBridge.js';
 import { StubBridge } from './bridges/StubBridge.js';
 import { AnthropicApiBridge } from './bridges/AnthropicApiBridge.js';
 import { ClaudeCodeBridge } from './bridges/ClaudeCodeBridge.js';
+import { ClaudeCliSubprocessBridge } from './bridges/ClaudeCliSubprocessBridge.js';
 
 /**
  * Registry that selects the appropriate AgentBridge for a given agent type.
@@ -122,15 +124,16 @@ export class BridgeRegistry {
 /**
  * Create a BridgeRegistry with auto-detected bridges based on environment.
  *
- * Detection logic:
- * 1. If inside a Claude Code session → register ClaudeCodeBridge
+ * Detection logic (registration order = priority):
+ * 1. If inside a Claude Code session → register ClaudeCodeBridge (file-based IPC)
  * 2. If ANTHROPIC_API_KEY is set → register AnthropicApiBridge
- * 3. StubBridge is always the final fallback (built into BridgeRegistry)
+ * 3. If inside Claude Code session and `claude` CLI is available → register ClaudeCliSubprocessBridge
+ * 4. StubBridge is always the final fallback (built into BridgeRegistry)
  */
 export function createDefaultBridgeRegistry(): BridgeRegistry {
   const registry = new BridgeRegistry();
 
-  // Claude Code session detection
+  // Claude Code session detection (file-based IPC)
   if (isClaudeCodeSession()) {
     registry.register(new ClaudeCodeBridge());
   }
@@ -140,7 +143,28 @@ export function createDefaultBridgeRegistry(): BridgeRegistry {
     registry.register(new AnthropicApiBridge());
   }
 
+  // Claude CLI subprocess (subscription users inside Claude Code)
+  if (isClaudeCodeSession() && isClaudeCliAvailable()) {
+    registry.register(new ClaudeCliSubprocessBridge());
+  }
+
   return registry;
+}
+
+/**
+ * Check if the `claude` CLI is available on the system PATH.
+ */
+function isClaudeCliAvailable(): boolean {
+  try {
+    execFileSync('claude', ['--version'], {
+      timeout: 5000,
+      encoding: 'utf-8',
+      stdio: 'pipe',
+    });
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 /**

--- a/src/agents/bridges/ClaudeCliSubprocessBridge.ts
+++ b/src/agents/bridges/ClaudeCliSubprocessBridge.ts
@@ -1,0 +1,156 @@
+/**
+ * ClaudeCliSubprocessBridge - Executes agents via the `claude` CLI in subprocess mode
+ *
+ * Used when running inside a Claude Code session where the `claude` CLI is available.
+ * Invokes `claude -p --output-format json` as a subprocess, passing the agent prompt
+ * via stdin-safe arguments. Suitable for subscription-based execution without an API key.
+ *
+ * @packageDocumentation
+ */
+
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import type { AgentBridge, AgentRequest, AgentResponse } from '../AgentBridge.js';
+import { getLogger } from '../../logging/index.js';
+
+const DEFAULT_TIMEOUT_MS = 300_000; // 5 minutes
+const MAX_BUFFER_BYTES = 10 * 1024 * 1024; // 10 MB
+
+/**
+ * Bridge that delegates agent execution to the `claude` CLI in non-interactive mode.
+ *
+ * The execution model:
+ * 1. Build a context-rich prompt from the AgentRequest
+ * 2. Invoke `claude -p --output-format json --dangerously-skip-permissions`
+ * 3. Parse the JSON output into an AgentResponse
+ */
+export class ClaudeCliSubprocessBridge implements AgentBridge {
+  private claudePath: string;
+  private timeoutMs: number;
+
+  constructor(options?: { claudePath?: string; timeoutMs?: number }) {
+    this.claudePath = options?.claudePath ?? 'claude';
+    this.timeoutMs = options?.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  }
+
+  /**
+   *
+   * @param _agentType
+   */
+  supports(_agentType: string): boolean {
+    return true;
+  }
+
+  /**
+   *
+   * @param request
+   */
+  execute(request: AgentRequest): Promise<AgentResponse> {
+    const logger = getLogger();
+    const prompt = this.buildPrompt(request);
+    const args = this.buildArgs(request);
+
+    logger.debug('Invoking claude CLI subprocess', {
+      agent: request.agentType,
+      claudePath: this.claudePath,
+      argCount: args.length,
+    });
+
+    try {
+      const result = execFileSync(this.claudePath, [...args, prompt], {
+        timeout: this.timeoutMs,
+        encoding: 'utf-8',
+        maxBuffer: MAX_BUFFER_BYTES,
+        cwd: request.projectDir,
+      });
+      return Promise.resolve(this.parseResponse(result));
+    } catch (error) {
+      const err = error instanceof Error ? error : new Error(String(error));
+      logger.error('Claude CLI subprocess failed', err, {
+        agent: request.agentType,
+      });
+      return Promise.resolve({ output: '', artifacts: [], success: false, error: err.message });
+    }
+  }
+
+  /**
+   *
+   */
+  dispose(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  /**
+   * Build CLI arguments for non-interactive JSON execution.
+   * @param request
+   */
+  buildArgs(request: AgentRequest): string[] {
+    const args = ['-p', '--output-format', 'json', '--dangerously-skip-permissions'];
+
+    // Use agent definition as system prompt if available
+    const agentFile = path.join(request.projectDir, '.claude', 'agents', `${request.agentType}.md`);
+    if (fs.existsSync(agentFile)) {
+      args.push('--system-prompt-file', agentFile);
+    }
+
+    return args;
+  }
+
+  /**
+   * Build a context-rich prompt from the agent request.
+   * @param request
+   */
+  buildPrompt(request: AgentRequest): string {
+    const parts = [`You are the ${request.agentType} agent.`];
+    parts.push(`Project directory: ${request.projectDir}`);
+    parts.push(`Scratchpad directory: ${request.scratchpadDir}`);
+    parts.push(`\nTask input:\n${request.input}`);
+
+    const priorOutputs = request.priorStageOutputs;
+    if (Object.keys(priorOutputs).length > 0) {
+      parts.push(`\nPrior stage outputs:\n${JSON.stringify(priorOutputs, null, 2)}`);
+    }
+
+    parts.push(
+      '\nProvide your output as a JSON object with "output" (string) and "success" (boolean) fields.'
+    );
+    return parts.join('\n');
+  }
+
+  /**
+   * Parse the raw CLI output into an AgentResponse.
+   *
+   * Claude `--output-format json` wraps output as `{ "type": "result", "result": "..." }`.
+   * The inner `result` string may itself be JSON containing output/success fields.
+   * @param raw
+   */
+  parseResponse(raw: string): AgentResponse {
+    try {
+      const parsed = JSON.parse(raw) as Record<string, unknown>;
+      const resultVal = parsed['result'];
+      const outputVal = parsed['output'];
+      const content =
+        typeof resultVal === 'string' ? resultVal : typeof outputVal === 'string' ? outputVal : raw;
+
+      // Try to parse inner JSON if the content itself is structured
+      try {
+        const inner = JSON.parse(content) as Record<string, unknown>;
+        const innerOutput = typeof inner['output'] === 'string' ? inner['output'] : content;
+        const innerArtifacts = Array.isArray(inner['artifacts'])
+          ? (inner['artifacts'] as AgentResponse['artifacts'])
+          : [];
+        return {
+          output: innerOutput,
+          artifacts: innerArtifacts,
+          success: typeof inner['success'] === 'boolean' ? inner['success'] : true,
+        };
+      } catch {
+        return { output: content, artifacts: [], success: true };
+      }
+    } catch {
+      // Not JSON at all — treat raw output as plain text
+      return { output: raw, artifacts: [], success: true };
+    }
+  }
+}

--- a/src/agents/bridges/index.ts
+++ b/src/agents/bridges/index.ts
@@ -7,3 +7,4 @@
 export { StubBridge } from './StubBridge.js';
 export { AnthropicApiBridge } from './AnthropicApiBridge.js';
 export { ClaudeCodeBridge } from './ClaudeCodeBridge.js';
+export { ClaudeCliSubprocessBridge } from './ClaudeCliSubprocessBridge.js';

--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -67,6 +67,7 @@ export { BridgeRegistry, createDefaultBridgeRegistry } from './BridgeRegistry.js
 export { StubBridge } from './bridges/StubBridge.js';
 export { AnthropicApiBridge } from './bridges/AnthropicApiBridge.js';
 export { ClaudeCodeBridge } from './bridges/ClaudeCodeBridge.js';
+export { ClaudeCliSubprocessBridge } from './bridges/ClaudeCliSubprocessBridge.js';
 
 export type { AgentBridge, AgentRequest, AgentResponse } from './AgentBridge.js';
 

--- a/tests/agents/bridges/ClaudeCliSubprocessBridge.test.ts
+++ b/tests/agents/bridges/ClaudeCliSubprocessBridge.test.ts
@@ -1,3 +1,4 @@
+import path from 'node:path';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import type { AgentRequest } from '../../../src/agents/AgentBridge.js';
 
@@ -78,7 +79,7 @@ describe('ClaudeCliSubprocessBridge', () => {
       const args = bridge.buildArgs(request);
 
       expect(args).toContain('--system-prompt-file');
-      expect(args).toContain('/test/project/.claude/agents/prd-writer.md');
+      expect(args).toContain(path.join('/test/project', '.claude', 'agents', 'prd-writer.md'));
     });
 
     it('should not include system-prompt-file when agent definition is missing', () => {

--- a/tests/agents/bridges/ClaudeCliSubprocessBridge.test.ts
+++ b/tests/agents/bridges/ClaudeCliSubprocessBridge.test.ts
@@ -1,0 +1,306 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import type { AgentRequest } from '../../../src/agents/AgentBridge.js';
+
+// Mock child_process before importing the bridge
+vi.mock('node:child_process', () => ({
+  execFileSync: vi.fn(() => '{}'),
+}));
+
+// Mock node:fs for existsSync used in buildArgs
+vi.mock('node:fs', () => ({
+  default: { existsSync: vi.fn(() => false) },
+  existsSync: vi.fn(() => false),
+}));
+
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import { ClaudeCliSubprocessBridge } from '../../../src/agents/bridges/ClaudeCliSubprocessBridge.js';
+
+const mockExecFileSync = vi.mocked(execFileSync);
+const mockExistsSync = vi.mocked(fs.existsSync);
+
+// ---------------------------------------------------------------------------
+// Test Helpers
+// ---------------------------------------------------------------------------
+
+function createRequest(overrides: Partial<AgentRequest> = {}): AgentRequest {
+  return {
+    agentType: 'collector',
+    input: 'Build a todo app',
+    scratchpadDir: '/test/.ad-sdlc/scratchpad',
+    projectDir: '/test/project',
+    priorStageOutputs: {},
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('ClaudeCliSubprocessBridge', () => {
+  let bridge: ClaudeCliSubprocessBridge;
+
+  beforeEach(() => {
+    bridge = new ClaudeCliSubprocessBridge({ claudePath: '/usr/local/bin/claude' });
+    vi.clearAllMocks();
+  });
+
+  afterEach(async () => {
+    await bridge.dispose();
+    vi.restoreAllMocks();
+  });
+
+  describe('supports', () => {
+    it('should support all agent types', () => {
+      expect(bridge.supports('collector')).toBe(true);
+      expect(bridge.supports('worker')).toBe(true);
+      expect(bridge.supports('prd-writer')).toBe(true);
+      expect(bridge.supports('unknown-type')).toBe(true);
+    });
+  });
+
+  describe('buildArgs', () => {
+    it('should include required CLI flags', () => {
+      const request = createRequest();
+      const args = bridge.buildArgs(request);
+
+      expect(args).toContain('-p');
+      expect(args).toContain('--output-format');
+      expect(args).toContain('json');
+      expect(args).toContain('--dangerously-skip-permissions');
+    });
+
+    it('should include system-prompt-file when agent definition exists', () => {
+      mockExistsSync.mockReturnValueOnce(true);
+
+      const request = createRequest({ agentType: 'prd-writer' });
+      const args = bridge.buildArgs(request);
+
+      expect(args).toContain('--system-prompt-file');
+      expect(args).toContain('/test/project/.claude/agents/prd-writer.md');
+    });
+
+    it('should not include system-prompt-file when agent definition is missing', () => {
+      mockExistsSync.mockReturnValueOnce(false);
+
+      const request = createRequest();
+      const args = bridge.buildArgs(request);
+
+      expect(args).not.toContain('--system-prompt-file');
+    });
+  });
+
+  describe('buildPrompt', () => {
+    it('should include agent type and project context', () => {
+      const request = createRequest();
+      const prompt = bridge.buildPrompt(request);
+
+      expect(prompt).toContain('You are the collector agent.');
+      expect(prompt).toContain('Project directory: /test/project');
+      expect(prompt).toContain('Scratchpad directory: /test/.ad-sdlc/scratchpad');
+      expect(prompt).toContain('Build a todo app');
+    });
+
+    it('should include prior stage outputs when present', () => {
+      const request = createRequest({
+        priorStageOutputs: { 'prd-writer': 'PRD content here' },
+      });
+      const prompt = bridge.buildPrompt(request);
+
+      expect(prompt).toContain('Prior stage outputs:');
+      expect(prompt).toContain('PRD content here');
+    });
+
+    it('should not include prior stage outputs section when empty', () => {
+      const request = createRequest({ priorStageOutputs: {} });
+      const prompt = bridge.buildPrompt(request);
+
+      expect(prompt).not.toContain('Prior stage outputs:');
+    });
+
+    it('should request JSON output format in the prompt', () => {
+      const request = createRequest();
+      const prompt = bridge.buildPrompt(request);
+
+      expect(prompt).toContain('"output"');
+      expect(prompt).toContain('"success"');
+    });
+  });
+
+  describe('parseResponse', () => {
+    it('should parse Claude CLI JSON wrapper with nested JSON result', () => {
+      const raw = JSON.stringify({
+        type: 'result',
+        result: JSON.stringify({ output: 'Agent completed', success: true }),
+      });
+
+      const response = bridge.parseResponse(raw);
+
+      expect(response.output).toBe('Agent completed');
+      expect(response.success).toBe(true);
+      expect(response.artifacts).toEqual([]);
+    });
+
+    it('should parse Claude CLI JSON wrapper with plain text result', () => {
+      const raw = JSON.stringify({
+        type: 'result',
+        result: 'Plain text agent output',
+      });
+
+      const response = bridge.parseResponse(raw);
+
+      expect(response.output).toBe('Plain text agent output');
+      expect(response.success).toBe(true);
+    });
+
+    it('should handle nested JSON with artifacts', () => {
+      const raw = JSON.stringify({
+        type: 'result',
+        result: JSON.stringify({
+          output: 'Done',
+          success: true,
+          artifacts: [{ path: '/test/file.ts', action: 'created' }],
+        }),
+      });
+
+      const response = bridge.parseResponse(raw);
+
+      expect(response.output).toBe('Done');
+      expect(response.artifacts).toEqual([{ path: '/test/file.ts', action: 'created' }]);
+    });
+
+    it('should handle nested JSON with success=false', () => {
+      const raw = JSON.stringify({
+        type: 'result',
+        result: JSON.stringify({ output: 'Failed', success: false }),
+      });
+
+      const response = bridge.parseResponse(raw);
+
+      expect(response.output).toBe('Failed');
+      expect(response.success).toBe(false);
+    });
+
+    it('should handle raw non-JSON output', () => {
+      const raw = 'This is not JSON at all';
+
+      const response = bridge.parseResponse(raw);
+
+      expect(response.output).toBe('This is not JSON at all');
+      expect(response.success).toBe(true);
+      expect(response.artifacts).toEqual([]);
+    });
+
+    it('should fall back to output field when result is missing', () => {
+      const raw = JSON.stringify({ output: 'Fallback output' });
+
+      const response = bridge.parseResponse(raw);
+
+      expect(response.output).toBe('Fallback output');
+      expect(response.success).toBe(true);
+    });
+
+    it('should handle empty result string', () => {
+      const raw = JSON.stringify({ type: 'result', result: '' });
+
+      const response = bridge.parseResponse(raw);
+
+      // Empty string falls through to raw JSON string via ?? fallback
+      expect(response.success).toBe(true);
+    });
+  });
+
+  describe('execute', () => {
+    it('should invoke claude CLI and return parsed response', async () => {
+      const cliOutput = JSON.stringify({
+        type: 'result',
+        result: JSON.stringify({ output: 'Collected data', success: true }),
+      });
+      mockExecFileSync.mockReturnValueOnce(cliOutput);
+
+      const request = createRequest();
+      const response = await bridge.execute(request);
+
+      expect(response.output).toBe('Collected data');
+      expect(response.success).toBe(true);
+
+      // Verify execFileSync was called with correct arguments
+      expect(mockExecFileSync).toHaveBeenCalledOnce();
+      const [cmd, args, options] = mockExecFileSync.mock.calls[0]!;
+      expect(cmd).toBe('/usr/local/bin/claude');
+      expect(args).toEqual(expect.arrayContaining(['-p', '--output-format', 'json']));
+      expect(options).toMatchObject({
+        encoding: 'utf-8',
+        cwd: '/test/project',
+      });
+    });
+
+    it('should return error response on subprocess failure', async () => {
+      mockExecFileSync.mockImplementationOnce(() => {
+        throw new Error('Command failed with exit code 1');
+      });
+
+      const request = createRequest();
+      const response = await bridge.execute(request);
+
+      expect(response.success).toBe(false);
+      expect(response.error).toContain('Command failed with exit code 1');
+      expect(response.output).toBe('');
+    });
+
+    it('should return error response on timeout', async () => {
+      mockExecFileSync.mockImplementationOnce(() => {
+        const err = new Error('TIMEOUT');
+        (err as NodeJS.ErrnoException).code = 'ETIMEDOUT';
+        throw err;
+      });
+
+      const request = createRequest();
+      const response = await bridge.execute(request);
+
+      expect(response.success).toBe(false);
+      expect(response.error).toContain('TIMEOUT');
+    });
+
+    it('should set cwd to project directory', async () => {
+      mockExecFileSync.mockReturnValueOnce(JSON.stringify({ result: 'ok' }));
+
+      const request = createRequest({ projectDir: '/my/project' });
+      await bridge.execute(request);
+
+      const [, , options] = mockExecFileSync.mock.calls[0]!;
+      expect((options as { cwd: string }).cwd).toBe('/my/project');
+    });
+  });
+
+  describe('constructor', () => {
+    it('should use default claude path when not specified', async () => {
+      const defaultBridge = new ClaudeCliSubprocessBridge();
+      mockExecFileSync.mockReturnValueOnce(JSON.stringify({ result: 'ok' }));
+
+      await defaultBridge.execute(createRequest());
+
+      const [cmd] = mockExecFileSync.mock.calls[0]!;
+      expect(cmd).toBe('claude');
+    });
+
+    it('should accept custom claude path', async () => {
+      const customBridge = new ClaudeCliSubprocessBridge({
+        claudePath: '/custom/path/claude',
+      });
+      mockExecFileSync.mockReturnValueOnce(JSON.stringify({ result: 'ok' }));
+
+      await customBridge.execute(createRequest());
+
+      const [cmd] = mockExecFileSync.mock.calls[0]!;
+      expect(cmd).toBe('/custom/path/claude');
+    });
+  });
+
+  describe('dispose', () => {
+    it('should dispose without error', async () => {
+      await expect(bridge.dispose()).resolves.toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
## What

### Summary
Adds a new `ClaudeCliSubprocessBridge` that invokes the `claude` CLI in non-interactive mode for each pipeline stage, enabling subscription account users to run the full pipeline without a separate API key.

### Change Type
- [x] Feature (new functionality)

### Affected Components
- New: `src/agents/bridges/ClaudeCliSubprocessBridge.ts`
- Updated: `src/agents/BridgeRegistry.ts` — detection and registration
- Updated: `src/agents/bridges/index.ts`, `src/agents/index.ts` — exports

## Why

### Related Issues
- Closes #713 (Add ClaudeCliSubprocessBridge for subscription-based execution)

### Problem
Subscription users inside Claude Code had no way to leverage their subscription for pipeline execution. The existing ClaudeCodeBridge uses file-based IPC that requires an external orchestrator. AnthropicApiBridge requires a separate API key.

## How

### Implementation
1. `ClaudeCliSubprocessBridge`: Uses `execFileSync('claude', ['-p', '--output-format', 'json', ...])` per stage
2. `buildPrompt()`: Constructs context-rich prompts from AgentRequest
3. `buildArgs()`: Adds `--system-prompt-file` if agent definition exists
4. `parseResponse()`: Handles Claude CLI JSON wrapper with nested JSON fallback
5. `isClaudeCliAvailable()`: Detects `claude` CLI at startup
6. Detection priority: ClaudeCodeBridge > AnthropicApiBridge > ClaudeCliSubprocessBridge > StubBridge

### Testing Done
- [x] 22 new unit tests (mocked execFileSync)
- [x] 53 bridge+registry tests pass
- [x] 236 E2E tests pass
- [x] Build clean

### Breaking Changes
None — new bridge is additive. Existing bridges unaffected.