### PR TITLE
fix(tests): align SecretManager tests with ANTHROPIC_API_KEY rename

### DIFF
--- a/tests/ad-sdlc-orchestrator/localMode.test.ts
+++ b/tests/ad-sdlc-orchestrator/localMode.test.ts
@@ -146,17 +146,17 @@ describe('adaptStagesForLocalMode', () => {
 });
 
 describe('getRequiredSecrets', () => {
-  it('should return only CLAUDE_API_KEY in local mode', async () => {
+  it('should return only ANTHROPIC_API_KEY in local mode', async () => {
     const { getRequiredSecrets } = await import('../../src/security/SecretManager.js');
     const secrets = getRequiredSecrets(true);
-    expect(secrets).toContain('CLAUDE_API_KEY');
+    expect(secrets).toContain('ANTHROPIC_API_KEY');
     expect(secrets).not.toContain('GITHUB_TOKEN');
   });
 
   it('should return both secrets in GitHub mode', async () => {
     const { getRequiredSecrets } = await import('../../src/security/SecretManager.js');
     const secrets = getRequiredSecrets(false);
-    expect(secrets).toContain('CLAUDE_API_KEY');
+    expect(secrets).toContain('ANTHROPIC_API_KEY');
     expect(secrets).toContain('GITHUB_TOKEN');
   });
 });

--- a/tests/security/SecretManager.test.ts
+++ b/tests/security/SecretManager.test.ts
@@ -133,7 +133,10 @@ describe('SecretManager', () => {
         delete process.env['ANTHROPIC_API_KEY'];
 
         const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-        const manager = new SecretManager({ throwOnMissing: true });
+        const manager = new SecretManager({
+          requiredSecrets: ['ANTHROPIC_API_KEY'],
+          throwOnMissing: true,
+        });
         manager.load();
 
         expect(manager.has('ANTHROPIC_API_KEY')).toBe(true);


### PR DESCRIPTION
## Summary

Fix pre-existing CI test failures on main caused by incomplete test updates after the `CLAUDE_API_KEY` → `ANTHROPIC_API_KEY` env var rename in commit 16a5e72.

## Why

Main has been failing CI on every subsequent PR since 16a5e72 (most recently observed on PR #756, #745, and main HEAD). The failing tests:

1. `tests/ad-sdlc-orchestrator/localMode.test.ts:152` — expected `['ANTHROPIC_API_KEY']` to contain `'CLAUDE_API_KEY'`
2. `tests/ad-sdlc-orchestrator/localMode.test.ts:159` — same pattern
3. `tests/security/SecretManager.test.ts:137` — `SecretNotFoundError: Secret not found: GITHUB_TOKEN`

All failures trace to the source rename: `src/security/SecretManager.ts:16` sets `CORE_REQUIRED_SECRETS = ['ANTHROPIC_API_KEY']`, but the tests were not updated.

## How

### `tests/ad-sdlc-orchestrator/localMode.test.ts`

Update the `getRequiredSecrets` assertions to expect `ANTHROPIC_API_KEY`:

```diff
- expect(secrets).toContain('CLAUDE_API_KEY');
+ expect(secrets).toContain('ANTHROPIC_API_KEY');
```

### `tests/security/SecretManager.test.ts`

The "API key backward compatibility" test intended to verify only the `CLAUDE_API_KEY` → `ANTHROPIC_API_KEY` fallback path, but it instantiated `SecretManager` with default `requiredSecrets` (`['ANTHROPIC_API_KEY', 'GITHUB_TOKEN']`). Since the test only sets `CLAUDE_API_KEY`, the missing `GITHUB_TOKEN` caused `SecretNotFoundError`. Isolate the test's concern by passing an explicit `requiredSecrets` array:

```diff
  const manager = new SecretManager({
+   requiredSecrets: ['ANTHROPIC_API_KEY'],
    throwOnMissing: true,
  });
```

## Test Plan

- [x] `npx vitest run tests/security/SecretManager.test.ts tests/ad-sdlc-orchestrator/localMode.test.ts` — 32/32 passing locally
- [ ] CI Test (ubuntu-latest) passes
- [ ] CI Test (windows-latest) passes

## Scope

- Changes: test files only, 7 lines added / 4 removed
- No source code modified
- No new dependencies
- Unblocks: PR #756 (YAML frontmatter) and all subsequent PRs on main