### PR TITLE
fix(issue-generator): break circular dependencies instead of throwing

### DIFF
--- a/src/issue-generator/DependencyGraph.ts
+++ b/src/issue-generator/DependencyGraph.ts
@@ -186,8 +186,10 @@ export class DependencyGraphBuilder {
    */
   private removeCycleEdge(cycle: string[]): void {
     // Remove the back-edge: from the second-to-last node to the first node
-    const from = cycle[cycle.length - 2]!;
-    const to = cycle[cycle.length - 1]!;
+    const from = cycle[cycle.length - 2];
+    const to = cycle[cycle.length - 1];
+
+    if (from === undefined || to === undefined) return;
 
     const fromNode = this.nodes.get(from);
     const toNode = this.nodes.get(to);

--- a/src/issue-generator/DependencyGraph.ts
+++ b/src/issue-generator/DependencyGraph.ts
@@ -13,7 +13,7 @@ import type {
   DependencyType,
   ParallelGroup,
 } from './types.js';
-import { CircularDependencyError, ComponentNotFoundError } from './errors.js';
+import { ComponentNotFoundError } from './errors.js';
 
 /**
  * Internal node representation for graph algorithms
@@ -29,11 +29,22 @@ interface InternalNode {
 }
 
 /**
+ * Represents a cycle that was detected and broken in the dependency graph
+ */
+interface BrokenCycle {
+  /** The chain of issue IDs forming the cycle */
+  cycle: readonly string[];
+  /** The edge that was removed to break the cycle (from -> to) */
+  removedEdge: { from: string; to: string };
+}
+
+/**
  * Builds and analyzes dependency graphs
  */
 export class DependencyGraphBuilder {
   private nodes: Map<string, InternalNode> = new Map();
   private componentToIssue: Map<string, string> = new Map();
+  private brokenCycles: BrokenCycle[] = [];
 
   /**
    * Build a dependency graph from SDS components
@@ -87,8 +98,8 @@ export class DependencyGraphBuilder {
       }
     }
 
-    // Detect cycles
-    this.detectCycles();
+    // Detect and break cycles (instead of throwing)
+    this.breakCycles();
 
     // Calculate depths
     this.calculateDepths();
@@ -103,31 +114,50 @@ export class DependencyGraphBuilder {
   private reset(): void {
     this.nodes.clear();
     this.componentToIssue.clear();
+    this.brokenCycles = [];
   }
 
   /**
-   * Detect circular dependencies using DFS
-   * @throws CircularDependencyError if a cycle is detected
+   * Detect and break circular dependencies.
+   *
+   * Instead of throwing on cycles, this method removes back-edges
+   * to produce a valid DAG while recording the broken cycles as warnings.
+   * Mutual dependencies between components are common in real software,
+   * so hard-failing is too aggressive for practical use.
    */
-  private detectCycles(): void {
-    for (const node of this.nodes.values()) {
-      node.visited = false;
-      node.inStack = false;
-    }
+  private breakCycles(): void {
+    this.brokenCycles = [];
+    let hasCycles = true;
 
-    for (const node of this.nodes.values()) {
-      if (!node.visited) {
-        this.dfsDetectCycle(node, []);
+    // Iterate until no more cycles remain (each pass breaks one cycle)
+    while (hasCycles) {
+      hasCycles = false;
+
+      for (const node of this.nodes.values()) {
+        node.visited = false;
+        node.inStack = false;
+      }
+
+      for (const node of this.nodes.values()) {
+        if (!node.visited) {
+          const cycle = this.dfsFindCycle(node, []);
+          if (cycle) {
+            this.removeCycleEdge(cycle);
+            hasCycles = true;
+            break; // restart full DFS after graph mutation
+          }
+        }
       }
     }
   }
 
   /**
-   * DFS helper for cycle detection
-   * @param node - The current node being visited in the DFS traversal
-   * @param path - The current path of node IDs from the DFS root to this node
+   * DFS helper that returns the first cycle found, or null if none.
+   * @param node - Current node in DFS traversal
+   * @param path - Current path from DFS root
+   * @returns Array of node IDs forming the cycle, or null
    */
-  private dfsDetectCycle(node: InternalNode, path: string[]): void {
+  private dfsFindCycle(node: InternalNode, path: string[]): string[] | null {
     node.visited = true;
     node.inStack = true;
     path.push(node.id);
@@ -137,16 +167,42 @@ export class DependencyGraphBuilder {
       if (!depNode) continue;
 
       if (!depNode.visited) {
-        this.dfsDetectCycle(depNode, [...path]);
+        const cycle = this.dfsFindCycle(depNode, [...path]);
+        if (cycle) return cycle;
       } else if (depNode.inStack) {
-        // Found a cycle
         const cycleStart = path.indexOf(depId);
-        const cycle = [...path.slice(cycleStart), depId];
-        throw new CircularDependencyError(cycle);
+        return [...path.slice(cycleStart), depId];
       }
     }
 
     node.inStack = false;
+    return null;
+  }
+
+  /**
+   * Remove the back-edge of a cycle to break it.
+   * Chooses the last edge in the cycle (the back-edge that closes the loop).
+   * @param cycle - Array of node IDs forming the cycle (last element == first element)
+   */
+  private removeCycleEdge(cycle: string[]): void {
+    // Remove the back-edge: from the second-to-last node to the first node
+    const from = cycle[cycle.length - 2]!;
+    const to = cycle[cycle.length - 1]!;
+
+    const fromNode = this.nodes.get(from);
+    const toNode = this.nodes.get(to);
+
+    if (fromNode) {
+      fromNode.dependencies.delete(to);
+    }
+    if (toNode) {
+      toNode.dependents.delete(from);
+    }
+
+    this.brokenCycles.push({
+      cycle,
+      removedEdge: { from, to },
+    });
   }
 
   /**
@@ -210,11 +266,17 @@ export class DependencyGraphBuilder {
     const executionOrder = this.topologicalSort();
     const parallelGroups = this.buildParallelGroups();
 
+    const warnings = this.brokenCycles.map(
+      (bc) =>
+        `Circular dependency broken: ${bc.cycle.join(' -> ')} (removed edge: ${bc.removedEdge.from} -> ${bc.removedEdge.to})`
+    );
+
     return {
       nodes,
       edges,
       executionOrder,
       parallelGroups,
+      warnings,
     };
   }
 

--- a/src/issue-generator/types.ts
+++ b/src/issue-generator/types.ts
@@ -264,6 +264,8 @@ export interface DependencyGraph {
   readonly executionOrder: readonly string[];
   /** Parallelizable groups */
   readonly parallelGroups: readonly ParallelGroup[];
+  /** Warnings about broken cycles or other graph issues */
+  readonly warnings: readonly string[];
 }
 
 /**

--- a/tests/e2e/error-recovery-edge-cases.e2e.test.ts
+++ b/tests/e2e/error-recovery-edge-cases.e2e.test.ts
@@ -454,9 +454,12 @@ Build a modular system.
 
         // When: Building dependency graph
         const builder = new DependencyGraphBuilder();
+        const graph = builder.build(components, componentToIssue);
 
-        // Then: Should detect cycle and throw
-        expect(() => builder.build(components, componentToIssue)).toThrow(CircularDependencyError);
+        // Then: Should break cycle gracefully with warnings
+        expect(graph.warnings.length).toBeGreaterThan(0);
+        expect(graph.warnings[0]).toContain('Circular dependency broken');
+        expect(graph.executionOrder.length).toBe(2);
       });
 
       it('should detect complex circular dependency chain', () => {
@@ -500,25 +503,15 @@ Build a modular system.
           ['CMP-003', 'ISSUE-003'],
         ]);
 
-        // When/Then: Should detect cycle and throw
+        // When: Building graph with cycle
         const builder = new DependencyGraphBuilder();
-        let caughtError: Error | undefined;
+        const graph = builder.build(components, componentToIssue);
 
-        try {
-          builder.build(components, componentToIssue);
-        } catch (error) {
-          caughtError = error as Error;
-        }
-
-        // Verify error was caught and is CircularDependencyError
-        expect(caughtError).toBeDefined();
-        expect(caughtError).toBeInstanceOf(CircularDependencyError);
-
-        const cycleError = caughtError as CircularDependencyError;
-        // Cycle should contain at least 2 nodes (the cycle itself)
-        expect(cycleError.cycle.length).toBeGreaterThanOrEqual(2);
-        // Cycle should involve the nodes that form the cycle
-        expect(cycleError.cycle.some((id) => id.includes('ISSUE'))).toBe(true);
+        // Then: Cycle should be broken with warnings
+        expect(graph.warnings.length).toBeGreaterThan(0);
+        expect(graph.warnings[0]).toContain('Circular dependency broken');
+        // All 3 nodes should be in execution order (cycle broken, not removed)
+        expect(graph.executionOrder.length).toBe(3);
       });
 
       it('should handle self-referencing dependency', () => {
@@ -538,9 +531,13 @@ Build a modular system.
 
         const componentToIssue = new Map([['CMP-001', 'ISSUE-001']]);
 
-        // When/Then: Should detect self-cycle
+        // When: Building graph with self-cycle
         const builder = new DependencyGraphBuilder();
-        expect(() => builder.build(components, componentToIssue)).toThrow(CircularDependencyError);
+        const graph = builder.build(components, componentToIssue);
+
+        // Then: Self-cycle should be broken
+        expect(graph.warnings.length).toBeGreaterThan(0);
+        expect(graph.executionOrder.length).toBe(1);
       });
 
       it('should allow valid dependency graph without cycles', () => {

--- a/tests/e2e/helpers/pipeline-runner.ts
+++ b/tests/e2e/helpers/pipeline-runner.ts
@@ -156,6 +156,20 @@ export async function runPipeline(
       const issuesStart = Date.now();
       issues = await runIssueGenerationStage(env, projectId);
       timing.issues = Date.now() - issuesStart;
+
+      if (!issues.success) {
+        return {
+          success: false,
+          projectId,
+          collection: collection.result,
+          prd: prd.result,
+          srs: srs.result,
+          sds: sds.result,
+          totalTimeMs: Date.now() - startTime,
+          timing,
+          error: issues.error,
+        };
+      }
     }
 
     return {

--- a/tests/issue-generator/DependencyGraph.test.ts
+++ b/tests/issue-generator/DependencyGraph.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect } from 'vitest';
 import {
   DependencyGraphBuilder,
   SDSComponent,
-  CircularDependencyError,
   ComponentNotFoundError,
 } from '../../src/issue-generator/index.js';
 
@@ -110,7 +109,7 @@ describe('DependencyGraphBuilder', () => {
       expect(node3?.depth).toBe(2);
     });
 
-    it('should throw CircularDependencyError for cycles', () => {
+    it('should break circular dependencies and report warnings', () => {
       const components = [
         createComponent('CMP-001', ['CMP-003']),
         createComponent('CMP-002', ['CMP-001']),
@@ -118,9 +117,14 @@ describe('DependencyGraphBuilder', () => {
       ];
       const mapping = createMapping(components);
 
-      expect(() => builder.build(components, mapping)).toThrow(
-        CircularDependencyError
-      );
+      const graph = builder.build(components, mapping);
+
+      // Should not throw — cycles are broken gracefully
+      expect(graph.nodes.length).toBe(3);
+      expect(graph.warnings.length).toBeGreaterThan(0);
+      expect(graph.warnings[0]).toContain('Circular dependency broken');
+      // Graph should still have a valid execution order
+      expect(graph.executionOrder.length).toBe(3);
     });
 
     it('should throw ComponentNotFoundError for missing mapping', () => {


### PR DESCRIPTION
Closes #732

## Summary
- **DependencyGraphBuilder** now breaks circular dependencies by removing back-edges instead of throwing `CircularDependencyError`
- Produces a valid DAG with warnings, allowing issue generation to proceed when SDS components have mutual references
- Fixes `runPipeline` to propagate issue generation failures instead of silently returning `undefined`

## What Changed

| File | Change |
|------|--------|
| `src/issue-generator/DependencyGraph.ts` | Replace `detectCycles()` (throws) with `breakCycles()` (removes back-edges, records warnings) |
| `src/issue-generator/types.ts` | Add `warnings: readonly string[]` to `DependencyGraph` interface |
| `tests/e2e/helpers/pipeline-runner.ts` | Propagate issue stage failure in `runPipeline` |
| `tests/issue-generator/DependencyGraph.test.ts` | Update cycle test to expect warnings instead of throw |
| `tests/e2e/error-recovery-edge-cases.e2e.test.ts` | Update 3 circular dependency tests for new behavior |

## Root Cause
The `MEDIUM_FEATURE_INPUT` fixture generates SDS components with bidirectional dependencies (e.g., `CMP-001 -> CMP-004 -> CMP-001`). `DependencyGraphBuilder.detectCycles()` threw `CircularDependencyError`, causing all 4 E2E test failures. Mutual component references are common in real software architectures.

## Test Plan
- [x] `tests/issue-generator/DependencyGraph.test.ts` — all 10 pass
- [x] `tests/e2e/agent-transitions.e2e.test.ts` — all 9 pass (previously 2 failed)
- [x] `tests/e2e/document-traceability.e2e.test.ts` — all 13 pass (previously 2 failed)
- [x] `tests/e2e/error-recovery-edge-cases.e2e.test.ts` — all 38 pass
- [x] TypeScript type check passes