### PR TITLE
feat(pipeline): add scaffold output for execution stages in stub mode

### DIFF
--- a/src/agents/AgentDispatcher.ts
+++ b/src/agents/AgentDispatcher.ts
@@ -26,6 +26,7 @@ import { getAgentTypeEntry } from './AgentTypeMapping.js';
 import type { AgentTypeEntry } from './AgentTypeMapping.js';
 import type { AgentRequest } from './AgentBridge.js';
 import { BridgeRegistry } from './BridgeRegistry.js';
+import { ExecutionScaffoldGenerator } from './ExecutionScaffoldGenerator.js';
 import { getLogger } from '../logging/index.js';
 
 /**
@@ -654,19 +655,22 @@ export class AgentDispatcher {
       'project-initializer',
       'mode-detector',
       'issue-generator',
-      'controller',
-      'worker',
-      'pr-reviewer',
       'code-reader',
       'doc-code-comparator',
       'ci-fixer',
       'analysis-orchestrator',
       'stage-verifier',
       'rtm-builder',
-      'validation',
     ]) {
       this.callAdapters.set(agentType, executeAdapter);
     }
+
+    // Execution stages: use scaffold generator in local+stub mode,
+    // otherwise fall through to the standard executeAdapter.
+    this.callAdapters.set('controller', this.createScaffoldAdapter('controller', executeAdapter));
+    this.callAdapters.set('worker', this.createScaffoldAdapter('worker', executeAdapter));
+    this.callAdapters.set('validation', this.createScaffoldAdapter('validation', executeAdapter));
+    this.callAdapters.set('pr-reviewer', this.createScaffoldAdapter('review', executeAdapter));
   }
 
   /**
@@ -703,6 +707,40 @@ export class AgentDispatcher {
         return JSON.stringify(result);
       }
       return this.defaultAdapter(agent, stage, session);
+    };
+  }
+
+  /**
+   * Create a scaffold-aware adapter for execution stages.
+   *
+   * When `session.localMode` is true and the bridge for the agent type is a
+   * stub, the adapter delegates to the appropriate ExecutionScaffoldGenerator
+   * method. Otherwise it falls through to the provided fallback adapter.
+   *
+   * @param scaffoldStage - Which scaffold method to invoke ('controller' | 'worker' | 'validation' | 'review')
+   * @param fallback - Adapter to use when scaffold mode is not active
+   */
+  private createScaffoldAdapter(
+    scaffoldStage: 'controller' | 'worker' | 'validation' | 'review',
+    fallback: AgentCallAdapter
+  ): AgentCallAdapter {
+    return async (agent, stage, session) => {
+      if (session.localMode && this.bridgeRegistry.isStub(stage.agentType)) {
+        getLogger().info(
+          `[Scaffold] Using scaffold generator for ${stage.agentType} (localMode + stub bridge)`
+        );
+        switch (scaffoldStage) {
+          case 'controller':
+            return ExecutionScaffoldGenerator.controller(session);
+          case 'worker':
+            return ExecutionScaffoldGenerator.worker(session);
+          case 'validation':
+            return ExecutionScaffoldGenerator.validation(session);
+          case 'review':
+            return ExecutionScaffoldGenerator.review(session);
+        }
+      }
+      return fallback(agent, stage, session);
     };
   }
 

--- a/src/agents/ExecutionScaffoldGenerator.ts
+++ b/src/agents/ExecutionScaffoldGenerator.ts
@@ -60,6 +60,16 @@ interface IssueEntry {
 }
 
 /**
+ * Sanitize an external ID for safe use in file paths.
+ * Strips path traversal sequences and replaces non-alphanumeric characters
+ * (except hyphens) with underscores.
+ * @param id - Raw ID from external source (e.g. issue_list.json)
+ */
+function sanitizeId(id: string): string {
+  return id.replace(/[^a-zA-Z0-9-]/g, '_');
+}
+
+/**
  * Read issue_list.json and return the issues array.
  * @param issueDir - Directory containing issue_list.json
  */
@@ -106,12 +116,18 @@ async function readWorkOrders(dir: string): Promise<ScaffoldWorkOrder[]> {
 
 /**
  * Read the V&V report from the results directory.
+ * Returns null if the file does not exist or is malformed.
  * @param resultsDir - Directory containing vnv-report.json
  */
-async function readVnvReport(resultsDir: string): Promise<ScaffoldVnvReport> {
+async function readVnvReport(resultsDir: string): Promise<ScaffoldVnvReport | null> {
   const reportPath = join(resultsDir, 'vnv-report.json');
-  const raw = await readFile(reportPath, 'utf-8');
-  return JSON.parse(raw) as ScaffoldVnvReport;
+  try {
+    const raw = await readFile(reportPath, 'utf-8');
+    return JSON.parse(raw) as ScaffoldVnvReport;
+  } catch {
+    logger.warn(`[Scaffold] Could not read V&V report at ${reportPath}`);
+    return null;
+  }
 }
 
 /**
@@ -164,10 +180,11 @@ function extractAcceptanceCriteria(body: string): string[] {
 
 /**
  * Convert issue ID like "ISS-001" to a valid function name like "issueISS001".
- * @param issueId - Issue identifier
+ * Input is expected to be already sanitized via sanitizeId().
+ * @param issueId - Sanitized issue identifier
  */
 function issueIdToFunctionName(issueId: string): string {
-  const cleaned = issueId.replace(/[^a-zA-Z0-9]/g, '');
+  const cleaned = sanitizeId(issueId).replace(/[^a-zA-Z0-9]/g, '');
   return `issue${cleaned.charAt(0).toUpperCase()}${cleaned.slice(1)}`;
 }
 
@@ -205,16 +222,17 @@ export const ExecutionScaffoldGenerator = {
     const workOrders: ScaffoldWorkOrder[] = [];
 
     for (const issue of issues) {
+      const safeId = sanitizeId(issue.id);
       const wo: ScaffoldWorkOrder = {
-        orderId: `WO-${issue.id}`,
-        issueId: issue.id,
+        orderId: `WO-${safeId}`,
+        issueId: safeId,
         title: issue.title,
         priority: priorityToScore(issue.labels?.priority),
         createdAt: new Date().toISOString(),
         acceptanceCriteria: extractAcceptanceCriteria(issue.body ?? ''),
       };
 
-      const woPath = join(workOrderDir, `WO-${issue.id}.json`);
+      const woPath = join(workOrderDir, `WO-${safeId}.json`);
       await writeFile(woPath, JSON.stringify(wo, null, 2), 'utf-8');
       workOrders.push(wo);
     }
@@ -368,7 +386,7 @@ export const ExecutionScaffoldGenerator = {
     const workOrders = await readWorkOrders(workOrderDir).catch(() => []);
 
     const resultsDir = join(session.scratchpadDir, 'progress', projectId, 'results');
-    const vnvReport = await readVnvReport(resultsDir).catch(() => null);
+    const vnvReport = await readVnvReport(resultsDir);
 
     const lines: string[] = [
       `# Review Report`,

--- a/src/agents/ExecutionScaffoldGenerator.ts
+++ b/src/agents/ExecutionScaffoldGenerator.ts
@@ -1,0 +1,429 @@
+/**
+ * ExecutionScaffoldGenerator - Produces meaningful scaffold output for
+ * controller, worker, validation, and review stages in local+stub mode.
+ *
+ * When no real AI bridge is available and the pipeline runs in localMode,
+ * the dispatcher delegates to these functions instead of returning generic
+ * stub strings. Each function reads prior-stage artifacts from the scratchpad
+ * and writes structured scaffold files that downstream stages can consume.
+ *
+ * @packageDocumentation
+ */
+
+import { readFile, readdir, writeFile, mkdir } from 'node:fs/promises';
+import { join, basename } from 'node:path';
+import { randomUUID } from 'node:crypto';
+
+import type { OrchestratorSession } from '../ad-sdlc-orchestrator/types.js';
+import { getLogger } from '../logging/index.js';
+
+const logger = getLogger();
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Work order scaffold written by the controller stage */
+export interface ScaffoldWorkOrder {
+  readonly orderId: string;
+  readonly issueId: string;
+  readonly title: string;
+  readonly priority: number;
+  readonly createdAt: string;
+  readonly acceptanceCriteria: readonly string[];
+}
+
+/** V&V report scaffold written by the validation stage */
+export interface ScaffoldVnvReport {
+  readonly reportId: string;
+  readonly projectId: string;
+  readonly generatedAt: string;
+  readonly overallResult: 'pass' | 'pass_with_warnings';
+  readonly summary: {
+    readonly totalRequirements: number;
+    readonly implementedRequirements: number;
+    readonly coveragePercent: number;
+  };
+  readonly notes: string;
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/** Issue shape extracted from issue_list.json */
+interface IssueEntry {
+  readonly id: string;
+  readonly title: string;
+  readonly body?: string;
+  readonly labels?: { readonly priority?: string };
+}
+
+/**
+ * Read issue_list.json and return the issues array.
+ * @param issueDir - Directory containing issue_list.json
+ */
+async function readIssueList(issueDir: string): Promise<readonly IssueEntry[]> {
+  const listPath = join(issueDir, 'issue_list.json');
+  try {
+    const raw = await readFile(listPath, 'utf-8');
+    const data = JSON.parse(raw) as { issues?: unknown[] };
+    return (data.issues ?? []) as IssueEntry[];
+  } catch {
+    logger.warn(
+      `[Scaffold] Could not read issue list at ${listPath} — generating empty work orders`
+    );
+    return [];
+  }
+}
+
+/**
+ * Read all WO-*.json files from a directory.
+ * @param dir - Directory containing work order JSON files
+ */
+async function readWorkOrders(dir: string): Promise<ScaffoldWorkOrder[]> {
+  let entries: string[];
+  try {
+    entries = await readdir(dir);
+  } catch {
+    return [];
+  }
+
+  const orders: ScaffoldWorkOrder[] = [];
+  for (const entry of entries) {
+    if (entry.startsWith('WO-') && entry.endsWith('.json')) {
+      try {
+        const raw = await readFile(join(dir, entry), 'utf-8');
+        orders.push(JSON.parse(raw) as ScaffoldWorkOrder);
+      } catch {
+        // Skip malformed work orders
+      }
+    }
+  }
+
+  return orders;
+}
+
+/**
+ * Read the V&V report from the results directory.
+ * @param resultsDir - Directory containing vnv-report.json
+ */
+async function readVnvReport(resultsDir: string): Promise<ScaffoldVnvReport> {
+  const reportPath = join(resultsDir, 'vnv-report.json');
+  const raw = await readFile(reportPath, 'utf-8');
+  return JSON.parse(raw) as ScaffoldVnvReport;
+}
+
+/**
+ * Map priority string to numeric score.
+ * @param priority - Priority label (P0-P3)
+ */
+function priorityToScore(priority?: string): number {
+  switch (priority) {
+    case 'P0':
+      return 100;
+    case 'P1':
+      return 75;
+    case 'P2':
+      return 50;
+    case 'P3':
+      return 25;
+    default:
+      return 50;
+  }
+}
+
+/**
+ * Extract acceptance criteria lines from issue body markdown.
+ *
+ * Looks for `- [ ] ...` checkbox lines under an "Acceptance Criteria" heading.
+ * @param body - Issue body markdown
+ */
+function extractAcceptanceCriteria(body: string): string[] {
+  const criteria: string[] = [];
+  let inAcSection = false;
+
+  for (const line of body.split('\n')) {
+    if (/^##\s*acceptance\s*criteria/i.test(line)) {
+      inAcSection = true;
+      continue;
+    }
+    if (inAcSection && /^##\s/.test(line)) {
+      break; // Next section
+    }
+    if (inAcSection) {
+      const match = /^-\s*\[[ x]\]\s*(.+)/.exec(line);
+      if (match !== null && match[1] !== undefined) {
+        criteria.push(match[1].trim());
+      }
+    }
+  }
+
+  return criteria;
+}
+
+/**
+ * Convert issue ID like "ISS-001" to a valid function name like "issueISS001".
+ * @param issueId - Issue identifier
+ */
+function issueIdToFunctionName(issueId: string): string {
+  const cleaned = issueId.replace(/[^a-zA-Z0-9]/g, '');
+  return `issue${cleaned.charAt(0).toUpperCase()}${cleaned.slice(1)}`;
+}
+
+// ---------------------------------------------------------------------------
+// Public scaffold generators (exported as namespace)
+// ---------------------------------------------------------------------------
+
+/**
+ * Scaffold generators for execution stages.
+ *
+ * Each function reads prior-stage artifacts and writes scaffold files.
+ * Grouped as a namespace object for clean imports.
+ */
+export const ExecutionScaffoldGenerator = {
+  /**
+   * Controller stage: read issue_list.json and produce work order files.
+   *
+   * Reads `scratchpad/issues/{projectId}/issue_list.json`, creates one
+   * `WO-{issueId}.json` per open issue under
+   * `scratchpad/progress/{projectId}/work_orders/`.
+   *
+   * @param session - Orchestrator session with project context
+   * @returns JSON string summarising the generated work orders
+   */
+  async controller(session: OrchestratorSession): Promise<string> {
+    const projectId = basename(session.projectDir);
+    const issueDir = join(session.scratchpadDir, 'issues', projectId);
+    const workOrderDir = join(session.scratchpadDir, 'progress', projectId, 'work_orders');
+
+    await mkdir(workOrderDir, { recursive: true });
+
+    // Read issue list from prior stage
+    const issues = await readIssueList(issueDir);
+
+    const workOrders: ScaffoldWorkOrder[] = [];
+
+    for (const issue of issues) {
+      const wo: ScaffoldWorkOrder = {
+        orderId: `WO-${issue.id}`,
+        issueId: issue.id,
+        title: issue.title,
+        priority: priorityToScore(issue.labels?.priority),
+        createdAt: new Date().toISOString(),
+        acceptanceCriteria: extractAcceptanceCriteria(issue.body ?? ''),
+      };
+
+      const woPath = join(workOrderDir, `WO-${issue.id}.json`);
+      await writeFile(woPath, JSON.stringify(wo, null, 2), 'utf-8');
+      workOrders.push(wo);
+    }
+
+    logger.info(`[Scaffold:Controller] Generated ${String(workOrders.length)} work orders`);
+
+    return JSON.stringify({
+      stage: 'controller',
+      scaffold: true,
+      workOrderDir,
+      workOrderCount: workOrders.length,
+      workOrders: workOrders.map((wo) => ({ orderId: wo.orderId, issueId: wo.issueId })),
+    });
+  },
+
+  /**
+   * Worker stage: read work orders and produce scaffold source files.
+   *
+   * For each work order, creates a minimal `src/index.ts` stub and
+   * `package.json` under `{projectDir}/`.
+   *
+   * @param session - Orchestrator session with project context
+   * @returns JSON string summarising the generated source files
+   */
+  async worker(session: OrchestratorSession): Promise<string> {
+    const projectId = basename(session.projectDir);
+    const workOrderDir = join(session.scratchpadDir, 'progress', projectId, 'work_orders');
+
+    // Read work orders
+    const workOrders = await readWorkOrders(workOrderDir);
+    const filesCreated: string[] = [];
+
+    // Generate project source scaffold
+    const srcDir = join(session.projectDir, 'src');
+    await mkdir(srcDir, { recursive: true });
+
+    // Collect function stubs from all work orders
+    const functions: string[] = [];
+    for (const wo of workOrders) {
+      const fnName = issueIdToFunctionName(wo.issueId);
+      functions.push(
+        `/**`,
+        ` * ${wo.title}`,
+        ` * @see Work order: ${wo.orderId}`,
+        ` */`,
+        `export function ${fnName}(): void {`,
+        `  // TODO: Implement ${wo.issueId}`,
+        `}`,
+        ''
+      );
+    }
+
+    const indexContent = [
+      '// Auto-generated scaffold from AD-SDLC pipeline (local mode)',
+      `// Project: ${projectId}`,
+      `// Generated: ${new Date().toISOString()}`,
+      '',
+      ...functions,
+    ].join('\n');
+
+    const indexPath = join(srcDir, 'index.ts');
+    await writeFile(indexPath, indexContent, 'utf-8');
+    filesCreated.push(indexPath);
+
+    // Generate package.json
+    const pkgPath = join(session.projectDir, 'package.json');
+    const pkg = {
+      name: projectId,
+      version: '0.1.0',
+      description: `Scaffold generated by AD-SDLC pipeline`,
+      main: 'src/index.ts',
+      scripts: {
+        build: 'tsc',
+        test: 'echo "No tests yet"',
+      },
+    };
+    await writeFile(pkgPath, JSON.stringify(pkg, null, 2), 'utf-8');
+    filesCreated.push(pkgPath);
+
+    logger.info(`[Scaffold:Worker] Generated ${String(filesCreated.length)} source files`);
+
+    return JSON.stringify({
+      stage: 'worker',
+      scaffold: true,
+      filesCreated,
+      functionCount: workOrders.length,
+    });
+  },
+
+  /**
+   * Validation stage: produce a V&V report scaffold.
+   *
+   * Reads work order count from the progress directory and generates
+   * `scratchpad/progress/{projectId}/results/vnv-report.json`.
+   *
+   * @param session - Orchestrator session with project context
+   * @returns JSON string of the scaffold report
+   */
+  async validation(session: OrchestratorSession): Promise<string> {
+    const projectId = basename(session.projectDir);
+    const resultsDir = join(session.scratchpadDir, 'progress', projectId, 'results');
+    await mkdir(resultsDir, { recursive: true });
+
+    // Count work orders to estimate requirement coverage
+    const workOrderDir = join(session.scratchpadDir, 'progress', projectId, 'work_orders');
+    const workOrders = await readWorkOrders(workOrderDir).catch(() => []);
+    const reqCount = workOrders.length || 1;
+
+    const report: ScaffoldVnvReport = {
+      reportId: `VNV-${randomUUID().slice(0, 8)}`,
+      projectId,
+      generatedAt: new Date().toISOString(),
+      overallResult: 'pass_with_warnings',
+      summary: {
+        totalRequirements: reqCount,
+        implementedRequirements: reqCount,
+        coveragePercent: 100,
+      },
+      notes: 'Scaffold V&V report generated in local+stub mode. Manual verification recommended.',
+    };
+
+    const reportPath = join(resultsDir, 'vnv-report.json');
+    await writeFile(reportPath, JSON.stringify(report, null, 2), 'utf-8');
+
+    logger.info(`[Scaffold:Validation] Generated V&V report at ${reportPath}`);
+
+    return JSON.stringify({
+      stage: 'validation',
+      scaffold: true,
+      reportPath,
+      overallResult: report.overallResult,
+    });
+  },
+
+  /**
+   * Review stage: produce a review report markdown document.
+   *
+   * Generates `scratchpad/progress/{projectId}/reviews/review-report.md`
+   * summarising the scaffold pipeline output.
+   *
+   * @param session - Orchestrator session with project context
+   * @returns JSON string pointing to the review document
+   */
+  async review(session: OrchestratorSession): Promise<string> {
+    const projectId = basename(session.projectDir);
+    const reviewDir = join(session.scratchpadDir, 'progress', projectId, 'reviews');
+    await mkdir(reviewDir, { recursive: true });
+
+    // Read context from prior stages
+    const workOrderDir = join(session.scratchpadDir, 'progress', projectId, 'work_orders');
+    const workOrders = await readWorkOrders(workOrderDir).catch(() => []);
+
+    const resultsDir = join(session.scratchpadDir, 'progress', projectId, 'results');
+    const vnvReport = await readVnvReport(resultsDir).catch(() => null);
+
+    const lines: string[] = [
+      `# Review Report`,
+      '',
+      `| Field | Value |`,
+      `|-------|-------|`,
+      `| **Project** | ${projectId} |`,
+      `| **Generated** | ${new Date().toISOString()} |`,
+      `| **Mode** | local+stub (scaffold) |`,
+      '',
+      `## Work Orders Reviewed`,
+      '',
+    ];
+
+    if (workOrders.length === 0) {
+      lines.push('No work orders found.');
+    } else {
+      lines.push('| Order ID | Issue ID | Title |');
+      lines.push('|----------|----------|-------|');
+      for (const wo of workOrders) {
+        lines.push(`| ${wo.orderId} | ${wo.issueId} | ${wo.title} |`);
+      }
+    }
+
+    lines.push('');
+    lines.push('## Validation Summary');
+    lines.push('');
+
+    if (vnvReport !== null) {
+      lines.push(`- **Result**: ${vnvReport.overallResult}`);
+      lines.push(
+        `- **Requirements**: ${String(vnvReport.summary.implementedRequirements)}/${String(vnvReport.summary.totalRequirements)}`
+      );
+      lines.push(`- **Coverage**: ${String(vnvReport.summary.coveragePercent)}%`);
+    } else {
+      lines.push('No V&V report found.');
+    }
+
+    lines.push('');
+    lines.push('## Notes');
+    lines.push('');
+    lines.push('This report was auto-generated in local+stub mode. All scaffold output');
+    lines.push('should be reviewed and replaced with real implementations before deployment.');
+    lines.push('');
+
+    const reviewPath = join(reviewDir, 'review-report.md');
+    await writeFile(reviewPath, lines.join('\n'), 'utf-8');
+
+    logger.info(`[Scaffold:Review] Generated review report at ${reviewPath}`);
+
+    return JSON.stringify({
+      stage: 'review',
+      scaffold: true,
+      reviewPath,
+      workOrdersReviewed: workOrders.length,
+    });
+  },
+} as const;

--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -64,6 +64,10 @@ export type { AgentCallAdapter } from './AgentDispatcher.js';
 
 export { BridgeRegistry, createDefaultBridgeRegistry } from './BridgeRegistry.js';
 
+export { ExecutionScaffoldGenerator } from './ExecutionScaffoldGenerator.js';
+
+export type { ScaffoldWorkOrder, ScaffoldVnvReport } from './ExecutionScaffoldGenerator.js';
+
 export { StubBridge } from './bridges/StubBridge.js';
 export { AnthropicApiBridge } from './bridges/AnthropicApiBridge.js';
 export { ClaudeCodeBridge } from './bridges/ClaudeCodeBridge.js';

--- a/tests/agents/ExecutionScaffoldDispatcher.test.ts
+++ b/tests/agents/ExecutionScaffoldDispatcher.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Tests for scaffold-aware adapter integration in AgentDispatcher.
+ *
+ * Verifies that the dispatcher routes execution stages to
+ * ExecutionScaffoldGenerator when session.localMode is true
+ * and the bridge is a stub.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { mkdtemp, rm, mkdir } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import { AgentDispatcher } from '../../src/agents/AgentDispatcher.js';
+import { BridgeRegistry } from '../../src/agents/BridgeRegistry.js';
+import type {
+  OrchestratorSession,
+  PipelineStageDefinition,
+} from '../../src/ad-sdlc-orchestrator/types.js';
+
+function makeStage(agentType: string, name: string): PipelineStageDefinition {
+  return {
+    name: name as PipelineStageDefinition['name'],
+    agentType,
+    description: `Test ${agentType}`,
+    parallel: false,
+    approvalRequired: false,
+    dependsOn: [],
+  };
+}
+
+function makeSession(
+  projectDir: string,
+  scratchpadDir: string,
+  localMode: boolean
+): OrchestratorSession {
+  return {
+    sessionId: 'disp-test',
+    projectDir,
+    userRequest: 'test',
+    mode: 'greenfield',
+    startedAt: new Date().toISOString(),
+    status: 'running',
+    stageResults: [],
+    scratchpadDir,
+    localMode,
+  };
+}
+
+describe('AgentDispatcher scaffold adapter integration', () => {
+  let tmpDir: string;
+  let projectDir: string;
+  let scratchpadDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), 'disp-scaffold-'));
+    projectDir = join(tmpDir, 'test-project');
+    scratchpadDir = join(tmpDir, 'scratchpad');
+    await mkdir(projectDir, { recursive: true });
+    await mkdir(scratchpadDir, { recursive: true });
+  });
+
+  // Cleanup
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('should use scaffold generator for controller in localMode + stub', async () => {
+    // No real bridges → everything is stub
+    const registry = new BridgeRegistry();
+    const dispatcher = new AgentDispatcher(registry);
+
+    // Inject a mock agent for the controller type
+    const mockAgent = {
+      agentId: 'controller',
+      name: 'Mock Controller',
+      initialize: async () => {},
+      dispose: async () => {},
+    };
+    dispatcher.setAgent('controller', mockAgent);
+
+    const session = makeSession(projectDir, scratchpadDir, true);
+    const stage = makeStage('controller', 'orchestration');
+
+    const output = await dispatcher.dispatch(stage, session);
+    const result = JSON.parse(output);
+
+    expect(result.stage).toBe('controller');
+    expect(result.scaffold).toBe(true);
+  });
+
+  it('should use scaffold generator for worker in localMode + stub', async () => {
+    const registry = new BridgeRegistry();
+    const dispatcher = new AgentDispatcher(registry);
+
+    const mockAgent = {
+      agentId: 'worker',
+      name: 'Mock Worker',
+      initialize: async () => {},
+      dispose: async () => {},
+    };
+    dispatcher.setAgent('worker', mockAgent);
+
+    const session = makeSession(projectDir, scratchpadDir, true);
+    const stage = makeStage('worker', 'implementation');
+
+    const output = await dispatcher.dispatch(stage, session);
+    const result = JSON.parse(output);
+
+    expect(result.stage).toBe('worker');
+    expect(result.scaffold).toBe(true);
+  });
+
+  it('should use scaffold generator for validation in localMode + stub', async () => {
+    const registry = new BridgeRegistry();
+    const dispatcher = new AgentDispatcher(registry);
+
+    const mockAgent = {
+      agentId: 'validation-agent',
+      name: 'Mock Validation',
+      initialize: async () => {},
+      dispose: async () => {},
+    };
+    dispatcher.setAgent('validation', mockAgent);
+
+    const session = makeSession(projectDir, scratchpadDir, true);
+    const stage = makeStage('validation', 'validation');
+
+    const output = await dispatcher.dispatch(stage, session);
+    const result = JSON.parse(output);
+
+    expect(result.stage).toBe('validation');
+    expect(result.scaffold).toBe(true);
+  });
+
+  it('should use scaffold generator for pr-reviewer in localMode + stub', async () => {
+    const registry = new BridgeRegistry();
+    const dispatcher = new AgentDispatcher(registry);
+
+    const mockAgent = {
+      agentId: 'local-review-agent',
+      name: 'Mock Reviewer',
+      initialize: async () => {},
+      dispose: async () => {},
+    };
+    dispatcher.setAgent('pr-reviewer', mockAgent);
+
+    const session = makeSession(projectDir, scratchpadDir, true);
+    const stage = makeStage('pr-reviewer', 'review');
+
+    const output = await dispatcher.dispatch(stage, session);
+    const result = JSON.parse(output);
+
+    expect(result.stage).toBe('review');
+    expect(result.scaffold).toBe(true);
+  });
+
+  it('should NOT use scaffold when localMode is false', async () => {
+    const registry = new BridgeRegistry();
+    const dispatcher = new AgentDispatcher(registry);
+
+    const mockAgent = {
+      agentId: 'controller',
+      name: 'Mock Controller',
+      initialize: async () => {},
+      dispose: async () => {},
+    };
+    dispatcher.setAgent('controller', mockAgent);
+
+    // localMode = false
+    const session = makeSession(projectDir, scratchpadDir, false);
+    const stage = makeStage('controller', 'orchestration');
+
+    const output = await dispatcher.dispatch(stage, session);
+
+    // Should fall through to defaultAdapter which returns a generic string
+    // (mock agent has no execute/analyze/generateFromProject methods)
+    expect(output).toContain('Agent controller executed for stage');
+  });
+});

--- a/tests/agents/ExecutionScaffoldGenerator.test.ts
+++ b/tests/agents/ExecutionScaffoldGenerator.test.ts
@@ -142,6 +142,45 @@ describe('ExecutionScaffoldGenerator', () => {
       expect(result.workOrders).toHaveLength(0);
     });
 
+    it('should sanitize issue IDs to prevent path traversal', async () => {
+      const issueDir = join(scratchpadDir, 'issues', 'test-project');
+      await mkdir(issueDir, { recursive: true });
+
+      const issueList: LocalIssueListFile = {
+        schemaVersion: '1.0.0',
+        projectId: 'test-project',
+        generatedAt: new Date().toISOString(),
+        issues: [
+          {
+            id: '../../../etc/passwd',
+            number: 1,
+            url: 'local://issues/malicious',
+            title: '[Feature] Malicious',
+            body: '',
+            state: 'open',
+            labels: { raw: [], priority: 'P2', type: 'feature', size: 'M' },
+            milestone: null,
+            assignees: [],
+            dependencies: { blocked_by: [], blocks: [] },
+            estimation: { size: 'M', hours: 6 },
+          },
+        ],
+      };
+
+      await writeFile(join(issueDir, 'issue_list.json'), JSON.stringify(issueList), 'utf-8');
+
+      const result = JSON.parse(await ExecutionScaffoldGenerator.controller(session));
+
+      // Sanitized: ../../../etc/passwd → _________etc_passwd (dots and slashes become _)
+      expect(result.workOrders[0].issueId).toBe('_________etc_passwd');
+      expect(result.workOrders[0].orderId).toBe('WO-_________etc_passwd');
+
+      // File should be safely inside the work_orders directory
+      const files = await readdir(result.workOrderDir);
+      expect(files).toHaveLength(1);
+      expect(files[0]).toBe('WO-_________etc_passwd.json');
+    });
+
     it('should map priority labels to correct numeric scores', async () => {
       const issueDir = join(scratchpadDir, 'issues', 'test-project');
       await mkdir(issueDir, { recursive: true });

--- a/tests/agents/ExecutionScaffoldGenerator.test.ts
+++ b/tests/agents/ExecutionScaffoldGenerator.test.ts
@@ -1,0 +1,367 @@
+/**
+ * Tests for ExecutionScaffoldGenerator
+ *
+ * Verifies that all 4 execution stages produce meaningful scaffold output
+ * in local+stub mode: controller → work orders, worker → source stubs,
+ * validation → V&V report, review → review document.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, rm, readFile, readdir, writeFile, mkdir } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import { ExecutionScaffoldGenerator } from '../../src/agents/ExecutionScaffoldGenerator.js';
+import type { OrchestratorSession } from '../../src/ad-sdlc-orchestrator/types.js';
+import type { LocalIssueListFile } from '../../src/issue-generator/LocalIssueWriter.js';
+
+function createTestSession(projectDir: string, scratchpadDir: string): OrchestratorSession {
+  return {
+    sessionId: 'test-session',
+    projectDir,
+    userRequest: 'Build a note manager',
+    mode: 'greenfield',
+    startedAt: new Date().toISOString(),
+    status: 'running',
+    stageResults: [],
+    scratchpadDir,
+    localMode: true,
+  };
+}
+
+/**
+ * Write a minimal issue_list.json matching LocalIssueWriter output format.
+ */
+async function writeTestIssueList(issueDir: string, count: number = 3): Promise<void> {
+  await mkdir(issueDir, { recursive: true });
+
+  const issues = Array.from({ length: count }, (_, i) => {
+    const n = i + 1;
+    const id = `ISS-${String(n).padStart(3, '0')}`;
+    return {
+      id,
+      number: n,
+      url: `local://issues/${id}`,
+      title: `[Feature] Feature ${n}`,
+      body: [
+        '## Description',
+        `Implement feature ${n}`,
+        '',
+        '## Acceptance Criteria',
+        `- [ ] AC-${n}-1: Must work correctly`,
+        `- [ ] AC-${n}-2: Must handle edge cases`,
+        '',
+        '## Traceability',
+        `- SRS Feature: SF-00${n}`,
+      ].join('\n'),
+      state: 'open',
+      labels: {
+        raw: ['type/feature', 'priority/p2'],
+        priority: 'P2',
+        type: 'feature',
+        size: 'M',
+      },
+      milestone: null,
+      assignees: [],
+      dependencies: { blocked_by: [], blocks: [] },
+      estimation: { size: 'M', hours: 6 },
+    };
+  });
+
+  const issueList: LocalIssueListFile = {
+    schemaVersion: '1.0.0',
+    projectId: 'test-project',
+    generatedAt: new Date().toISOString(),
+    issues,
+  };
+
+  await writeFile(join(issueDir, 'issue_list.json'), JSON.stringify(issueList, null, 2), 'utf-8');
+}
+
+describe('ExecutionScaffoldGenerator', () => {
+  let tmpDir: string;
+  let projectDir: string;
+  let scratchpadDir: string;
+  let session: OrchestratorSession;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), 'scaffold-test-'));
+    projectDir = join(tmpDir, 'test-project');
+    scratchpadDir = join(tmpDir, 'scratchpad');
+    await mkdir(projectDir, { recursive: true });
+    await mkdir(scratchpadDir, { recursive: true });
+    session = createTestSession(projectDir, scratchpadDir);
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  // --------------------------------------------------------------------------
+  // Controller Stage
+  // --------------------------------------------------------------------------
+
+  describe('controller', () => {
+    it('should generate work order files from issue_list.json', async () => {
+      const issueDir = join(scratchpadDir, 'issues', 'test-project');
+      await writeTestIssueList(issueDir, 3);
+
+      const result = JSON.parse(await ExecutionScaffoldGenerator.controller(session));
+
+      expect(result.stage).toBe('controller');
+      expect(result.scaffold).toBe(true);
+      expect(result.workOrderCount).toBe(3);
+      expect(result.workOrders).toHaveLength(3);
+      expect(result.workOrders[0].orderId).toBe('WO-ISS-001');
+    });
+
+    it('should write valid WO-*.json files to the work_orders directory', async () => {
+      const issueDir = join(scratchpadDir, 'issues', 'test-project');
+      await writeTestIssueList(issueDir, 2);
+
+      const result = JSON.parse(await ExecutionScaffoldGenerator.controller(session));
+
+      const files = await readdir(result.workOrderDir);
+      expect(files).toContain('WO-ISS-001.json');
+      expect(files).toContain('WO-ISS-002.json');
+
+      // Verify work order content
+      const wo = JSON.parse(await readFile(join(result.workOrderDir, 'WO-ISS-001.json'), 'utf-8'));
+      expect(wo.orderId).toBe('WO-ISS-001');
+      expect(wo.issueId).toBe('ISS-001');
+      expect(wo.title).toBe('[Feature] Feature 1');
+      expect(wo.priority).toBe(50); // P2 = 50
+      expect(wo.acceptanceCriteria).toHaveLength(2);
+      expect(wo.acceptanceCriteria[0]).toContain('Must work correctly');
+    });
+
+    it('should return empty work orders when issue_list.json is missing', async () => {
+      const result = JSON.parse(await ExecutionScaffoldGenerator.controller(session));
+
+      expect(result.workOrderCount).toBe(0);
+      expect(result.workOrders).toHaveLength(0);
+    });
+
+    it('should map priority labels to correct numeric scores', async () => {
+      const issueDir = join(scratchpadDir, 'issues', 'test-project');
+      await mkdir(issueDir, { recursive: true });
+
+      const issueList: LocalIssueListFile = {
+        schemaVersion: '1.0.0',
+        projectId: 'test-project',
+        generatedAt: new Date().toISOString(),
+        issues: [
+          {
+            id: 'ISS-001',
+            number: 1,
+            url: 'local://issues/ISS-001',
+            title: '[Feature] Critical',
+            body: '',
+            state: 'open',
+            labels: { raw: [], priority: 'P0', type: 'feature', size: 'M' },
+            milestone: null,
+            assignees: [],
+            dependencies: { blocked_by: [], blocks: [] },
+            estimation: { size: 'M', hours: 6 },
+          },
+          {
+            id: 'ISS-002',
+            number: 2,
+            url: 'local://issues/ISS-002',
+            title: '[Feature] High',
+            body: '',
+            state: 'open',
+            labels: { raw: [], priority: 'P1', type: 'feature', size: 'M' },
+            milestone: null,
+            assignees: [],
+            dependencies: { blocked_by: [], blocks: [] },
+            estimation: { size: 'M', hours: 6 },
+          },
+        ],
+      };
+
+      await writeFile(join(issueDir, 'issue_list.json'), JSON.stringify(issueList), 'utf-8');
+
+      await ExecutionScaffoldGenerator.controller(session);
+
+      const wo1 = JSON.parse(
+        await readFile(
+          join(scratchpadDir, 'progress', 'test-project', 'work_orders', 'WO-ISS-001.json'),
+          'utf-8'
+        )
+      );
+      const wo2 = JSON.parse(
+        await readFile(
+          join(scratchpadDir, 'progress', 'test-project', 'work_orders', 'WO-ISS-002.json'),
+          'utf-8'
+        )
+      );
+
+      expect(wo1.priority).toBe(100); // P0
+      expect(wo2.priority).toBe(75); // P1
+    });
+  });
+
+  // --------------------------------------------------------------------------
+  // Worker Stage
+  // --------------------------------------------------------------------------
+
+  describe('worker', () => {
+    it('should generate src/index.ts with function stubs from work orders', async () => {
+      // First create work orders (simulate controller output)
+      const issueDir = join(scratchpadDir, 'issues', 'test-project');
+      await writeTestIssueList(issueDir, 2);
+      await ExecutionScaffoldGenerator.controller(session);
+
+      // Then run worker
+      const result = JSON.parse(await ExecutionScaffoldGenerator.worker(session));
+
+      expect(result.stage).toBe('worker');
+      expect(result.scaffold).toBe(true);
+      expect(result.functionCount).toBe(2);
+      expect(result.filesCreated).toContain(join(projectDir, 'src', 'index.ts'));
+      expect(result.filesCreated).toContain(join(projectDir, 'package.json'));
+
+      // Verify index.ts content
+      const indexContent = await readFile(join(projectDir, 'src', 'index.ts'), 'utf-8');
+      expect(indexContent).toContain('export function issueISS001');
+      expect(indexContent).toContain('export function issueISS002');
+      expect(indexContent).toContain('TODO: Implement ISS-001');
+      expect(indexContent).toContain('[Feature] Feature 1');
+    });
+
+    it('should generate package.json with project name', async () => {
+      const issueDir = join(scratchpadDir, 'issues', 'test-project');
+      await writeTestIssueList(issueDir, 1);
+      await ExecutionScaffoldGenerator.controller(session);
+
+      await ExecutionScaffoldGenerator.worker(session);
+
+      const pkg = JSON.parse(await readFile(join(projectDir, 'package.json'), 'utf-8'));
+      expect(pkg.name).toBe('test-project');
+      expect(pkg.version).toBe('0.1.0');
+      expect(pkg.scripts.build).toBe('tsc');
+    });
+
+    it('should handle missing work orders gracefully', async () => {
+      const result = JSON.parse(await ExecutionScaffoldGenerator.worker(session));
+
+      expect(result.functionCount).toBe(0);
+      // Should still create the files (empty scaffold)
+      expect(result.filesCreated).toContain(join(projectDir, 'src', 'index.ts'));
+    });
+  });
+
+  // --------------------------------------------------------------------------
+  // Validation Stage
+  // --------------------------------------------------------------------------
+
+  describe('validation', () => {
+    it('should generate vnv-report.json with requirement counts from work orders', async () => {
+      // Set up the pipeline output
+      const issueDir = join(scratchpadDir, 'issues', 'test-project');
+      await writeTestIssueList(issueDir, 3);
+      await ExecutionScaffoldGenerator.controller(session);
+
+      const result = JSON.parse(await ExecutionScaffoldGenerator.validation(session));
+
+      expect(result.stage).toBe('validation');
+      expect(result.scaffold).toBe(true);
+      expect(result.overallResult).toBe('pass_with_warnings');
+
+      // Verify the actual report file
+      const report = JSON.parse(await readFile(result.reportPath, 'utf-8'));
+      expect(report.projectId).toBe('test-project');
+      expect(report.overallResult).toBe('pass_with_warnings');
+      expect(report.summary.totalRequirements).toBe(3);
+      expect(report.summary.implementedRequirements).toBe(3);
+      expect(report.summary.coveragePercent).toBe(100);
+      expect(report.notes).toContain('local+stub mode');
+    });
+
+    it('should handle missing work orders with default count', async () => {
+      const result = JSON.parse(await ExecutionScaffoldGenerator.validation(session));
+
+      const report = JSON.parse(await readFile(result.reportPath, 'utf-8'));
+      expect(report.summary.totalRequirements).toBe(1);
+    });
+  });
+
+  // --------------------------------------------------------------------------
+  // Review Stage
+  // --------------------------------------------------------------------------
+
+  describe('review', () => {
+    it('should generate review-report.md referencing work orders and V&V report', async () => {
+      // Run full pipeline: controller → worker → validation → review
+      const issueDir = join(scratchpadDir, 'issues', 'test-project');
+      await writeTestIssueList(issueDir, 2);
+      await ExecutionScaffoldGenerator.controller(session);
+      await ExecutionScaffoldGenerator.worker(session);
+      await ExecutionScaffoldGenerator.validation(session);
+
+      const result = JSON.parse(await ExecutionScaffoldGenerator.review(session));
+
+      expect(result.stage).toBe('review');
+      expect(result.scaffold).toBe(true);
+      expect(result.workOrdersReviewed).toBe(2);
+
+      // Verify review document content
+      const reviewContent = await readFile(result.reviewPath, 'utf-8');
+      expect(reviewContent).toContain('# Review Report');
+      expect(reviewContent).toContain('test-project');
+      expect(reviewContent).toContain('local+stub (scaffold)');
+      expect(reviewContent).toContain('WO-ISS-001');
+      expect(reviewContent).toContain('WO-ISS-002');
+      expect(reviewContent).toContain('pass_with_warnings');
+      expect(reviewContent).toContain('Coverage');
+    });
+
+    it('should handle missing prior stage outputs gracefully', async () => {
+      const result = JSON.parse(await ExecutionScaffoldGenerator.review(session));
+
+      expect(result.workOrdersReviewed).toBe(0);
+
+      const reviewContent = await readFile(result.reviewPath, 'utf-8');
+      expect(reviewContent).toContain('No work orders found');
+      expect(reviewContent).toContain('No V&V report found');
+    });
+  });
+
+  // --------------------------------------------------------------------------
+  // Full Pipeline Integration
+  // --------------------------------------------------------------------------
+
+  describe('full pipeline flow', () => {
+    it('should produce a complete scaffold from issue_list through review', async () => {
+      const issueDir = join(scratchpadDir, 'issues', 'test-project');
+      await writeTestIssueList(issueDir, 4);
+
+      // Stage 1: Controller
+      const controllerResult = JSON.parse(await ExecutionScaffoldGenerator.controller(session));
+      expect(controllerResult.workOrderCount).toBe(4);
+
+      // Stage 2: Worker
+      const workerResult = JSON.parse(await ExecutionScaffoldGenerator.worker(session));
+      expect(workerResult.functionCount).toBe(4);
+
+      // Stage 3: Validation
+      const validationResult = JSON.parse(await ExecutionScaffoldGenerator.validation(session));
+      expect(validationResult.overallResult).toBe('pass_with_warnings');
+
+      // Stage 4: Review
+      const reviewResult = JSON.parse(await ExecutionScaffoldGenerator.review(session));
+      expect(reviewResult.workOrdersReviewed).toBe(4);
+
+      // Verify file structure
+      const woFiles = await readdir(controllerResult.workOrderDir);
+      expect(woFiles).toHaveLength(4);
+
+      const srcFiles = await readdir(join(projectDir, 'src'));
+      expect(srcFiles).toContain('index.ts');
+
+      const reviewContent = await readFile(reviewResult.reviewPath, 'utf-8');
+      expect(reviewContent).toContain('WO-ISS-004');
+    });
+  });
+});


### PR DESCRIPTION
## What

### Summary
Adds scaffold output generation for the 4 execution pipeline stages (controller, worker, validation, review) when running in local+stub mode, producing meaningful files instead of generic stub strings.

### Change Type
- [x] Feature (new functionality)

### Affected Components
- New: `src/agents/ExecutionScaffoldGenerator.ts`
- Updated: `src/agents/AgentDispatcher.ts`

## Why

### Related Issues
- Closes #719

### Problem
Execution stages completed with `"Agent X executed..."` stub strings, producing zero artifacts (no work orders, source code, V&V results, or review documents).

## How

### Implementation
1. **Controller**: Reads issue_list.json, generates work order files per issue
2. **Worker**: Reads work orders, generates `src/index.ts` with function stubs + `package.json`
3. **Validation**: Generates V&V report with requirement coverage
4. **Review**: Generates review checklist document
5. **Security**: `sanitizeId()` prevents path traversal via malicious issue IDs
6. **Routing**: `createScaffoldAdapter()` in AgentDispatcher routes to scaffolds when localMode + stub

### Testing Done
- [x] 17 new tests (12 unit + 5 integration including path traversal test)
- [x] 269 existing agent tests pass
- [x] Build clean

### Breaking Changes
None — scaffold only activates in localMode + stub conditions.