### PR TITLE
docs: reconcile claude-config-reference.md with actual rule paths

### DIFF
--- a/docs/claude-config-reference.md
+++ b/docs/claude-config-reference.md
@@ -19,29 +19,44 @@ claude-config is a Claude Code configuration management and development guidelin
 | **project-workflow** | Git, issues, PR management | `.claude/skills/project-workflow/` |
 | **documentation** | README, API docs, comments | `.claude/skills/documentation/` |
 
-### Guidelines (Detailed Guidelines)
+### Rules (`.claude/rules/`)
+
+Rules are loaded automatically by Claude Code based on `alwaysApply` and `paths` frontmatter.
 
 ```
-claude-guidelines/
-├── coding-standards/
-│   ├── general.md          # Naming, modularity, comments
-│   ├── quality.md          # Complexity, refactoring, SOLID
+.claude/rules/
+├── core/
+│   ├── principles.md       # Think, Minimize, Verify (alwaysApply)
+│   ├── communication.md    # English code, Korean conversation (alwaysApply)
+│   └── environment.md      # KST, Korean locale (alwaysApply)
+├── coding/
+│   ├── standards.md        # Naming, modularity, SOLID, quality
 │   ├── error-handling.md   # Error patterns, validation
-│   ├── concurrency.md      # Thread safety, async
-│   ├── memory.md           # RAII, GC, memory leaks
-│   └── performance.md      # Profiling, caching, algorithms
+│   ├── performance.md      # Profiling, caching, algorithms
+│   ├── safety.md           # Safe code practices
+│   ├── implementation-standards.md  # Tier implementation
+│   └── cpp-specifics.md    # C++ specific rules
+├── api/
+│   ├── api-design.md       # REST, GraphQL design
+│   ├── architecture.md     # SOLID, layered design
+│   ├── observability.md    # Logging, metrics, tracing
+│   └── rest-api.md         # REST conventions
 ├── project-management/
 │   ├── build.md            # Build, dependency management
 │   ├── testing.md          # Unit/integration/E2E tests
 │   └── documentation.md    # API docs, README
-├── api-architecture/
-│   ├── api-design.md       # REST, GraphQL
-│   ├── architecture.md     # SOLID, patterns, microservices
-│   ├── logging.md          # Structured logging
-│   └── observability.md    # Metrics, tracing
-├── security.md             # Input validation, auth, secure coding
-└── ...
+├── security.md             # Input validation, auth, OWASP Top 10
+└── workflow/
+    ├── git-commit-format.md    # Conventional Commits
+    ├── github-issue-5w1h.md    # Issue framework
+    └── github-pr-5w1h.md       # PR framework
 ```
+
+> **Note**: `coding-standards/` was renamed to `coding/`, and `api-architecture/` to `api/`.
+> `quality.md` and `concurrency.md` were merged into `standards.md`.
+> `logging.md` was merged into `observability.md`.
+
+*Last reconciled: 2026-04-11*
 
 ## Recommended References by Agent
 
@@ -51,10 +66,10 @@ Responsible for code implementation. Requires the most guideline references.
 
 | Reference Resource | Purpose |
 |--------------------|---------|
-| `coding-standards/general.md` | Naming rules, code structure |
-| `coding-standards/error-handling.md` | Exception handling patterns |
+| `coding/standards.md` | Naming rules, code structure, quality |
+| `coding/error-handling.md` | Exception handling patterns |
 | `project-management/testing.md` | Test writing rules (AAA pattern) |
-| `coding-standards/concurrency.md` | For async code writing |
+| `coding/implementation-standards.md` | Complete tier implementation |
 
 **Prompt Example**:
 ```markdown
@@ -87,8 +102,8 @@ Responsible for code review. Focuses on quality and security guidelines.
 | Reference Resource | Purpose |
 |--------------------|---------|
 | `security.md` | Security vulnerability checklist |
-| `coding-standards/quality.md` | Code quality criteria |
-| `coding-standards/performance.md` | Performance issue identification |
+| `coding/standards.md` | Code quality criteria |
+| `coding/performance.md` | Performance issue identification |
 
 **Prompt Example**:
 ```markdown
@@ -101,7 +116,7 @@ Responsible for code review. Focuses on quality and security guidelines.
 - [ ] No hardcoded secrets or credentials
 - [ ] Proper authentication/authorization checks
 
-### Code Quality (from claude-config/coding-standards/quality.md)
+### Code Quality (from claude-config/coding/standards.md)
 - [ ] Cyclomatic complexity < 10 per function
 - [ ] No code duplication (DRY principle)
 - [ ] Single Responsibility Principle
@@ -114,9 +129,9 @@ Responsible for software design documentation. Focuses on API/architecture guide
 
 | Reference Resource | Purpose |
 |--------------------|---------|
-| `api-architecture/api-design.md` | REST/GraphQL design patterns |
-| `api-architecture/architecture.md` | Architecture patterns, SOLID |
-| `api-architecture/observability.md` | Monitoring, health check design |
+| `api/api-design.md` | REST/GraphQL design patterns |
+| `api/architecture.md` | Architecture patterns, SOLID |
+| `api/observability.md` | Monitoring, health check design |
 
 **Prompt Example**:
 ```markdown
@@ -161,7 +176,7 @@ Document writing agents.
 curl -s https://raw.githubusercontent.com/kcenon/claude-config/main/project/.claude/skills/coding-guidelines/SKILL.md
 
 # View specific guideline
-curl -s https://raw.githubusercontent.com/kcenon/claude-config/main/project/claude-guidelines/coding-standards/general.md
+curl -s https://raw.githubusercontent.com/kcenon/claude-config/main/project/claude-config/rules/coding/general.md
 ```
 
 ### Method 2: Local Clone
@@ -171,7 +186,7 @@ curl -s https://raw.githubusercontent.com/kcenon/claude-config/main/project/clau
 git clone https://github.com/kcenon/claude-config.git ../claude-config
 
 # Reference in agent prompt
-# "Follow ../claude-config/project/claude-guidelines/ when generating code"
+# "Follow ../claude-config/project/.claude/rules/ when generating code"
 ```
 
 ### Method 3: Direct Inclusion in Agent Prompts
@@ -196,14 +211,14 @@ model: inherit
 
 Follow these rules when generating code:
 
-### From claude-config/coding-standards
+### From claude-config/coding
 1. Naming: camelCase (variables), PascalCase (classes), UPPER_SNAKE_CASE (constants)
 2. Error handling: Use specific error types, distinguish recoverability
 3. Testing: AAA pattern, 80%+ coverage
 
 ### Reference Links
-- [Full Coding Guidelines](https://github.com/kcenon/claude-config/blob/main/project/claude-guidelines/coding-standards/general.md)
-- [Error Handling](https://github.com/kcenon/claude-config/blob/main/project/claude-guidelines/coding-standards/error-handling.md)
+- [Full Coding Guidelines](https://github.com/kcenon/claude-config/blob/main/project/claude-config/rules/coding/general.md)
+- [Error Handling](https://github.com/kcenon/claude-config/blob/main/project/claude-config/rules/coding/error-handling.md)
 ```
 
 ## Expected Benefits


### PR DESCRIPTION
Closes #740

## Summary
- Update all path references in `claude-config-reference.md` to match actual `.claude/rules/` structure
- Remove references to non-existent files (`concurrency.md`, `memory.md`, `logging.md`)
- Add reconciliation date stamp for future sync tracking

## Path Changes

| Old Path | New Path | Reason |
|----------|----------|--------|
| `coding-standards/general.md` | `coding/standards.md` | Directory renamed, file merged |
| `coding-standards/quality.md` | `coding/standards.md` | Merged into standards.md |
| `coding-standards/error-handling.md` | `coding/error-handling.md` | Directory renamed |
| `coding-standards/concurrency.md` | *(removed)* | Does not exist |
| `coding-standards/memory.md` | *(removed)* | Does not exist |
| `coding-standards/performance.md` | `coding/performance.md` | Directory renamed |
| `api-architecture/api-design.md` | `api/api-design.md` | Directory renamed |
| `api-architecture/architecture.md` | `api/architecture.md` | Directory renamed |
| `api-architecture/logging.md` | *(removed)* | Merged into observability.md |
| `api-architecture/observability.md` | `api/observability.md` | Directory renamed |

## Test Plan
- [x] All referenced paths exist in `.claude/rules/`
- [x] No broken path references remain in the document
- [x] Directory tree in document matches actual structure