### PR TITLE
feat(issue-generator): add LocalIssueWriter for non-GitHub projects

### DIFF
--- a/src/issue-generator/LocalIssueWriter.ts
+++ b/src/issue-generator/LocalIssueWriter.ts
@@ -1,0 +1,243 @@
+/**
+ * LocalIssueWriter - Generates local issue files from SRS features
+ *
+ * Reads SRS from the scratchpad, extracts features using SRSParser,
+ * and writes issue_list.json + individual ISS-XXX.md files compatible
+ * with LocalIssueReader.
+ */
+
+import { readFile, writeFile, mkdir } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { SRSParser } from '../sds-writer/SRSParser.js';
+import type { ParsedSRSFeature } from '../sds-writer/types.js';
+import type { Priority, EffortSize } from './types.js';
+import { getLogger } from '../logging/index.js';
+
+const logger = getLogger();
+
+/**
+ * Effort size mapping based on acceptance criteria count and description length
+ * @param feature
+ */
+function estimateSize(feature: ParsedSRSFeature): EffortSize {
+  const acCount = feature.acceptanceCriteria.length;
+  const descLen = feature.description.length;
+
+  if (acCount <= 1 && descLen < 80) return 'S';
+  if (acCount <= 3 && descLen < 200) return 'M';
+  if (acCount <= 5) return 'L';
+  return 'XL';
+}
+
+/**
+ * Estimated hours by effort size
+ */
+const EFFORT_HOURS: Readonly<Record<EffortSize, number>> = {
+  XS: 2,
+  S: 4,
+  M: 6,
+  L: 12,
+  XL: 20,
+};
+
+/**
+ * Shape of a single issue in issue_list.json
+ */
+export interface LocalIssueEntry {
+  readonly id: string;
+  readonly number: number;
+  readonly url: string;
+  readonly title: string;
+  readonly body: string;
+  readonly state: string;
+  readonly labels: {
+    readonly raw: readonly string[];
+    readonly priority: Priority;
+    readonly type: string;
+    readonly size: EffortSize;
+  };
+  readonly milestone: string | null;
+  readonly assignees: readonly string[];
+  readonly dependencies: {
+    readonly blocked_by: readonly string[];
+    readonly blocks: readonly string[];
+  };
+  readonly estimation: {
+    readonly size: EffortSize;
+    readonly hours: number;
+  };
+}
+
+/**
+ * Schema for issue_list.json
+ */
+export interface LocalIssueListFile {
+  readonly schemaVersion: string;
+  readonly projectId: string;
+  readonly generatedAt: string;
+  readonly issues: readonly LocalIssueEntry[];
+}
+
+/**
+ * Result returned by LocalIssueWriter.generate()
+ */
+export interface LocalIssueWriterResult {
+  readonly issueListPath: string;
+  readonly issueFiles: readonly string[];
+  readonly issueCount: number;
+}
+
+/**
+ * Options for LocalIssueWriter
+ */
+export interface LocalIssueWriterOptions {
+  /** Base path for scratchpad (defaults to .ad-sdlc/scratchpad) */
+  readonly scratchpadBasePath?: string;
+}
+
+const DEFAULT_SCRATCHPAD = '.ad-sdlc/scratchpad';
+
+/**
+ * Generates local issue files from SRS features.
+ */
+export class LocalIssueWriter {
+  private readonly scratchpadBasePath: string;
+
+  constructor(options: LocalIssueWriterOptions = {}) {
+    this.scratchpadBasePath = options.scratchpadBasePath ?? DEFAULT_SCRATCHPAD;
+  }
+
+  /**
+   * Generate issue files from an SRS document.
+   *
+   * @param projectId - Project identifier used for directory paths
+   * @param srsContent - Optional raw SRS markdown. If omitted, reads from scratchpad.
+   * @returns Paths of generated files and issue count
+   */
+  async generate(projectId: string, srsContent?: string): Promise<LocalIssueWriterResult> {
+    // 1. Read SRS
+    const content = srsContent ?? (await this.readSRS(projectId));
+
+    // 2. Parse features
+    const parser = new SRSParser();
+    const parsed = parser.parse(content);
+    const features = parsed.features;
+
+    if (features.length === 0) {
+      logger.warn('No features found in SRS — generating empty issue list');
+    }
+
+    // 3. Convert features to issue entries
+    const issues = features.map((feature, idx) => this.featureToIssue(feature, idx + 1));
+
+    // 4. Build issue_list.json
+    const issueList: LocalIssueListFile = {
+      schemaVersion: '1.0.0',
+      projectId,
+      generatedAt: new Date().toISOString(),
+      issues,
+    };
+
+    // 5. Write files
+    const issueDir = join(this.scratchpadBasePath, 'issues', projectId);
+    await mkdir(issueDir, { recursive: true });
+
+    const issueListPath = join(issueDir, 'issue_list.json');
+    await writeFile(issueListPath, JSON.stringify(issueList, null, 2), 'utf-8');
+    logger.info(`Wrote ${issueListPath} with ${String(issues.length)} issues`);
+
+    const issueFiles: string[] = [];
+    for (const issue of issues) {
+      const mdPath = join(issueDir, `${issue.id}.md`);
+      await writeFile(mdPath, this.renderIssueMd(issue), 'utf-8');
+      issueFiles.push(mdPath);
+    }
+
+    logger.info(`Wrote ${String(issueFiles.length)} individual issue markdown files`);
+
+    return { issueListPath, issueFiles, issueCount: issues.length };
+  }
+
+  /**
+   * Read SRS content from the scratchpad.
+   * @param projectId
+   */
+  private async readSRS(projectId: string): Promise<string> {
+    const srsPath = join(this.scratchpadBasePath, 'documents', projectId, 'srs.md');
+    if (!existsSync(srsPath)) {
+      throw new Error(`SRS file not found at ${srsPath}`);
+    }
+    return readFile(srsPath, 'utf-8');
+  }
+
+  /**
+   * Convert a ParsedSRSFeature into a LocalIssueEntry.
+   * @param feature
+   * @param number
+   */
+  private featureToIssue(feature: ParsedSRSFeature, number: number): LocalIssueEntry {
+    const id = `ISS-${String(number).padStart(3, '0')}`;
+    const size = estimateSize(feature);
+    const hours = EFFORT_HOURS[size];
+
+    const acSection =
+      feature.acceptanceCriteria.length > 0
+        ? `\n\n## Acceptance Criteria\n${feature.acceptanceCriteria.map((ac) => `- [ ] ${ac}`).join('\n')}`
+        : '';
+
+    const traceSection = `\n\n## Traceability\n- SRS Feature: ${feature.id}${feature.sourceRequirements.length > 0 ? `\n- PRD Requirements: ${feature.sourceRequirements.join(', ')}` : ''}`;
+
+    const body = `## Description\n${feature.description || feature.name}${acSection}${traceSection}`;
+
+    return {
+      id,
+      number,
+      url: `local://issues/${id}`,
+      title: `[Feature] ${feature.name}`,
+      body,
+      state: 'open',
+      labels: {
+        raw: ['type/feature', `priority/${feature.priority.toLowerCase()}`],
+        priority: feature.priority as Priority,
+        type: 'feature',
+        size,
+      },
+      milestone: null,
+      assignees: [],
+      dependencies: {
+        blocked_by: [],
+        blocks: [],
+      },
+      estimation: {
+        size,
+        hours,
+      },
+    };
+  }
+
+  /**
+   * Render a human-readable markdown file for a single issue.
+   * @param issue
+   */
+  private renderIssueMd(issue: LocalIssueEntry): string {
+    const lines: string[] = [
+      `# ${issue.title}`,
+      '',
+      `| Field | Value |`,
+      `|-------|-------|`,
+      `| **ID** | ${issue.id} |`,
+      `| **State** | ${issue.state} |`,
+      `| **Priority** | ${issue.labels.priority} |`,
+      `| **Size** | ${issue.labels.size} |`,
+      `| **Estimated Hours** | ${String(issue.estimation.hours)} |`,
+      `| **Labels** | ${issue.labels.raw.join(', ')} |`,
+      '',
+      issue.body,
+      '',
+    ];
+
+    return lines.join('\n');
+  }
+}

--- a/src/issue-generator/LocalIssueWriter.ts
+++ b/src/issue-generator/LocalIssueWriter.ts
@@ -7,12 +7,12 @@
  */
 
 import { readFile, writeFile, mkdir } from 'node:fs/promises';
-import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 
 import { SRSParser } from '../sds-writer/SRSParser.js';
 import type { ParsedSRSFeature } from '../sds-writer/types.js';
-import type { Priority, EffortSize } from './types.js';
+import type { EffortSize, Priority } from './types.js';
+import { EFFORT_HOURS } from '../issue-reader/types.js';
 import { getLogger } from '../logging/index.js';
 
 const logger = getLogger();
@@ -30,17 +30,6 @@ function estimateSize(feature: ParsedSRSFeature): EffortSize {
   if (acCount <= 5) return 'L';
   return 'XL';
 }
-
-/**
- * Estimated hours by effort size
- */
-const EFFORT_HOURS: Readonly<Record<EffortSize, number>> = {
-  XS: 2,
-  S: 4,
-  M: 6,
-  L: 12,
-  XL: 20,
-};
 
 /**
  * Shape of a single issue in issue_list.json
@@ -166,10 +155,14 @@ export class LocalIssueWriter {
    */
   private async readSRS(projectId: string): Promise<string> {
     const srsPath = join(this.scratchpadBasePath, 'documents', projectId, 'srs.md');
-    if (!existsSync(srsPath)) {
-      throw new Error(`SRS file not found at ${srsPath}`);
+    try {
+      return await readFile(srsPath, 'utf-8');
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+        throw new Error(`SRS file not found at ${srsPath}`, { cause: err });
+      }
+      throw err;
     }
-    return readFile(srsPath, 'utf-8');
   }
 
   /**
@@ -200,7 +193,7 @@ export class LocalIssueWriter {
       state: 'open',
       labels: {
         raw: ['type/feature', `priority/${feature.priority.toLowerCase()}`],
-        priority: feature.priority as Priority,
+        priority: feature.priority,
         type: 'feature',
         size,
       },

--- a/src/issue-generator/index.ts
+++ b/src/issue-generator/index.ts
@@ -15,6 +15,15 @@ export {
   ISSUE_GENERATOR_AGENT_ID,
 } from './IssueGeneratorAgentAdapter.js';
 
+// Local issue generation (no GitHub dependency)
+export { LocalIssueWriter } from './LocalIssueWriter.js';
+export type {
+  LocalIssueEntry,
+  LocalIssueListFile,
+  LocalIssueWriterResult,
+  LocalIssueWriterOptions,
+} from './LocalIssueWriter.js';
+
 export { SDSParser } from './SDSParser.js';
 export { IssueTransformer } from './IssueTransformer.js';
 export { EffortEstimator } from './EffortEstimator.js';

--- a/tests/issue-generator/LocalIssueWriter.test.ts
+++ b/tests/issue-generator/LocalIssueWriter.test.ts
@@ -1,0 +1,256 @@
+/**
+ * LocalIssueWriter unit tests
+ *
+ * Tests SRS feature → issue_list.json + ISS-XXX.md file generation.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { LocalIssueWriter } from '../../src/issue-generator/LocalIssueWriter.js';
+import { LocalIssueReader } from '../../src/issue-reader/LocalIssueReader.js';
+import type { LocalIssueListFile } from '../../src/issue-generator/LocalIssueWriter.js';
+
+/**
+ * Minimal SRS markdown with 3 features for testing
+ */
+const SAMPLE_SRS = `# Test Project SRS
+
+| **Document ID** | SRS-test |
+| **Version** | 1.0.0 |
+| **Status** | Draft |
+| **Project ID** | test_project |
+
+## 1. Introduction
+
+**Test Project** is a sample application for testing LocalIssueWriter.
+
+## 3. System Features
+
+### SF-001: User Authentication
+
+| **Priority** | P0 |
+| **Source Requirements** | FR-001 |
+
+**Description:**
+Allow users to register and login using email and password.
+
+**Acceptance Criteria:**
+- User can register with email and password
+- User can login with valid credentials
+- Invalid credentials show error message
+
+---
+
+### SF-002: Task Management
+
+| **Priority** | P1 |
+| **Source Requirements** | FR-002, FR-003 |
+| **Use Cases** | UC-001, UC-002 |
+
+**Description:**
+Create, edit, and delete tasks with title, description, and due date.
+
+**Acceptance Criteria:**
+- User can create a task
+- User can edit a task
+- User can delete a task
+- Tasks have title, description, and due date
+
+---
+
+### SF-003: Dashboard Overview
+
+| **Priority** | P2 |
+| **Source Requirements** | FR-004 |
+
+**Description:**
+Display summary of tasks.
+
+## 5. Non-Functional Requirements
+
+### NFR-001: Performance
+
+| **Priority** | P1 |
+
+API response time must be under 200ms.
+`;
+
+describe('LocalIssueWriter', () => {
+  let tmpDir: string;
+  let writer: LocalIssueWriter;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'local-issue-writer-'));
+    writer = new LocalIssueWriter({ scratchpadBasePath: tmpDir });
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  describe('generate', () => {
+    it('should generate issue_list.json from SRS content', async () => {
+      const result = await writer.generate('test_project', SAMPLE_SRS);
+
+      expect(result.issueCount).toBe(3);
+      expect(result.issueListPath).toContain('issue_list.json');
+      expect(fs.existsSync(result.issueListPath)).toBe(true);
+
+      const raw = fs.readFileSync(result.issueListPath, 'utf-8');
+      const issueList: LocalIssueListFile = JSON.parse(raw);
+
+      expect(issueList.schemaVersion).toBe('1.0.0');
+      expect(issueList.projectId).toBe('test_project');
+      expect(issueList.issues).toHaveLength(3);
+    });
+
+    it('should produce sequential ISS-XXX IDs', async () => {
+      const result = await writer.generate('test_project', SAMPLE_SRS);
+      const raw = fs.readFileSync(result.issueListPath, 'utf-8');
+      const issueList: LocalIssueListFile = JSON.parse(raw);
+
+      expect(issueList.issues[0].id).toBe('ISS-001');
+      expect(issueList.issues[1].id).toBe('ISS-002');
+      expect(issueList.issues[2].id).toBe('ISS-003');
+    });
+
+    it('should map feature priority to issue labels', async () => {
+      const result = await writer.generate('test_project', SAMPLE_SRS);
+      const raw = fs.readFileSync(result.issueListPath, 'utf-8');
+      const issueList: LocalIssueListFile = JSON.parse(raw);
+
+      expect(issueList.issues[0].labels.priority).toBe('P0');
+      expect(issueList.issues[1].labels.priority).toBe('P1');
+      expect(issueList.issues[2].labels.priority).toBe('P2');
+    });
+
+    it('should include acceptance criteria in issue body', async () => {
+      const result = await writer.generate('test_project', SAMPLE_SRS);
+      const raw = fs.readFileSync(result.issueListPath, 'utf-8');
+      const issueList: LocalIssueListFile = JSON.parse(raw);
+
+      // SF-001 has 3 acceptance criteria
+      expect(issueList.issues[0].body).toContain('Acceptance Criteria');
+      expect(issueList.issues[0].body).toContain('User can register with email and password');
+    });
+
+    it('should include traceability in issue body', async () => {
+      const result = await writer.generate('test_project', SAMPLE_SRS);
+      const raw = fs.readFileSync(result.issueListPath, 'utf-8');
+      const issueList: LocalIssueListFile = JSON.parse(raw);
+
+      expect(issueList.issues[0].body).toContain('SRS Feature: SF-001');
+      expect(issueList.issues[0].body).toContain('PRD Requirements: FR-001');
+    });
+
+    it('should generate individual ISS-XXX.md files', async () => {
+      const result = await writer.generate('test_project', SAMPLE_SRS);
+
+      expect(result.issueFiles).toHaveLength(3);
+      for (const filePath of result.issueFiles) {
+        expect(fs.existsSync(filePath)).toBe(true);
+        const content = fs.readFileSync(filePath, 'utf-8');
+        expect(content).toContain('# [Feature]');
+        expect(content).toContain('| **ID** |');
+      }
+    });
+
+    it('should produce issue titles with [Feature] prefix', async () => {
+      const result = await writer.generate('test_project', SAMPLE_SRS);
+      const raw = fs.readFileSync(result.issueListPath, 'utf-8');
+      const issueList: LocalIssueListFile = JSON.parse(raw);
+
+      expect(issueList.issues[0].title).toBe('[Feature] User Authentication');
+      expect(issueList.issues[1].title).toBe('[Feature] Task Management');
+      expect(issueList.issues[2].title).toBe('[Feature] Dashboard Overview');
+    });
+
+    it('should estimate size based on feature complexity', async () => {
+      const result = await writer.generate('test_project', SAMPLE_SRS);
+      const raw = fs.readFileSync(result.issueListPath, 'utf-8');
+      const issueList: LocalIssueListFile = JSON.parse(raw);
+
+      // SF-003 has no AC and short description → S
+      expect(issueList.issues[2].estimation.size).toBe('S');
+      // SF-002 has 4 AC → L
+      expect(issueList.issues[1].estimation.size).toBe('L');
+    });
+
+    it('should handle empty SRS gracefully', async () => {
+      const emptySRS = '# Empty Project\n\n## 1. Introduction\n\nNo features yet.';
+      const result = await writer.generate('empty_project', emptySRS);
+
+      expect(result.issueCount).toBe(0);
+      expect(result.issueFiles).toHaveLength(0);
+
+      const raw = fs.readFileSync(result.issueListPath, 'utf-8');
+      const issueList: LocalIssueListFile = JSON.parse(raw);
+      expect(issueList.issues).toHaveLength(0);
+    });
+  });
+
+  describe('LocalIssueReader compatibility', () => {
+    it('should produce files readable by LocalIssueReader', async () => {
+      const result = await writer.generate('test_project', SAMPLE_SRS);
+
+      const reader = new LocalIssueReader();
+      const issueDir = path.dirname(result.issueListPath);
+      const importResult = await reader.importFromLocal(issueDir);
+
+      expect(importResult.repository).toBe('local');
+      expect(importResult.issues).toHaveLength(3);
+
+      // Verify round-trip integrity
+      expect(importResult.issues[0].id).toBe('ISS-001');
+      expect(importResult.issues[0].title).toBe('[Feature] User Authentication');
+      expect(importResult.issues[0].labels.priority).toBe('P0');
+      expect(importResult.issues[0].labels.type).toBe('feature');
+      expect(importResult.issues[0].state).toBe('open');
+    });
+
+    it('should produce valid dependency graph via LocalIssueReader', async () => {
+      const result = await writer.generate('test_project', SAMPLE_SRS);
+
+      const reader = new LocalIssueReader();
+      const issueDir = path.dirname(result.issueListPath);
+      const importResult = await reader.importFromLocal(issueDir);
+
+      expect(importResult.dependencyGraph).toBeDefined();
+      expect(importResult.dependencyGraph.nodes).toHaveLength(3);
+      expect(importResult.dependencyGraph.hasCycles).toBe(false);
+    });
+
+    it('should produce valid statistics via LocalIssueReader', async () => {
+      const result = await writer.generate('test_project', SAMPLE_SRS);
+
+      const reader = new LocalIssueReader();
+      const issueDir = path.dirname(result.issueListPath);
+      const importResult = await reader.importFromLocal(issueDir);
+
+      expect(importResult.stats.total).toBe(3);
+      expect(importResult.stats.imported).toBe(3);
+      expect(importResult.stats.byPriority.P0).toBe(1);
+      expect(importResult.stats.byPriority.P1).toBe(1);
+      expect(importResult.stats.byPriority.P2).toBe(1);
+    });
+  });
+
+  describe('SRS from scratchpad', () => {
+    it('should read SRS from scratchpad when no content provided', async () => {
+      // Write SRS to scratchpad location
+      const docsDir = path.join(tmpDir, 'documents', 'from_file');
+      fs.mkdirSync(docsDir, { recursive: true });
+      fs.writeFileSync(path.join(docsDir, 'srs.md'), SAMPLE_SRS);
+
+      const result = await writer.generate('from_file');
+
+      expect(result.issueCount).toBe(3);
+    });
+
+    it('should throw when SRS file is missing from scratchpad', async () => {
+      await expect(writer.generate('nonexistent')).rejects.toThrow('SRS file not found');
+    });
+  });
+});


### PR DESCRIPTION
## What

### Summary
Adds `LocalIssueWriter` that generates structured issue files from SRS features for projects not registered on GitHub, bridging the document pipeline to the execution pipeline in local mode.

### Change Type
- [x] Feature (new functionality)

### Affected Components
- New: `src/issue-generator/LocalIssueWriter.ts`
- Updated: `src/issue-generator/index.ts`

## Why

### Related Issues
- Closes #721 (Local issue file generation for non-GitHub projects)
- Partially addresses #718 (issue generator stub mode output for local projects)

### Problem
In `--local` mode, `issue_generation` produced zero issue files. The existing `LocalIssueReader` could read `issue_list.json` but nothing wrote it. This broke the document→execution pipeline chain.

## How

### Implementation
1. `LocalIssueWriter.generate(projectId, srsContent?)`: Reads SRS, parses features via `SRSParser`, generates `ImportedIssue` objects
2. Writes `issue_list.json` (compatible with `LocalIssueReader`) + individual `ISS-XXX.md` files
3. Each issue has title, body with description/acceptance criteria/traceability, labels, priority, size estimation
4. Round-trip verified: LocalIssueWriter output → LocalIssueReader input

### Testing Done
- [x] 14 new tests including round-trip with LocalIssueReader
- [x] Build clean

### Breaking Changes
None — new component, no existing code modified.