### PR TITLE
fix(collector): strip label prefixes before prose FR splitting

### DIFF
--- a/src/collector/InformationExtractor.ts
+++ b/src/collector/InformationExtractor.ts
@@ -181,6 +181,13 @@ const FR_ACTION_VERB_PATTERNS: readonly RegExp[] = FR_ACTION_VERBS.map(
 );
 
 /**
+ * Common label prefixes that precede semicolon-delimited feature lists in prose.
+ * These are stripped before clause splitting so they don't pollute FR titles.
+ */
+const LABEL_PREFIX_PATTERN =
+  /^(?:features|requirements|capabilities|functions|commands|abilities)\s*:\s*/i;
+
+/**
  * Acceptance criteria indicator patterns
  */
 const AC_INDICATORS: readonly string[] = [
@@ -406,6 +413,32 @@ export class InformationExtractor {
   }
 
   /**
+   * Pre-process content to expand label-prefixed semicolon lists into
+   * individual sentences so downstream extraction handles them correctly.
+   *
+   * Example: "Build an app. Features: add X; delete Y; list Z."
+   * becomes: "Build an app. add X. delete Y. list Z."
+   *
+   * @param content - Raw input text
+   * @returns Pre-processed text with label prefixes stripped and semicolons expanded
+   */
+  private preprocessContent(content: string): string {
+    // Match a label prefix followed by a semicolon-delimited list
+    // The label may appear after a sentence boundary or at the start of content
+    return content.replace(
+      /(?:^|(?<=[.!?]\s*))(?:features|requirements|capabilities|functions|commands|abilities)\s*:\s*([^.!?]*(?:;[^.!?]*)*)(?=[.!?]|$)/gi,
+      (_match, list: string) => {
+        // Split the captured list on semicolons and rejoin as separate sentences
+        return list
+          .split(/;/)
+          .map((item: string) => item.trim())
+          .filter((item: string) => item.length > 0)
+          .join('. ');
+      }
+    );
+  }
+
+  /**
    * Extract requirements from content
    * @param content - The text content to analyze for requirements
    * @param source - The source reference for traceability
@@ -418,8 +451,11 @@ export class InformationExtractor {
     const functional: ExtractedRequirement[] = [];
     const nonFunctional: ExtractedRequirement[] = [];
 
+    // Pre-process to expand label-prefixed semicolon lists
+    const processed = this.preprocessContent(content);
+
     // Split content into sentences/bullet points
-    const segments = this.splitIntoSegments(content);
+    const segments = this.splitIntoSegments(processed);
 
     for (let i = 0; i < segments.length; i++) {
       const segment = segments[i];
@@ -467,16 +503,24 @@ export class InformationExtractor {
       }
     }
 
-    // Prose fallback: when structured extraction finds nothing, try action-verb detection
-    if (functional.length === 0 && nonFunctional.length === 0) {
-      const proseClauses = this.splitIntoProseClauses(content);
+    // Prose fallback: when structured extraction finds nothing, or when
+    // the content contains semicolons suggesting a list that the structured
+    // path may have under-extracted, try action-verb detection on prose clauses.
+    const proseClauses = this.splitIntoProseClauses(content);
+    const proseFunctional: ExtractedRequirement[] = [];
+    const proseNonFunctional: ExtractedRequirement[] = [];
+
+    // Only run prose extraction when it might improve results.
+    // Check original content for semicolons (preprocessContent may have replaced them).
+    const structuredTotal = functional.length + nonFunctional.length;
+    if (structuredTotal === 0 || content.includes(';')) {
       for (const clause of proseClauses) {
         const normalized = clause.toLowerCase();
 
         // Check for NFR keywords first (reuse existing detection)
         const nfrCategory = this.detectNfrCategory(normalized);
         if (nfrCategory !== undefined) {
-          nonFunctional.push({
+          proseNonFunctional.push({
             id: this.nextNfrId(),
             title: this.extractTitle(clause),
             description: clause.trim(),
@@ -491,7 +535,7 @@ export class InformationExtractor {
 
         // Check for action verbs → FR candidate
         if (this.hasActionVerb(normalized)) {
-          functional.push({
+          proseFunctional.push({
             id: this.nextRequirementId(),
             title: this.extractProseTitle(clause),
             description: clause.trim(),
@@ -500,6 +544,22 @@ export class InformationExtractor {
             confidence: 0.5,
             isFunctional: true,
           });
+        }
+      }
+
+      // Use prose results if they produced more requirements
+      const proseTotal = proseFunctional.length + proseNonFunctional.length;
+      if (proseTotal > structuredTotal) {
+        functional.length = 0;
+        nonFunctional.length = 0;
+        this.requirementCounter = 0;
+        this.nfrCounter = 0;
+
+        for (const req of proseFunctional) {
+          functional.push({ ...req, id: this.nextRequirementId() });
+        }
+        for (const req of proseNonFunctional) {
+          nonFunctional.push({ ...req, id: this.nextNfrId() });
         }
       }
     }
@@ -518,8 +578,11 @@ export class InformationExtractor {
   private splitIntoProseClauses(content: string): string[] {
     const clauses: string[] = [];
 
+    // Strip label prefixes (e.g., "Features:") before splitting
+    const stripped = content.replace(LABEL_PREFIX_PATTERN, '');
+
     // Split on semicolons first as the primary delimiter
-    const semiParts = content
+    const semiParts = stripped
       .split(/;/)
       .map((s) => s.trim())
       .filter((s) => s.length > 0);
@@ -528,7 +591,7 @@ export class InformationExtractor {
     for (const part of semiParts) {
       const sentences = part
         .split(/[.!?]+/)
-        .map((s) => s.trim())
+        .map((s) => s.trim().replace(LABEL_PREFIX_PATTERN, '').trim())
         .filter((s) => s.length > 5);
 
       for (const sentence of sentences) {
@@ -991,7 +1054,9 @@ export class InformationExtractor {
    * @returns A capitalized verb-object title
    */
   private extractProseTitle(clause: string): string {
-    const words = clause.trim().split(/\s+/);
+    // Strip label prefixes before title extraction
+    const cleaned = clause.replace(LABEL_PREFIX_PATTERN, '').trim();
+    const words = cleaned.split(/\s+/);
     const lowerWords = words.map((w) => w.toLowerCase());
 
     // Find the first action verb
@@ -1042,8 +1107,8 @@ export class InformationExtractor {
       }
     }
 
-    // Fallback to generic extractTitle
-    return this.extractTitle(clause);
+    // Fallback to generic extractTitle on cleaned text
+    return this.extractTitle(cleaned);
   }
 
   /**

--- a/src/collector/InformationExtractor.ts
+++ b/src/collector/InformationExtractor.ts
@@ -512,16 +512,19 @@ export class InformationExtractor {
 
     // Only run prose extraction when it might improve results.
     // Check original content for semicolons (preprocessContent may have replaced them).
+    // Require at least 2 semicolons to avoid false positives on incidental semicolons.
     const structuredTotal = functional.length + nonFunctional.length;
-    if (structuredTotal === 0 || content.includes(';')) {
+    const semicolonCount = (content.match(/;/g) ?? []).length;
+    if (structuredTotal === 0 || semicolonCount >= 2) {
       for (const clause of proseClauses) {
         const normalized = clause.toLowerCase();
 
         // Check for NFR keywords first (reuse existing detection)
         const nfrCategory = this.detectNfrCategory(normalized);
         if (nfrCategory !== undefined) {
+          // Use placeholder ID; real IDs assigned below if prose path wins
           proseNonFunctional.push({
-            id: this.nextNfrId(),
+            id: '',
             title: this.extractTitle(clause),
             description: clause.trim(),
             priority: this.detectPriority(normalized),
@@ -536,7 +539,7 @@ export class InformationExtractor {
         // Check for action verbs → FR candidate
         if (this.hasActionVerb(normalized)) {
           proseFunctional.push({
-            id: this.nextRequirementId(),
+            id: '',
             title: this.extractProseTitle(clause),
             description: clause.trim(),
             priority: this.detectPriority(normalized),
@@ -552,8 +555,6 @@ export class InformationExtractor {
       if (proseTotal > structuredTotal) {
         functional.length = 0;
         nonFunctional.length = 0;
-        this.requirementCounter = 0;
-        this.nfrCounter = 0;
 
         for (const req of proseFunctional) {
           functional.push({ ...req, id: this.nextRequirementId() });

--- a/tests/collector/InformationExtractor.test.ts
+++ b/tests/collector/InformationExtractor.test.ts
@@ -577,6 +577,32 @@ describe('InformationExtractor', () => {
       expect(result.functionalRequirements.length).toBeGreaterThanOrEqual(2);
       expect(result.nonFunctionalRequirements.length).toBeGreaterThanOrEqual(1);
     });
+
+    it('should strip label prefixes like "Features:" before splitting (#720)', () => {
+      const source = parser.parseText(
+        'Create a note manager CLI application. Features: create note with title and body; ' +
+          'edit note by ID; delete note by ID; list all notes; show note details; ' +
+          'tag notes with labels; filter notes by tag; export all notes to markdown files.'
+      );
+      const input = parser.combineInputs([source]);
+
+      const result = extractor.extract(input);
+
+      // Should produce 8+ individual FRs, not 2 collapsed ones
+      expect(result.functionalRequirements.length).toBeGreaterThanOrEqual(8);
+
+      // No FR title should be the bare label word "Features"
+      for (const req of result.functionalRequirements) {
+        expect(req.title.toLowerCase()).not.toBe('features');
+      }
+
+      // Spot-check that key action-verb titles appear
+      const titles = result.functionalRequirements.map((r) => r.title.toLowerCase());
+      expect(titles.some((t) => t.includes('create note'))).toBe(true);
+      expect(titles.some((t) => t.includes('edit note'))).toBe(true);
+      expect(titles.some((t) => t.includes('delete note'))).toBe(true);
+      expect(titles.some((t) => t.includes('export'))).toBe(true);
+    });
   });
 
   describe('stub mode output quality', () => {


### PR DESCRIPTION
## What

### Summary
Fixes prose FR extraction to handle label prefixes like `Features:` before semicolon-separated lists, producing individual FRs instead of one collapsed FR.

### Change Type
- [x] Bugfix (fixes an issue)

### Affected Components
- `src/collector/InformationExtractor.ts`

## Why

### Related Issues
- Closes #720

### Problem
Input `"Features: create note; edit note; delete note"` produced 1 FR titled `"Features"` instead of 3 individual FRs.

## How

### Implementation
1. `preprocessContent()`: Detects label+semicolon patterns, expands into sentences
2. Label stripping in `splitIntoProseClauses()` and `extractProseTitle()`
3. Enhanced prose fallback: runs when >= 2 semicolons detected, selects best result
4. Deferred ID assignment: prose uses placeholder IDs, real IDs assigned only when selected

### Testing Done
- [x] 1 new test (40/40 total pass)
- [x] Build clean

### Breaking Changes
None