### PR TITLE
feat(pipeline): add doc_indexing as post-pipeline stage

### DIFF
--- a/.claude/agents/doc-index-generator.md
+++ b/.claude/agents/doc-index-generator.md
@@ -1,0 +1,104 @@
+---
+name: doc-index-generator
+description: |
+  Documentation Index Generator Agent. Generates structured YAML index files
+  (manifest, bundles, graph, router) from pipeline-generated documents.
+  Runs as the final pipeline stage after review to ensure complete cross-references.
+tools:
+  - Read
+  - Write
+  - Glob
+  - Grep
+  - Bash
+model: inherit
+---
+
+# Documentation Index Generator Agent
+
+## Role
+
+You are a Documentation Index Generator Agent responsible for creating searchable
+indexes and cross-reference maps from pipeline-generated documents (PRD, SRS, SDS).
+
+## Primary Responsibilities
+
+1. Discover all markdown documents in the project
+2. Classify documents by directory path and content
+3. Generate `docs/.index/manifest.yaml` — document registry with metadata
+4. Generate `docs/.index/bundles.yaml` — feature-grouped document sets
+5. Generate `docs/.index/graph.yaml` — cross-reference dependency graph
+6. Generate `docs/.index/router.yaml` — query-to-bundle routing
+
+## Input Specification
+
+| Input | Source | Description |
+|-------|--------|-------------|
+| Pipeline artifacts | `.ad-sdlc/scratchpad/documents/{projectId}/` | PRD, SRS, SDS markdown files |
+| Public docs | `docs/` | Published documentation directory |
+| Existing index | `docs/.index/` (if present) | Previous index for incremental updates |
+
+## Output Specification
+
+| File | Required | Description |
+|------|----------|-------------|
+| `docs/.index/manifest.yaml` | Yes | Document registry with metadata, sections, keywords |
+| `docs/.index/bundles.yaml` | No | Feature-grouped document sets with line ranges |
+| `docs/.index/graph.yaml` | No | Cross-reference dependency graph |
+| `docs/.index/router.yaml` | No | Query-to-bundle routing with keyword mapping |
+
+## Workflow
+
+### Phase 1: Document Discovery
+
+1. Find all `.md` files excluding `.git/`, `node_modules/`, `docs/.index/`
+2. Determine mode:
+   - **Flat mode** (<50% files have `doc_id` frontmatter): path-based classification
+   - **Grouped mode** (>=50%): semantic classification using frontmatter
+
+### Phase 2: Index Generation
+
+1. Create `docs/.index/` directory if needed
+2. Generate manifest with document metadata (title, path, keywords, sections)
+3. Group documents into bundles by feature domain
+4. Build cross-reference graph from markdown links between files
+5. Generate keyword-to-bundle router
+
+### Phase 3: Incremental Update (Enhancement Mode)
+
+When existing indexes exist:
+1. Read current `manifest.yaml` to identify known documents
+2. Detect added, modified, or removed documents
+3. Update only affected entries in all 4 index files
+4. Preserve `custom:` sections in `bundles.yaml`
+
+## Error Handling
+
+| Scenario | Action |
+|----------|--------|
+| No documents found | Generate empty manifest, warn |
+| Malformed markdown | Skip file, log warning |
+| Existing index corrupt | Regenerate from scratch |
+| Write permission error | Report failure, do not block pipeline |
+
+## Result Schema
+
+```yaml
+success: true
+artifacts:
+  - docs/.index/manifest.yaml
+  - docs/.index/bundles.yaml
+  - docs/.index/graph.yaml
+  - docs/.index/router.yaml
+stats:
+  documentsIndexed: <number>
+  bundlesCreated: <number>
+  crossReferences: <number>
+  processingTimeMs: <number>
+```
+
+## Related Agents
+
+- **PRD Writer** — generates PRD documents indexed by this agent
+- **SRS Writer** — generates SRS documents indexed by this agent
+- **SDS Writer** — generates SDS documents indexed by this agent
+- **PR Reviewer** — review stage that precedes doc indexing

--- a/src/ad-sdlc-orchestrator/ArtifactValidator.ts
+++ b/src/ad-sdlc-orchestrator/ArtifactValidator.ts
@@ -144,6 +144,31 @@ export const GREENFIELD_ARTIFACTS: readonly StageArtifactMap[] = [
       },
     ],
   },
+  {
+    stage: 'doc_indexing' as StageName,
+    requiredArtifacts: [
+      {
+        pathPattern: 'docs/.index/manifest.yaml',
+        description: 'Document manifest index',
+        required: true,
+      },
+      {
+        pathPattern: 'docs/.index/bundles.yaml',
+        description: 'Document bundles',
+        required: false,
+      },
+      {
+        pathPattern: 'docs/.index/graph.yaml',
+        description: 'Cross-reference graph',
+        required: false,
+      },
+      {
+        pathPattern: 'docs/.index/router.yaml',
+        description: 'Query router',
+        required: false,
+      },
+    ],
+  },
 ];
 
 /**
@@ -251,6 +276,16 @@ export const ENHANCEMENT_ARTIFACTS: readonly StageArtifactMap[] = [
       {
         pathPattern: '.ad-sdlc/scratchpad/vnv/*/validation-report.yaml',
         description: 'Validation report',
+        required: true,
+      },
+    ],
+  },
+  {
+    stage: 'doc_indexing' as StageName,
+    requiredArtifacts: [
+      {
+        pathPattern: 'docs/.index/manifest.yaml',
+        description: 'Document manifest index',
         required: true,
       },
     ],

--- a/src/ad-sdlc-orchestrator/types.ts
+++ b/src/ad-sdlc-orchestrator/types.ts
@@ -28,7 +28,8 @@ export type GreenfieldStageName =
   | 'orchestration'
   | 'implementation'
   | 'validation'
-  | 'review';
+  | 'review'
+  | 'doc_indexing';
 
 /**
  * Pipeline stage names for Enhancement mode
@@ -47,7 +48,8 @@ export type EnhancementStageName =
   | 'implementation'
   | 'regression_testing'
   | 'validation'
-  | 'review';
+  | 'review'
+  | 'doc_indexing';
 
 /**
  * Pipeline stage names for Import mode
@@ -415,6 +417,14 @@ export const GREENFIELD_STAGES: readonly PipelineStageDefinition[] = [
     approvalRequired: false,
     dependsOn: ['validation'],
   },
+  {
+    name: 'doc_indexing',
+    agentType: 'doc-index-generator',
+    description: 'Generate searchable documentation index from pipeline artifacts',
+    parallel: false,
+    approvalRequired: false,
+    dependsOn: ['review'],
+  },
 ];
 
 /**
@@ -536,6 +546,14 @@ export const ENHANCEMENT_STAGES: readonly PipelineStageDefinition[] = [
     parallel: false,
     approvalRequired: false,
     dependsOn: ['validation'],
+  },
+  {
+    name: 'doc_indexing',
+    agentType: 'doc-index-generator',
+    description: 'Generate searchable documentation index from pipeline artifacts',
+    parallel: false,
+    approvalRequired: false,
+    dependsOn: ['review'],
   },
 ];
 

--- a/tests/ad-sdlc-orchestrator/AdsdlcOrchestratorAgent.test.ts
+++ b/tests/ad-sdlc-orchestrator/AdsdlcOrchestratorAgent.test.ts
@@ -1190,13 +1190,13 @@ describe('AdsdlcOrchestratorAgent', () => {
 });
 
 describe('GREENFIELD_STAGES', () => {
-  it('should define 13 stages', () => {
-    expect(GREENFIELD_STAGES).toHaveLength(13);
+  it('should define 14 stages', () => {
+    expect(GREENFIELD_STAGES).toHaveLength(14);
   });
 
-  it('should start with initialization and end with review', () => {
+  it('should start with initialization and end with doc_indexing', () => {
     expect(GREENFIELD_STAGES[0]!.name).toBe('initialization');
-    expect(GREENFIELD_STAGES[GREENFIELD_STAGES.length - 1]!.name).toBe('review');
+    expect(GREENFIELD_STAGES[GREENFIELD_STAGES.length - 1]!.name).toBe('doc_indexing');
   });
 
   it('should have valid dependency chains', () => {
@@ -1223,8 +1223,8 @@ describe('GREENFIELD_STAGES', () => {
 });
 
 describe('ENHANCEMENT_STAGES', () => {
-  it('should define 14 stages', () => {
-    expect(ENHANCEMENT_STAGES).toHaveLength(14);
+  it('should define 15 stages', () => {
+    expect(ENHANCEMENT_STAGES).toHaveLength(15);
   });
 
   it('should start with parallel analysis stages', () => {
@@ -1233,11 +1233,10 @@ describe('ENHANCEMENT_STAGES', () => {
     expect(firstThree.every((s) => s.dependsOn.length === 0)).toBe(true);
   });
 
-  it('should end with regression testing, validation, and review', () => {
-    const lastThree = ENHANCEMENT_STAGES.slice(-3);
-    expect(lastThree[0]!.name).toBe('regression_testing');
-    expect(lastThree[1]!.name).toBe('validation');
-    expect(lastThree[2]!.name).toBe('review');
+  it('should end with review and doc_indexing', () => {
+    const lastTwo = ENHANCEMENT_STAGES.slice(-2);
+    expect(lastTwo[0]!.name).toBe('review');
+    expect(lastTwo[1]!.name).toBe('doc_indexing');
   });
 
   it('should have doc_code_comparison depend on all three analysis stages', () => {

--- a/tests/e2e/helpers/pipeline-runner.ts
+++ b/tests/e2e/helpers/pipeline-runner.ts
@@ -642,6 +642,14 @@ export async function placeMockArtifacts(
       case 'sds_update':
         await placeMockArtifacts(projectDir, ['sds_generation'], projectId);
         break;
+      case 'doc_indexing':
+        await fs.mkdir(path.join(projectDir, 'docs', '.index'), { recursive: true });
+        await fs.writeFile(
+          path.join(projectDir, 'docs', '.index', 'manifest.yaml'),
+          '_meta: {schema: "1.0.0"}\n',
+          'utf-8'
+        );
+        break;
       // Stages without artifact definitions (mode_detection, repo_detection, etc.) — no-op
       default:
         break;


### PR DESCRIPTION
Closes #736

## Summary
- Add `doc_indexing` stage to greenfield (14th stage) and enhancement (15th stage) pipelines
- Stage runs after `review` to generate structured documentation indexes
- Produces 4 YAML files: `manifest.yaml`, `bundles.yaml`, `graph.yaml`, `router.yaml`
- Non-blocking: stage failure does not prevent pipeline completion

## What Changed

| File | Change |
|------|--------|
| `src/ad-sdlc-orchestrator/types.ts` | Add `doc_indexing` to stage name types and both pipeline arrays |
| `src/ad-sdlc-orchestrator/ArtifactValidator.ts` | Add artifact definitions for greenfield and enhancement |
| `.claude/agents/doc-index-generator.md` | New agent definition with role, workflow, and error handling |
| `tests/e2e/helpers/pipeline-runner.ts` | Add `doc_indexing` case in `placeMockArtifacts` |
| `tests/ad-sdlc-orchestrator/AdsdlcOrchestratorAgent.test.ts` | Update stage count and end-stage assertions |

## Design Decisions
- **Post-pipeline, not per-document**: Cross-reference graph requires all documents to exist
- **After review**: Ensures all code changes are merged before indexing
- **Not in import mode**: Import pipeline has no document generation to index
- **Non-critical**: `approvalRequired: false`, failure doesn't block the pipeline

## Test Plan
- [x] `GREENFIELD_STAGES` — 14 stages, valid dependency chain, topological order
- [x] `ENHANCEMENT_STAGES` — 15 stages, ends with `doc_indexing`
- [x] `IMPORT_STAGES` — unchanged at 5 stages
- [x] Pipeline dependency chain validation — no circular dependencies
- [x] Cross-pipeline agent type consistency
- [x] TypeScript type check passes