### PR TITLE
feat(sdp-writer): add Software Development Plan writer agent

### DIFF
--- a/.claude/agents/sdp-writer.md
+++ b/.claude/agents/sdp-writer.md
@@ -1,0 +1,213 @@
+---
+name: sdp-writer
+description: |
+  SDP Writing Agent. Creates a Software Development Plan (SDP) from PRD and SRS inputs.
+  Defines lifecycle, development environment, team responsibilities, V&V strategy,
+  risk management, and delivery milestones.
+  Use this agent after SRS is approved and before SDS generation.
+tools:
+  - Read
+  - Write
+  - Edit
+  - Glob
+  - Grep
+model: inherit
+---
+
+# SDP Writer Agent
+
+## Role
+
+You are an SDP Writer Agent responsible for creating a Software Development Plan (SDP)
+that translates the approved PRD and SRS into a concrete plan covering lifecycle model,
+tools, team structure, quality assurance, verification & validation strategy, risk
+management, schedule, and configuration management.
+
+## Primary Responsibilities
+
+1. **Lifecycle & Process Definition**
+   - Select an appropriate lifecycle model (Iterative / Agile by default)
+   - Document phases, gates, and review checkpoints
+
+2. **Development Environment & Tools**
+   - List languages, frameworks, IDEs, build, and CI tooling
+   - Document environment configuration assumptions
+
+3. **Team Structure & Responsibilities**
+   - Identify roles required to deliver the product
+   - Map responsibilities to lifecycle phases
+
+4. **V&V and QA Strategy**
+   - Define verification activities (reviews, static analysis, unit tests)
+   - Define validation activities (integration, system, acceptance tests)
+   - Document QA gates per milestone
+
+5. **Risk Management**
+   - Enumerate top risks based on SRS feature/NFR counts
+   - Document likelihood, impact, and mitigation per risk
+
+6. **Schedule & Milestones**
+   - Define milestones (M1..Mn) tied to lifecycle phases
+   - Document deliverables per milestone
+
+7. **Configuration Management**
+   - Document version control, branching, release, and document management policies
+
+## SDP Template Structure
+
+```markdown
+# SDP: [Product Name]
+
+| Field       | Value                 |
+| ----------- | --------------------- |
+| Document ID | SDP-XXX               |
+| Source PRD  | PRD-XXX               |
+| Source SRS  | SRS-XXX               |
+| Version     | X.Y.Z                 |
+| Status      | Draft/Review/Approved |
+
+## 1. Project Overview
+
+- Product summary
+- Objectives and scope
+- Source documents
+
+## 2. Lifecycle Model
+
+- Selected model and rationale
+- Phases and gates
+
+## 3. Development Environment
+
+- Languages, frameworks, IDEs
+- Build and CI tooling
+- Environments (dev/stage/prod)
+
+## 4. Artifact Definitions
+
+- Source artifacts (PRD, SRS, SDS, code, tests)
+- Naming conventions
+- Storage locations
+
+## 5. QA Strategy
+
+- Code review policy
+- Static analysis and linting
+- Coverage targets
+
+## 6. V&V Strategy
+
+- Verification activities
+- Validation activities
+- Acceptance criteria
+
+## 7. Risk Management
+
+| ID  | Risk | Likelihood | Impact | Mitigation |
+| --- | ---- | ---------- | ------ | ---------- |
+
+## 8. Schedule & Milestones
+
+| ID  | Milestone | Phase | Deliverables |
+| --- | --------- | ----- | ------------ |
+
+## 9. Configuration Management
+
+- Version control workflow
+- Branching strategy
+- Release management
+- Document control
+```
+
+## CRITICAL: Tool Usage
+
+When writing files, you MUST use the `Write` tool with the exact parameter names:
+
+```
+Write tool invocation:
+- Tool name: Write (capital W, not write_file)
+- Parameters:
+  - file_path: "/absolute/path/to/file.md" (must be absolute path)
+  - content: "file content here"
+```
+
+**IMPORTANT**:
+
+- DO NOT use `write_file` - this function does not exist
+- DO NOT use `writeFile` - this function does not exist
+- Always use the `Write` tool with `file_path` and `content` parameters
+- Always use absolute paths (starting with `/`)
+
+**Example for this agent**:
+
+```
+Write(
+  file_path: ".ad-sdlc/scratchpad/documents/{project_id}/sdp.md",
+  content: "<SDP markdown content>"
+)
+```
+
+## Workflow
+
+1. **Read PRD**: Load from `.ad-sdlc/scratchpad/documents/{project_id}/prd.md`
+2. **Read SRS**: Load from `.ad-sdlc/scratchpad/documents/{project_id}/srs.md`
+3. **Define Lifecycle**: Choose lifecycle model and phases
+4. **Plan Tools & Environment**: List development environment and tools
+5. **Define Team & Responsibilities**: Outline roles and responsibilities
+6. **Plan QA and V&V**: Define quality and verification strategy
+7. **Identify Risks**: Enumerate risks scaled to feature/NFR counts
+8. **Schedule Milestones**: Generate M1..Mn milestones with deliverables
+9. **Document Configuration Management**: Version control, branching, release policy
+10. **Save English Version**: Write to `.ad-sdlc/scratchpad/documents/{project_id}/sdp.md` and `docs/sdp/SDP-{project_id}.md`
+11. **Generate Korean Version**: Translate following Bilingual Output Policy guidelines
+12. **Save Korean Version**: Write to `.ad-sdlc/scratchpad/documents/{project_id}/sdp.kr.md` and `docs/sdp/SDP-{project_id}.kr.md`
+
+## Input Location
+
+- `.ad-sdlc/scratchpad/documents/{project_id}/prd.md`
+- `.ad-sdlc/scratchpad/documents/{project_id}/srs.md`
+
+## Output Location
+
+### English Version (Primary)
+
+- `.ad-sdlc/scratchpad/documents/{project_id}/sdp.md`
+- `docs/sdp/SDP-{project_id}.md`
+
+### Korean Version
+
+- `.ad-sdlc/scratchpad/documents/{project_id}/sdp.kr.md`
+- `docs/sdp/SDP-{project_id}.kr.md`
+
+## Bilingual Output Policy
+
+All documents MUST be generated in both languages:
+
+1. **English Version** (`*.md`): Primary document, used for technical implementation
+2. **Korean Version** (`*.kr.md`): Localized document for Korean stakeholders
+
+### Generation Order
+
+1. Generate English version first
+2. Generate Korean version by translating content while preserving:
+   - Document structure and formatting
+   - Technical terms (keep original + Korean translation in parentheses)
+   - Code blocks and examples (unchanged)
+   - IDs and references (unchanged)
+   - Table structures and markdown syntax
+
+### Translation Guidelines
+
+- **Section Headers**: Translate to Korean
+- **Technical Terms**: Keep English term with Korean in parentheses, e.g., "Software Development Plan (소프트웨어 개발 계획서)"
+- **Milestone IDs**: Keep as-is (e.g., M1, M2)
+- **Risk IDs**: Keep as-is (e.g., R1, R2)
+- **Code Blocks**: Do not translate
+- **Field Names in Tables**: Translate to Korean
+
+## Quality Criteria
+
+- Every SDP must reference both source PRD and SRS
+- Lifecycle, environment, team, QA, V&V, risks, milestones, and configuration sections must be present
+- Number of milestones and risks must scale with the SRS feature/NFR counts
+- Bilingual output (English + Korean) must be produced

--- a/README.md
+++ b/README.md
@@ -25,13 +25,13 @@ That's it! The agents will generate documents, create issues, implement code, an
 
 ## What is AD-SDLC?
 
-AD-SDLC is an automated software development pipeline that uses **25 specialized Claude agents** to transform your requirements into production-ready code. It supports three modes:
+AD-SDLC is an automated software development pipeline that uses **26 specialized Claude agents** to transform your requirements into production-ready code. It supports three modes:
 
 ### Greenfield Pipeline (New Projects)
 
 ```
-User Input → Collector → PRD Writer → SRS Writer → SDS Writer
-                                                       ↓
+User Input → Collector → PRD Writer → SRS Writer → SDP Writer → SDS Writer
+                                                                    ↓
                            Worker ← Controller ← Issue Generator
                               ↓
                          PR Reviewer → Merge
@@ -63,7 +63,7 @@ GitHub Issues → Issue Reader → Controller → Worker → PR Reviewer
                                                  CI Fix (on failure)
 ```
 
-### Agent Pipeline (25 Agents)
+### Agent Pipeline (26 Agents)
 
 | Phase             | Agent                 | Role                                                 |
 | ----------------- | --------------------- | ---------------------------------------------------- |
@@ -77,6 +77,7 @@ GitHub Issues → Issue Reader → Controller → Worker → PR Reviewer
 |                   | Issue Reader          | Imports existing GitHub Issues for Import pipeline   |
 | **Documentation** | PRD Writer            | Generates Product Requirements Document              |
 |                   | SRS Writer            | Generates Software Requirements Specification        |
+|                   | SDP Writer            | Generates Software Development Plan from PRD and SRS |
 |                   | SDS Writer            | Generates Software Design Specification              |
 | **Planning**      | Issue Generator       | Creates GitHub Issues from SDS components            |
 | **Execution**     | Controller            | Orchestrates work distribution and monitors progress |
@@ -283,7 +284,7 @@ See [Use Cases Guide](docs/use-cases.md) for more examples.
 ```
 your-project/
 ├── .claude/
-│   └── agents/              # Agent definitions (25 agents)
+│   └── agents/              # Agent definitions (26 agents)
 │       ├── *.md             # English versions (used by Claude)
 │       └── *.kr.md          # Korean versions (for reference)
 ├── .ad-sdlc/

--- a/docs/architecture/agent-communication.md
+++ b/docs/architecture/agent-communication.md
@@ -29,13 +29,13 @@ Agents do not communicate directly. Instead, they:
 
 ### Benefits
 
-| Benefit | Description |
-|---------|-------------|
-| **Persistence** | State survives agent restarts |
+| Benefit          | Description                        |
+| ---------------- | ---------------------------------- |
+| **Persistence**  | State survives agent restarts      |
 | **Transparency** | Human-readable intermediate states |
-| **Debugging** | Easy to inspect and modify state |
-| **Recovery** | Resume from last successful state |
-| **Traceability** | Full audit trail of changes |
+| **Debugging**    | Easy to inspect and modify state   |
+| **Recovery**     | Resume from last successful state  |
+| **Traceability** | Full audit trail of changes        |
 
 ---
 
@@ -73,20 +73,20 @@ Agents do not communicate directly. Instead, they:
 
 Each agent has designated files it reads from and writes to:
 
-| Agent | Reads | Writes |
-|-------|-------|--------|
-| Collector | User input, files, URLs | `info/collected_info.yaml` |
-| PRD Writer | `info/collected_info.yaml` | `documents/prd.md` |
-| SRS Writer | `documents/prd.md` | `documents/srs.md` |
-| GitHub Repo Setup | `documents/prd.md`, `documents/srs.md` | `repo/github_repo.yaml` |
-| SDS Writer | `documents/srs.md`, `repo/github_repo.yaml` | `documents/sds.md` |
-| Issue Generator | `documents/sds.md` | `issues/issues.json` |
-| Controller | `issues/issues.json` | `progress/controller_state.yaml` |
-| Worker | `progress/work_orders.yaml` | Implementation results |
-| PR Reviewer | Worker results | PR status |
-| Document Reader | `docs/*.md` | `state/current_state.yaml` |
-| Codebase Analyzer | Source code | `analysis/architecture_overview.yaml` |
-| Impact Analyzer | State + analysis | `impact/impact_report.yaml` |
+| Agent             | Reads                                       | Writes                                |
+| ----------------- | ------------------------------------------- | ------------------------------------- |
+| Collector         | User input, files, URLs                     | `info/collected_info.yaml`            |
+| PRD Writer        | `info/collected_info.yaml`                  | `documents/prd.md`                    |
+| SRS Writer        | `documents/prd.md`                          | `documents/srs.md`                    |
+| GitHub Repo Setup | `documents/prd.md`, `documents/srs.md`      | `repo/github_repo.yaml`               |
+| SDS Writer        | `documents/srs.md`, `repo/github_repo.yaml` | `documents/sds.md`                    |
+| Issue Generator   | `documents/sds.md`                          | `issues/issues.json`                  |
+| Controller        | `issues/issues.json`                        | `progress/controller_state.yaml`      |
+| Worker            | `progress/work_orders.yaml`                 | Implementation results                |
+| PR Reviewer       | Worker results                              | PR status                             |
+| Document Reader   | `docs/*.md`                                 | `state/current_state.yaml`            |
+| Codebase Analyzer | Source code                                 | `analysis/architecture_overview.yaml` |
+| Impact Analyzer   | State + analysis                            | `impact/impact_report.yaml`           |
 
 ---
 
@@ -97,15 +97,23 @@ Each agent has designated files it reads from and writes to:
 Used in document generation pipeline:
 
 ```
-┌───────────┐    ┌───────────┐    ┌───────────┐    ┌────────────────┐    ┌───────────┐
-│ Collector │───▶│PRD Writer │───▶│SRS Writer │───▶│GitHub Repo Setup│───▶│SDS Writer │
-└───────────┘    └───────────┘    └───────────┘    └────────────────┘    └───────────┘
-      │                │                │                  │                   │
-      ▼                ▼                ▼                  ▼                   ▼
- collected_info    prd.md           srs.md          github_repo.yaml       sds.md
+┌───────────┐    ┌───────────┐    ┌───────────┐    ┌────────────────┐
+│ Collector │───▶│PRD Writer │───▶│SRS Writer │───▶│GitHub Repo Setup│──┐
+└───────────┘    └───────────┘    └───────────┘    └────────────────┘  │
+      │                │                │                  │           │
+      ▼                ▼                ▼                  ▼           │
+ collected_info    prd.md           srs.md          github_repo.yaml   │
+                                                                        │
+                       ┌───────────┐    ┌───────────┐                  │
+                       │SDS Writer │◀───│SDP Writer │◀─────────────────┘
+                       └───────────┘    └───────────┘
+                             │                │
+                             ▼                ▼
+                          sds.md            sdp.md
 ```
 
 **Protocol Steps**:
+
 1. Agent A completes and writes output
 2. Orchestrator validates output
 3. Orchestrator spawns Agent B
@@ -137,6 +145,7 @@ Used in enhancement pipeline analysis:
 ```
 
 **Protocol Steps**:
+
 1. Orchestrator spawns multiple agents in parallel
 2. Each agent writes to its designated file
 3. Orchestrator waits for all completions
@@ -162,16 +171,17 @@ Used by Controller to distribute work:
 ```
 
 **Work Order Format**:
+
 ```yaml
 work_order:
-  id: "WO-001"
+  id: 'WO-001'
   issue_number: 42
-  issue_title: "Implement user authentication"
+  issue_title: 'Implement user authentication'
   priority: P0
   dependencies: []
-  assigned_worker: "worker-1"
-  status: "assigned"
-  created_at: "2025-01-01T00:00:00Z"
+  assigned_worker: 'worker-1'
+  status: 'assigned'
+  created_at: '2025-01-01T00:00:00Z'
 ```
 
 ### 4. Result Aggregation Protocol
@@ -181,15 +191,15 @@ Used when multiple workers complete:
 ```yaml
 # progress/controller_state.yaml
 completed_work:
-  - order_id: "WO-001"
-    status: "success"
+  - order_id: 'WO-001'
+    status: 'success'
     pr_number: 101
-    completed_at: "2025-01-01T01:00:00Z"
+    completed_at: '2025-01-01T01:00:00Z'
 
-  - order_id: "WO-002"
-    status: "success"
+  - order_id: 'WO-002'
+    status: 'success'
     pr_number: 102
-    completed_at: "2025-01-01T01:30:00Z"
+    completed_at: '2025-01-01T01:30:00Z'
 
 pending_review:
   - pr_number: 101
@@ -203,61 +213,64 @@ pending_review:
 ### YAML Schema Examples
 
 #### collected_info.yaml
+
 ```yaml
-schema_version: "1.0"
-project_name: "my-project"
-collected_at: "2025-01-01T00:00:00Z"
+schema_version: '1.0'
+project_name: 'my-project'
+collected_at: '2025-01-01T00:00:00Z'
 
 requirements:
   functional:
-    - id: "REQ-001"
-      description: "User can log in with email"
-      priority: "high"
-      source: "user_input"
+    - id: 'REQ-001'
+      description: 'User can log in with email'
+      priority: 'high'
+      source: 'user_input'
 
   non_functional:
-    - id: "NFR-001"
-      description: "Response time < 200ms"
-      category: "performance"
+    - id: 'NFR-001'
+      description: 'Response time < 200ms'
+      category: 'performance'
 
 constraints:
-  - "Must use existing auth provider"
+  - 'Must use existing auth provider'
 
 assumptions:
-  - "Users have email addresses"
+  - 'Users have email addresses'
 ```
 
 #### current_state.yaml
+
 ```yaml
-schema_version: "1.0"
-analysis_date: "2025-01-01T00:00:00Z"
+schema_version: '1.0'
+analysis_date: '2025-01-01T00:00:00Z'
 
 project:
-  name: "existing-project"
-  version: "2.1.0"
+  name: 'existing-project'
+  version: '2.1.0'
 
 documents:
   prd:
-    path: "docs/PRD.md"
+    path: 'docs/PRD.md'
     exists: true
     requirements_count: 15
   srs:
-    path: "docs/SRS.md"
+    path: 'docs/SRS.md'
     exists: true
     features_count: 23
   sds:
-    path: "docs/SDS.md"
+    path: 'docs/SDS.md'
     exists: false
 
 traceability:
-  - prd_id: "FR-001"
-    srs_ids: ["SF-001", "SF-002"]
-    sds_ids: ["CMP-001"]
+  - prd_id: 'FR-001'
+    srs_ids: ['SF-001', 'SF-002']
+    sds_ids: ['CMP-001']
 ```
 
 ### JSON Schema Examples
 
 #### issues.json
+
 ```json
 {
   "schema_version": "1.0",
@@ -293,7 +306,7 @@ Atomic writes prevent corruption:
 // Scratchpad uses atomic write operations
 await scratchpad.write('data', content, {
   atomic: true,
-  backup: true
+  backup: true,
 });
 ```
 
@@ -302,7 +315,7 @@ await scratchpad.write('data', content, {
 Files include version for compatibility:
 
 ```yaml
-schema_version: "1.0"
+schema_version: '1.0'
 # ... rest of content
 ```
 
@@ -321,11 +334,11 @@ Progress is checkpointed for recovery:
 
 ```yaml
 checkpoint:
-  stage: "srs_generation"
+  stage: 'srs_generation'
   completed_stages:
-    - "collection"
-    - "prd_generation"
-  last_updated: "2025-01-01T00:30:00Z"
+    - 'collection'
+    - 'prd_generation'
+  last_updated: '2025-01-01T00:30:00Z'
 ```
 
 ---
@@ -406,4 +419,4 @@ try {
 
 ---
 
-*Part of [AD-SDLC Architecture Documentation](./overview.md)*
+_Part of [AD-SDLC Architecture Documentation](./overview.md)_

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -29,13 +29,13 @@ AD-SDLC (Agent-Driven Software Development Lifecycle) is an automated software d
 
 ### Key Capabilities
 
-| Capability | Description |
-|------------|-------------|
-| Document Generation | PRD, SRS, SDS automatic generation |
-| Issue Management | GitHub issue creation from design documents |
-| Code Implementation | Automated code generation with tests |
-| PR Management | Automated PR creation, review, and merge |
-| Impact Analysis | Change impact assessment for existing projects |
+| Capability          | Description                                    |
+| ------------------- | ---------------------------------------------- |
+| Document Generation | PRD, SRS, SDS automatic generation             |
+| Issue Management    | GitHub issue creation from design documents    |
+| Code Implementation | Automated code generation with tests           |
+| PR Management       | Automated PR creation, review, and merge       |
+| Impact Analysis     | Change impact assessment for existing projects |
 
 ---
 
@@ -62,7 +62,7 @@ AD-SDLC (Agent-Driven Software Development Lifecycle) is an automated software d
     ┌─────────────────────┐               ┌─────────────────────┐
     │  Document Pipeline  │               │  Analysis Pipeline  │
     │  Collector → PRD →  │               │  DocReader →        │
-    │  SRS → SDS          │               │  CodeAnalyzer →     │
+    │  SRS → SDP → SDS    │               │  CodeAnalyzer →     │
     └─────────────────────┘               │  ImpactAnalyzer     │
               │                           └─────────────────────┘
               │                                           │
@@ -112,44 +112,44 @@ AD-SDLC (Agent-Driven Software Development Lifecycle) is an automated software d
 
 ### Runtime Environment
 
-| Component | Version | Purpose |
-|-----------|---------|---------|
-| **Node.js** | 18+ | Runtime environment |
-| **TypeScript** | 5.3+ | Primary language |
-| **ES2022** | - | Module system (ESM) |
+| Component      | Version | Purpose             |
+| -------------- | ------- | ------------------- |
+| **Node.js**    | 18+     | Runtime environment |
+| **TypeScript** | 5.3+    | Primary language    |
+| **ES2022**     | -       | Module system (ESM) |
 
 ### Core Dependencies
 
-| Package | Version | Purpose |
-|---------|---------|---------|
-| `commander` | ^14.0.2 | CLI framework |
-| `chalk` | ^5.6.2 | Terminal output styling |
-| `inquirer` | ^13.1.0 | Interactive CLI prompts |
-| `js-yaml` | ^4.1.1 | YAML parsing |
-| `zod` | ^4.2.1 | Schema validation |
-| `ts-morph` | ^27.0.2 | TypeScript AST manipulation |
-| `dotenv` | ^17.2.3 | Environment configuration |
-| `mammoth` | ^1.11.0 | DOCX file parsing |
-| `pdf-parse` | ^2.4.5 | PDF file parsing |
+| Package     | Version | Purpose                     |
+| ----------- | ------- | --------------------------- |
+| `commander` | ^14.0.2 | CLI framework               |
+| `chalk`     | ^5.6.2  | Terminal output styling     |
+| `inquirer`  | ^13.1.0 | Interactive CLI prompts     |
+| `js-yaml`   | ^4.1.1  | YAML parsing                |
+| `zod`       | ^4.2.1  | Schema validation           |
+| `ts-morph`  | ^27.0.2 | TypeScript AST manipulation |
+| `dotenv`    | ^17.2.3 | Environment configuration   |
+| `mammoth`   | ^1.11.0 | DOCX file parsing           |
+| `pdf-parse` | ^2.4.5  | PDF file parsing            |
 
 ### Development Tools
 
-| Tool | Version | Purpose |
-|------|---------|---------|
-| `vitest` | ^4.0.16 | Test runner |
-| `@vitest/coverage-v8` | ^4.0.16 | Code coverage |
-| `eslint` | ^9.0.0 | Code linting |
-| `prettier` | ^3.0.0 | Code formatting |
-| `@typescript-eslint` | ^8.0.0 | TypeScript linting rules |
+| Tool                  | Version | Purpose                  |
+| --------------------- | ------- | ------------------------ |
+| `vitest`              | ^4.0.16 | Test runner              |
+| `@vitest/coverage-v8` | ^4.0.16 | Code coverage            |
+| `eslint`              | ^9.0.0  | Code linting             |
+| `prettier`            | ^3.0.0  | Code formatting          |
+| `@typescript-eslint`  | ^8.0.0  | TypeScript linting rules |
 
 ### External Integrations
 
-| Service | Purpose |
-|---------|---------|
-| **GitHub** | Issue tracking, PR management |
-| **Claude API** | AI agent backbone |
-| **Codecov** | Coverage reporting |
-| **CodeQL** | Security analysis |
+| Service        | Purpose                       |
+| -------------- | ----------------------------- |
+| **GitHub**     | Issue tracking, PR management |
+| **Claude API** | AI agent backbone             |
+| **Codecov**    | Coverage reporting            |
+| **CodeQL**     | Security analysis             |
 
 ---
 
@@ -160,17 +160,20 @@ AD-SDLC (Agent-Driven Software Development Lifecycle) is an automated software d
 The system consists of 15 specialized agents organized into functional categories:
 
 #### Document Generation Agents
+
 - **Collector**: Gathers requirements from multiple sources
 - **PRD Writer**: Generates Product Requirements Document
 - **SRS Writer**: Generates Software Requirements Specification
 - **SDS Writer**: Generates Software Design Specification
 
 #### Document Update Agents
+
 - **PRD Updater**: Incremental PRD modifications
 - **SRS Updater**: Incremental SRS modifications
 - **SDS Updater**: Incremental SDS modifications
 
 #### Analysis Agents
+
 - **Document Reader**: Parses existing documentation
 - **Codebase Analyzer**: Analyzes code structure
 - **Code Reader**: Extracts code inventory
@@ -178,6 +181,7 @@ The system consists of 15 specialized agents organized into functional categorie
 - **Doc-Code Comparator**: Identifies documentation gaps
 
 #### Execution Agents
+
 - **Issue Generator**: Creates GitHub issues from SDS
 - **Controller**: Orchestrates work distribution
 - **Worker**: Implements issues with code
@@ -296,12 +300,14 @@ Stage 9: Review & Merge
 Agents communicate through file-based state rather than direct messaging:
 
 **Benefits**:
+
 - Persistence across agent invocations
 - Human-readable intermediate states
 - Easy debugging and inspection
 - Recovery from failures
 
 **Implementation**:
+
 ```typescript
 // Write state
 await scratchpad.write('collected_info', data);
@@ -321,6 +327,7 @@ PRD (FR-001) ←→ SRS (SF-001, SF-002) ←→ SDS (CMP-001) ←→ Issue #1
 ### 3. Pipeline Stage Pattern
 
 Each pipeline stage:
+
 1. Reads input from scratchpad
 2. Processes with specialized agent
 3. Writes output to scratchpad
@@ -329,6 +336,7 @@ Each pipeline stage:
 ### 4. Worker Pool Pattern
 
 Controller manages a pool of workers:
+
 - Maximum 5 concurrent workers
 - Dependency-aware scheduling
 - Priority-based ordering
@@ -337,6 +345,7 @@ Controller manages a pool of workers:
 ### 5. Quality Gate Pattern
 
 Gates enforce standards at transitions:
+
 - Document completeness validation
 - Code coverage thresholds (80%)
 - Security scanning
@@ -408,4 +417,4 @@ claude_code_agent/
 
 ---
 
-*Part of [AD-SDLC Documentation](../README.md)*
+_Part of [AD-SDLC Documentation](../README.md)_

--- a/docs/reference/agents/ad-sdlc-orchestrator.md
+++ b/docs/reference/agents/ad-sdlc-orchestrator.md
@@ -182,13 +182,14 @@ orchestration_result:
 | 2     | collector         | Gather requirements | No            |
 | 3     | prd-writer        | Generate PRD        | Yes           |
 | 4     | srs-writer        | Generate SRS        | Yes           |
-| 5     | repo-detector     | Check repository    | No            |
-| 6     | github-repo-setup | Create repo         | No            |
-| 7     | sds-writer        | Generate SDS        | Yes           |
-| 8     | issue-generator   | Create issues       | Yes           |
-| 9     | controller        | Assign work         | No            |
-| 10    | worker            | Implement           | No            |
-| 11    | pr-reviewer       | Review PRs          | No            |
+| 5     | sdp-writer        | Generate SDP        | Yes           |
+| 6     | repo-detector     | Check repository    | No            |
+| 7     | github-repo-setup | Create repo         | No            |
+| 8     | sds-writer        | Generate SDS        | Yes           |
+| 9     | issue-generator   | Create issues       | Yes           |
+| 10    | controller        | Assign work         | No            |
+| 11    | worker            | Implement           | No            |
+| 12    | pr-reviewer       | Review PRs          | No            |
 
 #### Enhancement Pipeline
 
@@ -412,6 +413,7 @@ Pipeline Execution
 | collector         | Greenfield             | Gather requirements           |
 | prd-writer        | Greenfield             | Generate PRD                  |
 | srs-writer        | Greenfield             | Generate SRS                  |
+| sdp-writer        | Greenfield             | Generate SDP                  |
 | sds-writer        | Greenfield             | Generate SDS                  |
 | repo-detector     | Greenfield             | Check for existing repo       |
 | github-repo-setup | Greenfield             | Create repository             |

--- a/docs/sdp-writer.md
+++ b/docs/sdp-writer.md
@@ -1,0 +1,127 @@
+# SDP Writer Agent Documentation
+
+## Overview
+
+The SDP Writer Agent is responsible for generating a Software Development Plan (SDP) from approved Product Requirements (PRD) and Software Requirements Specification (SRS) inputs. It is a key component of the AD-SDLC document pipeline and bridges requirements (what to build) with design (how to build it) by capturing the lifecycle model, tools, team responsibilities, V&V strategy, risk management, and delivery milestones.
+
+## Pipeline Position
+
+```
+Collector → PRD Writer → SRS Writer → SDP Writer → SDS Writer → Issue Generator
+                                          ↑
+                                     You are here
+```
+
+## Purpose
+
+The SDP Writer Agent:
+
+1. Reads and parses PRD and SRS documents
+2. Selects a lifecycle model and documents phases, gates, and review checkpoints
+3. Captures development environment, tools, and team responsibilities
+4. Defines QA, V&V, and configuration management strategies
+5. Generates a milestone schedule sized from the SRS feature/NFR counts
+6. Outputs a structured SDP document in both English and Korean
+
+## Input
+
+- **PRD location**: `.ad-sdlc/scratchpad/documents/{project_id}/prd.md`
+- **SRS location**: `.ad-sdlc/scratchpad/documents/{project_id}/srs.md`
+- **Format**: Markdown documents following PRD and SRS templates
+- **Requirements**: SRS must reference its source PRD; PRD timeline section is optional
+
+## Output
+
+- **Scratchpad (English)**: `.ad-sdlc/scratchpad/documents/{project_id}/sdp.md`
+- **Scratchpad (Korean)**: `.ad-sdlc/scratchpad/documents/{project_id}/sdp.kr.md`
+- **Public (English)**: `docs/sdp/SDP-{project_id}.md`
+- **Public (Korean)**: `docs/sdp/SDP-{project_id}.kr.md`
+- **Format**: Markdown document with structured SDP sections and YAML frontmatter
+
+## ID Conventions
+
+| Type         | Pattern          | Example |
+| ------------ | ---------------- | ------- |
+| SDP Document | SDP-{project_id} | SDP-001 |
+| Milestone    | M{N}             | M1, M2  |
+| Risk         | R{N}             | R1, R2  |
+
+## SDP Sections
+
+The generated SDP captures:
+
+- **Lifecycle Model** — Default `Iterative / Agile`, configurable via `lifecycleModel`
+- **Development Environment** — Tools, languages, frameworks
+- **Team Responsibilities** — Roles and ownership
+- **QA & V&V Strategy** — Verification and validation approach
+- **Risk Management** — Likelihood/Impact/Mitigation entries
+- **Schedule & Milestones** — Phase-grouped milestones sized from SRS scope
+- **Configuration Management** — Branching, versioning, release strategy
+
+## CLI Integration
+
+```bash
+# Generate SDP for a project (after SRS is approved)
+ad-sdlc generate-sdp --project 001
+```
+
+## API Reference
+
+### SDPWriterAgent
+
+Main orchestrator class for SDP generation. Implements `IAgent` for unified
+instantiation through `AgentFactory`.
+
+#### Methods
+
+| Method                           | Description                                               |
+| -------------------------------- | --------------------------------------------------------- |
+| `initialize()`                   | Initialize the agent (IAgent interface)                   |
+| `dispose()`                      | Release resources and clear session (IAgent interface)    |
+| `getSession()`                   | Return the current generation session, or `null` if none  |
+| `startSession(projectId)`        | Start a new generation session by parsing PRD and SRS     |
+| `generateFromProject(projectId)` | Run the full pipeline (start → finalize) in one call      |
+| `finalize()`                     | Persist generated SDP to scratchpad and public docs paths |
+
+### Agent ID
+
+Registered as `sdp-writer-agent` (`SDP_WRITER_AGENT_ID`) for `AgentFactory`.
+
+## Quality Criteria
+
+The SDP Writer Agent ensures:
+
+1. **Source Traceability**: Every SDP references its source PRD and SRS document IDs
+2. **Schedule Coverage**: Milestones are generated proportionally to SRS feature/NFR counts
+3. **Risk Hygiene**: Each risk entry has likelihood, impact, and a mitigation strategy
+4. **Bilingual Output**: English and Korean variants are produced for every document
+5. **Frontmatter Compliance**: All outputs include the standard `doc_id`, `version`, and `status` frontmatter
+
+## Error Handling
+
+| Error               | Cause                                        | Resolution                                            |
+| ------------------- | -------------------------------------------- | ----------------------------------------------------- |
+| `PRDNotFoundError`  | PRD document missing at expected path        | Generate PRD via PRD Writer first                     |
+| `SRSNotFoundError`  | SRS document missing at expected path        | Generate SRS via SRS Writer first                     |
+| `SessionStateError` | Operation called in an invalid session state | Follow session workflow (`startSession` → `finalize`) |
+| `GenerationError`   | SDP content generation failed                | Inspect `phase` field and retry                       |
+| `FileWriteError`    | Output path not writable                     | Verify permissions on `docs/sdp` and scratchpad       |
+| `ValidationError`   | Generated SDP failed schema validation       | Review `errors` list returned by the validator        |
+
+## Configuration
+
+```yaml
+# .ad-sdlc/config/sdp-writer.yaml
+sdp_writer:
+  scratchpad_base_path: '.ad-sdlc/scratchpad'
+  template_path: '.ad-sdlc/templates/sdp-template.md'
+  public_docs_path: 'docs/sdp'
+  lifecycle_model: 'Iterative / Agile'
+```
+
+## Related Documentation
+
+- [PRD Writer Agent](prd-writer.md)
+- [SRS Writer Agent](srs-writer.md)
+- [SDS Writer Agent](sds-writer.md)
+- [Issue Generator](issue-generator.md)

--- a/docs/system-architecture.kr.md
+++ b/docs/system-architecture.kr.md
@@ -14,6 +14,7 @@ flowchart TB
         COLLECT[Collector Agent]
         PRD[PRD Writer Agent]
         SRS[SRS Writer Agent]
+        SDP[SDP Writer Agent]
         SDS[SDS Writer Agent]
     end
 
@@ -51,7 +52,8 @@ flowchart TB
 
     COLLECT --> PRD
     PRD --> SRS
-    SRS --> SDS
+    SRS --> SDP
+    SDP --> SDS
 
     SDS --> ISSUE
     ISSUE --> CTRL
@@ -67,6 +69,7 @@ flowchart TB
     COLLECT -.-> DOCS
     PRD -.-> DOCS
     SRS -.-> DOCS
+    SDP -.-> DOCS
     SDS -.-> DOCS
     ISSUE -.-> ISSUES
     WORKER1 -.-> CODE
@@ -96,6 +99,7 @@ flowchart TB
         A1[Collector]
         A2[PRD Writer]
         A3[SRS Writer]
+        A3B[SDP Writer]
         A4[SDS Writer]
         A5[Issue Generator]
         A6[Controller]
@@ -110,6 +114,7 @@ flowchart TB
         S1[info/*.yaml]
         S2[docs/prd/*.md]
         S3[docs/srs/*.md]
+        S3B[docs/sdp/*.md]
         S4[docs/sds/*.md]
         S5[issues/*.json]
         S6[progress/*.yaml]
@@ -122,6 +127,7 @@ flowchart TB
     MAIN -->|spawn| A1
     MAIN -->|spawn| A2
     MAIN -->|spawn| A3
+    MAIN -->|spawn| A3B
     MAIN -->|spawn| A4
     MAIN -->|spawn| A5
     MAIN -->|spawn| A6
@@ -136,6 +142,9 @@ flowchart TB
     A2 -->|write| S2
     A3 -->|read| S2
     A3 -->|write| S3
+    A3B -->|read| S2
+    A3B -->|read| S3
+    A3B -->|write| S3B
     A4 -->|read| S3
     A4 -->|write| S4
     A5 -->|read| S4
@@ -161,6 +170,7 @@ flowchart TB
     A1 -.->|result| MAIN
     A2 -.->|result| MAIN
     A3 -.->|result| MAIN
+    A3B -.->|result| MAIN
     A4 -.->|result| MAIN
     A5 -.->|result| MAIN
     A6 -.->|result| MAIN
@@ -373,6 +383,7 @@ claude_code_agent/
 │       ├── collector.md           # 정보 수집 에이전트
 │       ├── prd-writer.md          # PRD 작성 에이전트
 │       ├── srs-writer.md          # SRS 작성 에이전트
+│       ├── sdp-writer.md          # SDP 작성 에이전트
 │       ├── sds-writer.md          # SDS 작성 에이전트
 │       ├── issue-generator.md     # 이슈 생성 에이전트
 │       ├── controller.md          # 관제 에이전트

--- a/docs/system-architecture.md
+++ b/docs/system-architecture.md
@@ -14,6 +14,7 @@ flowchart TB
         COLLECT[Collector Agent]
         PRD[PRD Writer Agent]
         SRS[SRS Writer Agent]
+        SDP[SDP Writer Agent]
         SDS[SDS Writer Agent]
     end
 
@@ -53,7 +54,8 @@ flowchart TB
 
     COLLECT --> PRD
     PRD --> SRS
-    SRS --> SDS
+    SRS --> SDP
+    SDP --> SDS
 
     SDS --> ISSUE
     ISSUE --> CTRL
@@ -69,6 +71,7 @@ flowchart TB
     COLLECT -.-> DOCS
     PRD -.-> DOCS
     SRS -.-> DOCS
+    SDP -.-> DOCS
     SDS -.-> DOCS
     ISSUE -.-> ISSUES
     WORKER1 -.-> CODE
@@ -101,6 +104,7 @@ flowchart TB
         A1[Collector]
         A2[PRD Writer]
         A3[SRS Writer]
+        A3B[SDP Writer]
         A4[SDS Writer]
         A5[Issue Generator]
         A6[Controller]
@@ -117,6 +121,7 @@ flowchart TB
         S1[info/*.yaml]
         S2[docs/prd/*.md]
         S3[docs/srs/*.md]
+        S3B[docs/sdp/*.md]
         S4[docs/sds/*.md]
         S5[issues/*.json]
         S6[progress/*.yaml]
@@ -132,6 +137,7 @@ flowchart TB
     MAIN -->|spawn| A1
     MAIN -->|spawn| A2
     MAIN -->|spawn| A3
+    MAIN -->|spawn| A3B
     MAIN -->|spawn| A4
     MAIN -->|spawn| A5
     MAIN -->|spawn| A6
@@ -148,6 +154,9 @@ flowchart TB
     A2 -->|write| S2
     A3 -->|read| S2
     A3 -->|write| S3
+    A3B -->|read| S2
+    A3B -->|read| S3
+    A3B -->|write| S3B
     A4 -->|read| S3
     A4 -->|write| S4
     A5 -->|read| S4
@@ -185,6 +194,7 @@ flowchart TB
     A1 -.->|result| MAIN
     A2 -.->|result| MAIN
     A3 -.->|result| MAIN
+    A3B -.->|result| MAIN
     A4 -.->|result| MAIN
     A5 -.->|result| MAIN
     A6 -.->|result| MAIN
@@ -399,6 +409,7 @@ claude_code_agent/
 │       ├── collector.md           # Information Collector Agent
 │       ├── prd-writer.md          # PRD Writer Agent
 │       ├── srs-writer.md          # SRS Writer Agent
+│       ├── sdp-writer.md          # SDP Writer Agent
 │       ├── sds-writer.md          # SDS Writer Agent
 │       ├── issue-generator.md     # Issue Generator Agent
 │       ├── controller.md          # Controller Agent

--- a/src/ad-sdlc-orchestrator/types.ts
+++ b/src/ad-sdlc-orchestrator/types.ts
@@ -21,6 +21,7 @@ export type GreenfieldStageName =
   | 'collection'
   | 'prd_generation'
   | 'srs_generation'
+  | 'sdp_generation'
   | 'repo_detection'
   | 'github_repo_setup'
   | 'sds_generation'
@@ -354,12 +355,20 @@ export const GREENFIELD_STAGES: readonly PipelineStageDefinition[] = [
     dependsOn: ['prd_generation'],
   },
   {
+    name: 'sdp_generation',
+    agentType: 'sdp-writer',
+    description: 'Generate SDP from PRD and SRS',
+    parallel: false,
+    approvalRequired: true,
+    dependsOn: ['srs_generation'],
+  },
+  {
     name: 'repo_detection',
     agentType: 'repo-detector',
     description: 'Detect existing GitHub repository presence',
     parallel: false,
     approvalRequired: false,
-    dependsOn: ['srs_generation'],
+    dependsOn: ['sdp_generation'],
   },
   {
     name: 'github_repo_setup',

--- a/src/agents/AgentTypeMapping.ts
+++ b/src/agents/AgentTypeMapping.ts
@@ -85,6 +85,14 @@ export const AGENT_TYPE_MAP: Readonly<Record<string, AgentTypeEntry>> = {
     importPath: '../srs-writer/index.js',
   },
 
+  'sdp-writer': {
+    agentId: 'sdp-writer-agent',
+    name: 'SDP Writer Agent',
+    lifecycle: 'singleton',
+    requiresWrapper: false,
+    importPath: '../sdp-writer/index.js',
+  },
+
   'repo-detector': {
     agentId: 'repo-detector-agent',
     name: 'Repo Detector',

--- a/src/sdp-writer/SDPWriterAgent.ts
+++ b/src/sdp-writer/SDPWriterAgent.ts
@@ -1,0 +1,1228 @@
+/**
+ * SDP Writer Agent
+ *
+ * Generates a Software Development Plan (SDP) document from PRD and SRS
+ * inputs. The SDP describes the lifecycle model, development environment,
+ * artifact definitions, QA strategy, V&V strategy, risk management,
+ * schedule, and configuration management for a project.
+ *
+ * Implements IAgent interface for AgentFactory integration.
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { randomUUID } from 'node:crypto';
+import type { IAgent } from '../agents/types.js';
+
+import type {
+  SDPWriterAgentConfig,
+  SDPGenerationSession,
+  SDPGenerationResult,
+  SDPGenerationStats,
+  ParsedPRDExtract,
+  ParsedSRSExtract,
+  PRDTimelineEntry,
+  GeneratedSDP,
+  SDPMetadata,
+  SDPMilestone,
+  SDPRisk,
+} from './types.js';
+import {
+  PRDNotFoundError,
+  SRSNotFoundError,
+  GenerationError,
+  FileWriteError,
+  SessionStateError,
+} from './errors.js';
+import { prependFrontmatter } from '../utilities/frontmatter.js';
+
+/**
+ * Default configuration for the SDP Writer Agent
+ */
+const DEFAULT_CONFIG: Required<SDPWriterAgentConfig> = {
+  scratchpadBasePath: '.ad-sdlc/scratchpad',
+  templatePath: '.ad-sdlc/templates/sdp-template.md',
+  publicDocsPath: 'docs/sdp',
+  lifecycleModel: 'Iterative / Agile',
+};
+
+/**
+ * Agent ID for SDPWriterAgent used in AgentFactory
+ */
+export const SDP_WRITER_AGENT_ID = 'sdp-writer-agent';
+
+/**
+ * SDP Writer Agent class
+ *
+ * Orchestrates the generation of SDP documents from PRD and SRS inputs.
+ * Implements IAgent interface for unified agent instantiation through AgentFactory.
+ */
+export class SDPWriterAgent implements IAgent {
+  public readonly agentId = SDP_WRITER_AGENT_ID;
+  public readonly name = 'SDP Writer Agent';
+
+  private readonly config: Required<SDPWriterAgentConfig>;
+  private session: SDPGenerationSession | null = null;
+  private initialized = false;
+
+  constructor(config: SDPWriterAgentConfig = {}) {
+    this.config = { ...DEFAULT_CONFIG, ...config };
+  }
+
+  /**
+   * Initialize the agent (IAgent interface)
+   */
+  public async initialize(): Promise<void> {
+    if (this.initialized) {
+      return;
+    }
+    await Promise.resolve();
+    this.initialized = true;
+  }
+
+  /**
+   * Dispose of the agent and release resources (IAgent interface)
+   */
+  public async dispose(): Promise<void> {
+    await Promise.resolve();
+    this.session = null;
+    this.initialized = false;
+  }
+
+  /**
+   * Get the current session
+   * @returns Current SDP generation session or null if no session is active
+   */
+  public getSession(): SDPGenerationSession | null {
+    return this.session;
+  }
+
+  /**
+   * Start a new SDP generation session
+   * @param projectId - Project identifier
+   * @returns The new session
+   */
+  public async startSession(projectId: string): Promise<SDPGenerationSession> {
+    await Promise.resolve();
+
+    const docsDir = path.join(this.config.scratchpadBasePath, 'documents', projectId);
+    const prdPath = path.join(docsDir, 'prd.md');
+    const srsPath = path.join(docsDir, 'srs.md');
+
+    if (!fs.existsSync(prdPath)) {
+      throw new PRDNotFoundError(projectId, prdPath);
+    }
+    if (!fs.existsSync(srsPath)) {
+      throw new SRSNotFoundError(projectId, srsPath);
+    }
+
+    const prdContent = fs.readFileSync(prdPath, 'utf-8');
+    const srsContent = fs.readFileSync(srsPath, 'utf-8');
+
+    const parsedPRD = this.extractPRD(prdContent, projectId);
+    const parsedSRS = this.extractSRS(srsContent, projectId, parsedPRD.documentId);
+
+    const warnings: string[] = [];
+    if (parsedSRS.featureCount === 0) {
+      warnings.push('No features detected in SRS — generated SDP uses default scope assumptions.');
+    }
+
+    this.session = {
+      sessionId: randomUUID(),
+      projectId,
+      status: 'pending',
+      parsedPRD,
+      parsedSRS,
+      startedAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      ...(warnings.length > 0 && { warnings }),
+    };
+
+    return this.session;
+  }
+
+  /**
+   * Generate SDP from a project
+   * @param projectId - Project identifier
+   * @returns Generation result
+   */
+  public async generateFromProject(projectId: string): Promise<SDPGenerationResult> {
+    const startTime = Date.now();
+
+    if (!this.session || this.session.projectId !== projectId) {
+      await this.startSession(projectId);
+    }
+
+    if (!this.session) {
+      throw new GenerationError(projectId, 'initialization', 'Failed to create session');
+    }
+
+    try {
+      this.updateSession({ status: 'parsing' });
+
+      const { parsedPRD, parsedSRS } = this.session;
+
+      this.updateSession({ status: 'generating' });
+
+      // Carry forward warnings collected during startSession (e.g. empty SRS)
+      // and let generateSDPDocument append further warnings (e.g. missing
+      // PRD timeline) into the same array.
+      const warnings: string[] = this.session.warnings ? [...this.session.warnings] : [];
+
+      const generatedSDP = this.generateSDPDocument(projectId, parsedPRD, parsedSRS, warnings);
+
+      this.updateSession({
+        status: 'completed',
+        generatedSDP,
+        ...(warnings.length > 0 && { warnings }),
+      });
+
+      const paths = await this.writeOutputFiles(projectId, generatedSDP);
+
+      const stats: SDPGenerationStats = {
+        srsFeatureCount: parsedSRS.featureCount,
+        nfrCount: parsedSRS.nfrCount,
+        milestonesGenerated: generatedSDP.milestones.length,
+        risksGenerated: generatedSDP.risks.length,
+        processingTimeMs: Date.now() - startTime,
+      };
+
+      return {
+        success: true,
+        projectId,
+        scratchpadPath: paths.scratchpadPath,
+        publicPath: paths.publicPath,
+        scratchpadPathKorean: paths.scratchpadPathKorean,
+        publicPathKorean: paths.publicPathKorean,
+        generatedSDP,
+        stats,
+        ...(warnings.length > 0 && { warnings }),
+      };
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+      this.updateSession({
+        status: 'failed',
+        errorMessage,
+      });
+      throw error;
+    }
+  }
+
+  /**
+   * Finalize the current session and write output files
+   * @returns Generation result based on the cached generated SDP
+   */
+  public async finalize(): Promise<SDPGenerationResult> {
+    if (!this.session) {
+      throw new SessionStateError('null', 'active', 'finalize');
+    }
+
+    if (this.session.status !== 'completed') {
+      throw new SessionStateError(this.session.status, 'completed', 'finalize');
+    }
+
+    if (!this.session.generatedSDP) {
+      throw new GenerationError(this.session.projectId, 'finalization', 'No generated SDP');
+    }
+
+    const paths = await this.writeOutputFiles(this.session.projectId, this.session.generatedSDP);
+
+    return {
+      success: true,
+      projectId: this.session.projectId,
+      scratchpadPath: paths.scratchpadPath,
+      publicPath: paths.publicPath,
+      scratchpadPathKorean: paths.scratchpadPathKorean,
+      publicPathKorean: paths.publicPathKorean,
+      generatedSDP: this.session.generatedSDP,
+      stats: {
+        srsFeatureCount: this.session.parsedSRS.featureCount,
+        nfrCount: this.session.parsedSRS.nfrCount,
+        milestonesGenerated: this.session.generatedSDP.milestones.length,
+        risksGenerated: this.session.generatedSDP.risks.length,
+        processingTimeMs: 0,
+      },
+    };
+  }
+
+  /**
+   * Update session with partial data
+   * @param updates - Partial session fields to merge into the current session
+   */
+  private updateSession(updates: Partial<SDPGenerationSession>): void {
+    if (!this.session) return;
+
+    this.session = {
+      ...this.session,
+      ...updates,
+      updatedAt: new Date().toISOString(),
+    };
+  }
+
+  /**
+   * Extract a lightweight PRD summary from PRD markdown content.
+   *
+   * Looks for a top-level title and the first description paragraph; falls
+   * back to defaults derived from the project ID if either is missing.
+   * @param content - Raw PRD markdown
+   * @param projectId - Project identifier (used as fallback)
+   */
+  private extractPRD(content: string, projectId: string): ParsedPRDExtract {
+    const docIdMatch =
+      content.match(/^doc_id:\s*['"]?([^'"\n]+)['"]?/m) ??
+      content.match(/\|\s*\*\*Document ID\*\*\s*\|\s*([^|]+)\s*\|/);
+    const documentId = docIdMatch?.[1]?.trim() ?? `PRD-${projectId}`;
+
+    const titleMatch =
+      content.match(/^#\s+(?:Product Requirements Document:\s*)?(.+)$/m) ??
+      content.match(/^title:\s*['"]?([^'"\n]+)['"]?/m);
+    const productName = titleMatch?.[1]?.trim() ?? projectId;
+
+    // First non-empty paragraph after the first heading is treated as description
+    const descMatch = content.match(/##[^\n]*\n+([^\n#][^\n]*)/);
+    const productDescription = descMatch?.[1]?.trim() ?? '';
+
+    const timelineEntries = this.extractPRDTimeline(content);
+
+    return {
+      documentId,
+      productName,
+      productDescription,
+      timelineEntries,
+    };
+  }
+
+  /**
+   * Extract timeline / milestone entries from a PRD timeline section.
+   *
+   * Supports two PRD layouts:
+   *   1. Markdown table — first column treated as phase, remaining columns
+   *      concatenated into the description.
+   *   2. Bullet list (`- Phase: description` or `- Phase — description`).
+   *
+   * Returns an empty array when no recognisable timeline section is found.
+   * @param content - Raw PRD markdown
+   */
+  private extractPRDTimeline(content: string): readonly PRDTimelineEntry[] {
+    // Locate a section header containing "Timeline", "Schedule", "Milestones",
+    // or the Korean equivalents. We split into lines and walk forward instead
+    // of relying on regex lookaheads with `^#` anchors, which behave
+    // inconsistently across multiline / dotall combinations in ECMAScript.
+    const lines = content.split('\n');
+    // Note: do not use `\b` here — JavaScript's word boundary does not align
+    // with CJK character classes, so it would prevent matches like "## 일정".
+    const headingPattern =
+      /^#{1,6}\s+(?:[\d.]+\s+)?(?:Timeline|Schedule|Milestones?|일정|마일스톤|타임라인)(?:[\s:]|$)/i;
+
+    let startIdx = -1;
+    for (let i = 0; i < lines.length; i++) {
+      if (headingPattern.test(lines[i] ?? '')) {
+        startIdx = i + 1;
+        break;
+      }
+    }
+    if (startIdx === -1) {
+      return [];
+    }
+
+    let endIdx = lines.length;
+    for (let i = startIdx; i < lines.length; i++) {
+      if (/^#{1,6}\s/.test(lines[i] ?? '')) {
+        endIdx = i;
+        break;
+      }
+    }
+
+    const body = lines.slice(startIdx, endIdx).join('\n');
+    const entries: PRDTimelineEntry[] = [];
+
+    // Try table form first.
+    const tableLines = body
+      .split('\n')
+      .filter((line) => line.trim().startsWith('|') && line.trim().endsWith('|'));
+    if (tableLines.length >= 2) {
+      // Skip header (first row) and separator (second row, contains ---).
+      for (let i = 0; i < tableLines.length; i++) {
+        const line = tableLines[i];
+        if (line === undefined) continue;
+        if (i < 2) continue; // header + separator
+        if (/^\|[\s\-:|]+\|$/.test(line.trim())) continue; // extra separator row
+        const cells = line
+          .split('|')
+          .slice(1, -1)
+          .map((c) => c.trim());
+        if (cells.length === 0) continue;
+        const phase = cells[0];
+        if (phase === undefined || phase.length === 0) continue;
+        const description = cells
+          .slice(1)
+          .filter((c) => c.length > 0)
+          .join(' — ');
+        entries.push({ phase, description });
+      }
+      if (entries.length > 0) {
+        return entries;
+      }
+    }
+
+    // Fall back to bullet list form.
+    const bulletRegex = /^\s*[-*]\s+(.+)$/gm;
+    let match: RegExpExecArray | null;
+    while ((match = bulletRegex.exec(body)) !== null) {
+      const text = match[1]?.trim();
+      if (text === undefined || text.length === 0) continue;
+      // Split on " — ", " – ", or ":" to separate phase from description.
+      const splitMatch = text.match(/^([^:—–]+?)\s*[:—–]\s*(.+)$/);
+      if (
+        splitMatch !== null &&
+        splitMatch[1] !== undefined &&
+        splitMatch[1].length > 0 &&
+        splitMatch[2] !== undefined &&
+        splitMatch[2].length > 0
+      ) {
+        entries.push({
+          phase: splitMatch[1].trim(),
+          description: splitMatch[2].trim(),
+        });
+      } else {
+        entries.push({ phase: text, description: '' });
+      }
+    }
+
+    return entries;
+  }
+
+  /**
+   * Extract a lightweight SRS summary from SRS markdown content.
+   *
+   * Counts feature headings (`### SF-xxx`) and NFR headings (`### NFR-xxx`).
+   * @param content - Raw SRS markdown
+   * @param projectId - Project identifier (used as fallback)
+   * @param sourcePRD - PRD document ID to record as the source
+   */
+  private extractSRS(content: string, projectId: string, sourcePRD: string): ParsedSRSExtract {
+    const docIdMatch =
+      content.match(/^doc_id:\s*['"]?([^'"\n]+)['"]?/m) ??
+      content.match(/\|\s*\*\*Document ID\*\*\s*\|\s*([^|]+)\s*\|/);
+    const documentId = docIdMatch?.[1]?.trim() ?? `SRS-${projectId}`;
+
+    const titleMatch =
+      content.match(/^#\s+(?:Software Requirements Specification:\s*)?(.+)$/m) ??
+      content.match(/^title:\s*['"]?([^'"\n]+)['"]?/m);
+    const productName = titleMatch?.[1]?.trim() ?? projectId;
+
+    const featureMatches = content.match(/^###\s+SF-\d+/gm);
+    const featureCount = featureMatches?.length ?? 0;
+
+    const nfrMatches = content.match(/^###\s+NFR-\d+/gm);
+    const nfrCount = nfrMatches?.length ?? 0;
+
+    return {
+      documentId,
+      sourcePRD,
+      productName,
+      featureCount,
+      nfrCount,
+    };
+  }
+
+  /**
+   * Generate the complete SDP document object (metadata + content + milestones + risks).
+   * @param projectId - Project identifier for document naming
+   * @param prd - Parsed PRD extract
+   * @param srs - Parsed SRS extract
+   * @param warnings
+   */
+  private generateSDPDocument(
+    projectId: string,
+    prd: ParsedPRDExtract,
+    srs: ParsedSRSExtract,
+    warnings: string[]
+  ): GeneratedSDP {
+    const now = new Date().toISOString().split('T')[0] ?? '';
+
+    const metadata: SDPMetadata = {
+      documentId: `SDP-${projectId}`,
+      sourcePRD: prd.documentId,
+      sourceSRS: srs.documentId,
+      version: '1.0.0',
+      status: 'Draft',
+      createdDate: now,
+      updatedDate: now,
+    };
+
+    const lifecycle = this.selectLifecycleModel(srs);
+    const milestones = this.generateMilestones(prd, warnings);
+    const risks = this.generateRisks(srs);
+
+    let content = this.generateMarkdownContent(metadata, prd, srs, lifecycle, milestones, risks);
+    let contentKorean = this.generateMarkdownContentKorean(
+      metadata,
+      prd,
+      srs,
+      lifecycle,
+      milestones,
+      risks
+    );
+
+    content = prependFrontmatter(content, {
+      docId: metadata.documentId,
+      title: `SDP: ${prd.productName}`,
+      version: metadata.version,
+      status: metadata.status,
+      generatedBy: 'AD-SDLC SDP Writer Agent',
+      generatedAt: new Date().toISOString(),
+      sourceDocuments: [metadata.sourcePRD, metadata.sourceSRS],
+      changeHistory: [
+        {
+          version: metadata.version,
+          date: now,
+          author: 'AD-SDLC SDP Writer Agent',
+          description: 'Initial document generation',
+        },
+      ],
+    });
+
+    contentKorean = prependFrontmatter(contentKorean, {
+      docId: metadata.documentId,
+      title: `SDP: ${prd.productName} (Korean)`,
+      version: metadata.version,
+      status: metadata.status,
+      generatedBy: 'AD-SDLC SDP Writer Agent',
+      generatedAt: new Date().toISOString(),
+      sourceDocuments: [metadata.sourcePRD, metadata.sourceSRS],
+      changeHistory: [
+        {
+          version: metadata.version,
+          date: now,
+          author: 'AD-SDLC SDP Writer Agent',
+          description: 'Initial document generation (Korean variant)',
+        },
+      ],
+    });
+
+    return {
+      metadata,
+      content,
+      contentKorean,
+      milestones,
+      risks,
+    };
+  }
+
+  /**
+   * Select a lifecycle model based on SRS scope.
+   *
+   * Heuristic (driven by SRS feature count):
+   *   - feature count > 50  → V-Model (large project, formal stage gates)
+   *   - 20 ≤ feature count ≤ 50 → Iterative (mid-size, balanced cadence)
+   *   - feature count < 20  → Agile (small/exploratory, fast feedback)
+   *
+   * If a non-default lifecycle model is configured explicitly, the
+   * configured value wins so callers can still override the heuristic.
+   * @param srs - Parsed SRS extract used to size the project
+   */
+  private selectLifecycleModel(srs: ParsedSRSExtract): {
+    model: string;
+    rationale: string;
+  } {
+    // Allow explicit override via configuration.
+    if (this.config.lifecycleModel !== DEFAULT_CONFIG.lifecycleModel) {
+      return {
+        model: this.config.lifecycleModel,
+        rationale: `Lifecycle model "${this.config.lifecycleModel}" was explicitly configured for this project.`,
+      };
+    }
+
+    const featureCount = srs.featureCount;
+    if (featureCount > 50) {
+      return {
+        model: 'V-Model',
+        rationale: `Selected V-Model because the SRS contains ${String(featureCount)} features (> 50). Large projects benefit from formal stage gates and explicit verification artifacts at every level.`,
+      };
+    }
+    if (featureCount >= 20) {
+      return {
+        model: 'Iterative',
+        rationale: `Selected an Iterative model because the SRS contains ${String(featureCount)} features (20-50). Mid-size projects benefit from incremental delivery with structured iteration boundaries.`,
+      };
+    }
+    return {
+      model: 'Agile',
+      rationale: `Selected an Agile model because the SRS contains ${String(featureCount)} features (< 20). Small projects benefit from short feedback cycles and flexible scope adjustment.`,
+    };
+  }
+
+  /**
+   * Generate the project milestone list.
+   *
+   * If the PRD timeline section is non-empty, milestones are derived from it
+   * (one milestone per timeline entry, prefixed with phase information). If
+   * the PRD timeline is empty, falls back to a stable default milestone set
+   * and pushes a warning describing the fallback.
+   *
+   * @param prd - Parsed PRD extract whose timeline is the primary source
+   * @param warnings - Mutable warnings array to append fallback notices to
+   */
+  private generateMilestones(prd: ParsedPRDExtract, warnings: string[]): readonly SDPMilestone[] {
+    if (prd.timelineEntries.length > 0) {
+      return prd.timelineEntries.map((entry, index) => ({
+        id: `M${String(index + 1)}`,
+        name: entry.phase,
+        description: entry.description.length > 0 ? entry.description : entry.phase,
+        phase: entry.phase,
+      }));
+    }
+
+    warnings.push(
+      'PRD timeline section was empty or missing — SDP milestones fall back to the default lifecycle phases (Planning → Release).'
+    );
+
+    return [
+      {
+        id: 'M1',
+        name: 'Requirements Baseline',
+        description: 'PRD and SRS approved; SDP baseline established.',
+        phase: 'Planning',
+      },
+      {
+        id: 'M2',
+        name: 'Design Baseline',
+        description: 'SDS approved; architecture and component design frozen.',
+        phase: 'Design',
+      },
+      {
+        id: 'M3',
+        name: 'Implementation Complete',
+        description: 'All features implemented and unit-tested.',
+        phase: 'Implementation',
+      },
+      {
+        id: 'M4',
+        name: 'Verification Complete',
+        description: 'Integration and system tests passed; coverage thresholds met.',
+        phase: 'Verification',
+      },
+      {
+        id: 'M5',
+        name: 'Release',
+        description: 'Validation passed; product released and documentation published.',
+        phase: 'Release',
+      },
+    ];
+  }
+
+  /**
+   * Generate the default risk register, augmenting it based on SRS scope.
+   * @param srs - Parsed SRS extract used to derive scope-aware risks
+   */
+  private generateRisks(srs: ParsedSRSExtract): readonly SDPRisk[] {
+    const risks: SDPRisk[] = [
+      {
+        id: 'R1',
+        description: 'Requirements churn during implementation phase.',
+        likelihood: 'Medium',
+        impact: 'High',
+        mitigation: 'Lock SRS baseline before implementation; enforce change control board.',
+      },
+      {
+        id: 'R2',
+        description: 'Underestimated complexity in third-party integrations.',
+        likelihood: 'Medium',
+        impact: 'Medium',
+        mitigation: 'Build integration spikes early; allocate buffer in schedule.',
+      },
+      {
+        id: 'R3',
+        description: 'Insufficient test coverage leading to regressions.',
+        likelihood: 'Low',
+        impact: 'High',
+        mitigation: 'Enforce coverage thresholds in CI; require tests for every PR.',
+      },
+    ];
+
+    if (srs.featureCount >= 10) {
+      risks.push({
+        id: 'R4',
+        description: 'Large feature scope increases coordination overhead across teams.',
+        likelihood: 'Medium',
+        impact: 'Medium',
+        mitigation:
+          'Split work into vertical slices; use the AD-SDLC orchestrator to parallelize delivery.',
+      });
+    }
+
+    if (srs.nfrCount >= 5) {
+      risks.push({
+        id: `R${String(risks.length + 1)}`,
+        description: 'High number of non-functional requirements may impact delivery velocity.',
+        likelihood: 'Medium',
+        impact: 'Medium',
+        mitigation:
+          'Prioritize NFRs by business value; defer non-critical NFRs to post-release iterations.',
+      });
+    }
+
+    return risks;
+  }
+
+  /**
+   * Generate the English markdown content for the SDP.
+   *
+   * Layout follows the 9-section template defined in the SDP template file.
+   * @param metadata - Document metadata for the header section
+   * @param prd - Parsed PRD extract for project overview
+   * @param srs - Parsed SRS extract for scope sizing
+   * @param lifecycle
+   * @param lifecycle.model
+   * @param lifecycle.rationale
+   * @param milestones - Milestones to render in the schedule section
+   * @param risks - Risks to render in the risk management section
+   */
+  private generateMarkdownContent(
+    metadata: SDPMetadata,
+    prd: ParsedPRDExtract,
+    srs: ParsedSRSExtract,
+    lifecycle: { model: string; rationale: string },
+    milestones: readonly SDPMilestone[],
+    risks: readonly SDPRisk[]
+  ): string {
+    const lines: string[] = [];
+
+    lines.push(`# Software Development Plan: ${prd.productName}`);
+    lines.push('');
+
+    lines.push('| **Document ID** | **Source PRD** | **Source SRS** | **Version** | **Status** |');
+    lines.push('|-----------------|----------------|----------------|-------------|------------|');
+    lines.push(
+      `| ${metadata.documentId} | ${metadata.sourcePRD} | ${metadata.sourceSRS} | ${metadata.version} | ${metadata.status} |`
+    );
+    lines.push('');
+    lines.push('---');
+    lines.push('');
+
+    lines.push('## Table of Contents');
+    lines.push('');
+    lines.push('1. [Project Overview](#1-project-overview)');
+    lines.push('2. [Lifecycle Model](#2-lifecycle-model)');
+    lines.push('3. [Development Environment](#3-development-environment)');
+    lines.push('4. [Artifact Definitions](#4-artifact-definitions)');
+    lines.push('5. [QA Strategy](#5-qa-strategy)');
+    lines.push('6. [V&V Strategy](#6-vv-strategy)');
+    lines.push('7. [Risk Management](#7-risk-management)');
+    lines.push('8. [Schedule and Milestones](#8-schedule-and-milestones)');
+    lines.push('9. [Configuration Management](#9-configuration-management)');
+    lines.push('');
+
+    // Section 1: Project Overview
+    lines.push('## 1. Project Overview');
+    lines.push('');
+    lines.push('### 1.1 Product');
+    lines.push('');
+    lines.push(`- **Name:** ${prd.productName}`);
+    lines.push(`- **Source PRD:** ${metadata.sourcePRD}`);
+    lines.push(`- **Source SRS:** ${metadata.sourceSRS}`);
+    lines.push('');
+    lines.push('### 1.2 Description');
+    lines.push('');
+    lines.push(prd.productDescription || 'See referenced PRD for the full product description.');
+    lines.push('');
+    lines.push('### 1.3 Scope Sizing');
+    lines.push('');
+    lines.push('| Metric | Value |');
+    lines.push('|--------|-------|');
+    lines.push(`| Software Features (SRS) | ${String(srs.featureCount)} |`);
+    lines.push(`| Non-Functional Requirements (SRS) | ${String(srs.nfrCount)} |`);
+    lines.push('');
+
+    // Section 2: Lifecycle Model
+    lines.push('## 2. Lifecycle Model');
+    lines.push('');
+    lines.push(`- **Selected Model:** ${lifecycle.model}`);
+    lines.push(`- **Rationale:** ${lifecycle.rationale}`);
+    lines.push('');
+    lines.push('### Selection Heuristic');
+    lines.push('');
+    lines.push('| SRS Feature Count | Lifecycle Model |');
+    lines.push('|-------------------|-----------------|');
+    lines.push('| > 50 | V-Model |');
+    lines.push('| 20 – 50 | Iterative |');
+    lines.push('| < 20 | Agile |');
+    lines.push('');
+    lines.push('### 2.1 Phases');
+    lines.push('');
+    lines.push('1. **Planning** — requirements baseline (PRD, SRS, SDP).');
+    lines.push('2. **Design** — system and component design (SDS).');
+    lines.push('3. **Implementation** — feature delivery via parallel worker agents.');
+    lines.push('4. **Verification** — automated tests, integration, and traceability checks.');
+    lines.push('5. **Release** — validation, packaging, and documentation publication.');
+    lines.push('');
+
+    // Section 3: Development Environment
+    lines.push('## 3. Development Environment');
+    lines.push('');
+    lines.push('### 3.1 Tooling');
+    lines.push('');
+    lines.push('| Category | Tool |');
+    lines.push('|----------|------|');
+    lines.push('| Language | TypeScript 5.x |');
+    lines.push('| Runtime | Node.js 20.x LTS |');
+    lines.push('| Package Manager | npm |');
+    lines.push('| Test Runner | Vitest |');
+    lines.push('| Version Control | Git / GitHub |');
+    lines.push('| CI/CD | GitHub Actions |');
+    lines.push('| Documentation | Markdown + Mermaid diagrams |');
+    lines.push('');
+    lines.push('### 3.2 Team Structure');
+    lines.push('');
+    lines.push('- **AD-SDLC Pipeline Operator** — drives the orchestrator and reviews approvals.');
+    lines.push('- **Worker Agents** — implement individual issues in parallel.');
+    lines.push('- **PR Reviewer Agent** — validates pull requests against quality gates.');
+    lines.push('- **Validation Agent** — verifies acceptance criteria before release.');
+    lines.push('');
+
+    // Section 4: Artifact Definitions
+    lines.push('## 4. Artifact Definitions');
+    lines.push('');
+    lines.push('| Artifact | Producer | Consumer | Storage |');
+    lines.push('|----------|----------|----------|---------|');
+    lines.push('| PRD | PRD Writer Agent | SRS Writer, SDP Writer | `docs/prd/` |');
+    lines.push('| SRS | SRS Writer Agent | SDS Writer, SDP Writer | `docs/srs/` |');
+    lines.push('| SDP | SDP Writer Agent | All downstream agents | `docs/sdp/` |');
+    lines.push('| SDS | SDS Writer Agent | Issue Generator, Workers | `docs/sds/` |');
+    lines.push('| Issues | Issue Generator | Workers | GitHub Issues |');
+    lines.push('| Pull Requests | Worker Agents | PR Reviewer | GitHub Pull Requests |');
+    lines.push('');
+
+    // Section 5: QA Strategy
+    lines.push('## 5. QA Strategy');
+    lines.push('');
+    lines.push('### 5.1 Quality Goals');
+    lines.push('');
+    lines.push('- Maintain ≥80% unit-test coverage on all production modules.');
+    lines.push('- Block merges on lint, type-check, and test failures.');
+    lines.push('- Require human approval at every pipeline stage gate.');
+    lines.push('');
+    lines.push('### 5.2 Quality Activities');
+    lines.push('');
+    lines.push('- **Static Analysis:** TypeScript strict mode + ESLint on every commit.');
+    lines.push('- **Unit Tests:** Vitest, executed in CI on every PR.');
+    lines.push('- **Code Review:** PR Reviewer Agent + human reviewer for every PR.');
+    lines.push('- **Documentation Review:** SDP/SDS/SRS reviewed against PRD acceptance criteria.');
+    lines.push('');
+
+    // Section 6: V&V Strategy
+    lines.push('## 6. V&V Strategy');
+    lines.push('');
+    lines.push('### 6.1 Scope Under V&V');
+    lines.push('');
+    lines.push(
+      `The V&V activities below cover **${String(srs.featureCount)} software feature(s) (SF-xxx)** and **${String(srs.nfrCount)} non-functional requirement(s) (NFR-xxx)** as defined in ${metadata.sourceSRS}.`
+    );
+    lines.push('');
+    lines.push('| Requirement Class | Count | Source |');
+    lines.push('|-------------------|-------|--------|');
+    lines.push(
+      `| Software Features (SF-xxx) | ${String(srs.featureCount)} | ${metadata.sourceSRS} |`
+    );
+    lines.push(
+      `| Non-Functional Requirements (NFR-xxx) | ${String(srs.nfrCount)} | ${metadata.sourceSRS} |`
+    );
+    lines.push('');
+    lines.push('### 6.2 Verification');
+    lines.push('');
+    lines.push('Verification answers: *"Did we build the product right?"*');
+    lines.push('');
+    lines.push(
+      `- Static analysis (TypeScript + ESLint) covering source for all ${String(srs.featureCount)} SF requirements.`
+    );
+    lines.push(
+      `- Unit tests for every module — each of the ${String(srs.featureCount)} SF requirements requires at least one dedicated unit test.`
+    );
+    lines.push('- Integration tests for cross-module flows.');
+    lines.push(
+      `- Traceability matrix linking each of the ${String(srs.featureCount)} SF and ${String(srs.nfrCount)} NFR entries to design (SDS) and tests.`
+    );
+    lines.push('');
+    lines.push('### 6.3 Validation');
+    lines.push('');
+    lines.push('Validation answers: *"Did we build the right product?"*');
+    lines.push('');
+    lines.push(
+      `- Acceptance tests covering all ${String(srs.featureCount)} SRS use cases referenced in ${metadata.sourceSRS}.`
+    );
+    lines.push(
+      `- NFR validation suites for the ${String(srs.nfrCount)} non-functional requirements (performance, security, usability).`
+    );
+    lines.push('- Demo to stakeholders at each milestone.');
+    lines.push('- Validation Agent enforces acceptance criteria from PRD before release.');
+    lines.push('');
+
+    // Section 7: Risk Management
+    lines.push('## 7. Risk Management');
+    lines.push('');
+    lines.push('### 7.1 Risk Register');
+    lines.push('');
+    lines.push('| ID | Risk | Likelihood | Impact | Mitigation |');
+    lines.push('|----|------|------------|--------|------------|');
+    for (const risk of risks) {
+      lines.push(
+        `| ${risk.id} | ${risk.description} | ${risk.likelihood} | ${risk.impact} | ${risk.mitigation} |`
+      );
+    }
+    lines.push('');
+    lines.push('### 7.2 Risk Review Cadence');
+    lines.push('');
+    lines.push('- Risks reviewed at each milestone.');
+    lines.push('- New risks added to the register as they are discovered.');
+    lines.push('');
+
+    // Section 8: Schedule & Milestones
+    lines.push('## 8. Schedule and Milestones');
+    lines.push('');
+    lines.push('### 8.1 Milestones');
+    lines.push('');
+    lines.push('| ID | Milestone | Phase | Description |');
+    lines.push('|----|-----------|-------|-------------|');
+    for (const milestone of milestones) {
+      lines.push(
+        `| ${milestone.id} | ${milestone.name} | ${milestone.phase} | ${milestone.description} |`
+      );
+    }
+    lines.push('');
+    lines.push('### 8.2 Delivery Cadence');
+    lines.push('');
+    lines.push(
+      '- Milestones are delivered iteratively; each milestone gates the next phase via human approval.'
+    );
+    lines.push('');
+
+    // Section 9: Configuration Management
+    lines.push('## 9. Configuration Management');
+    lines.push('');
+    lines.push('### 9.1 Source Control');
+    lines.push('');
+    lines.push('- All code, documents, and infrastructure-as-code are stored in Git.');
+    lines.push('- Branching: feature branches per issue, merged via squash to `main`.');
+    lines.push('');
+    lines.push('### 9.2 Document Control');
+    lines.push('');
+    lines.push('- PRD/SRS/SDP/SDS carry YAML frontmatter (`doc_id`, `version`, `status`).');
+    lines.push('- Change history is recorded in the document frontmatter.');
+    lines.push('- Bilingual variants (`.md`, `.kr.md`) are produced for end-user documents.');
+    lines.push('');
+    lines.push('### 9.3 Release Control');
+    lines.push('');
+    lines.push('- Releases are tagged in Git using semantic versioning.');
+    lines.push('- Each release records the PRD, SRS, SDP, and SDS document versions in scope.');
+    lines.push('');
+
+    return lines.join('\n');
+  }
+
+  /**
+   * Generate the Korean variant of the SDP markdown content.
+   *
+   * Mirrors the English structure with localized headings and prose.
+   * @param metadata - Document metadata for the header section
+   * @param prd - Parsed PRD extract for project overview
+   * @param srs - Parsed SRS extract for scope sizing
+   * @param lifecycle
+   * @param lifecycle.model
+   * @param lifecycle.rationale
+   * @param milestones - Milestones to render in the schedule section
+   * @param risks - Risks to render in the risk management section
+   */
+  private generateMarkdownContentKorean(
+    metadata: SDPMetadata,
+    prd: ParsedPRDExtract,
+    srs: ParsedSRSExtract,
+    lifecycle: { model: string; rationale: string },
+    milestones: readonly SDPMilestone[],
+    risks: readonly SDPRisk[]
+  ): string {
+    const lines: string[] = [];
+
+    lines.push(`# 소프트웨어 개발 계획서: ${prd.productName}`);
+    lines.push('');
+
+    lines.push('| **문서 ID** | **출처 PRD** | **출처 SRS** | **버전** | **상태** |');
+    lines.push('|-------------|--------------|--------------|----------|----------|');
+    lines.push(
+      `| ${metadata.documentId} | ${metadata.sourcePRD} | ${metadata.sourceSRS} | ${metadata.version} | ${metadata.status} |`
+    );
+    lines.push('');
+    lines.push('---');
+    lines.push('');
+
+    lines.push('## 목차');
+    lines.push('');
+    lines.push('1. [프로젝트 개요](#1-프로젝트-개요)');
+    lines.push('2. [생명주기 모델](#2-생명주기-모델)');
+    lines.push('3. [개발 환경](#3-개발-환경)');
+    lines.push('4. [산출물 정의](#4-산출물-정의)');
+    lines.push('5. [품질 보증 전략](#5-품질-보증-전략)');
+    lines.push('6. [V&V 전략](#6-vv-전략)');
+    lines.push('7. [리스크 관리](#7-리스크-관리)');
+    lines.push('8. [일정 및 마일스톤](#8-일정-및-마일스톤)');
+    lines.push('9. [형상 관리](#9-형상-관리)');
+    lines.push('');
+
+    lines.push('## 1. 프로젝트 개요');
+    lines.push('');
+    lines.push('### 1.1 제품');
+    lines.push('');
+    lines.push(`- **이름:** ${prd.productName}`);
+    lines.push(`- **출처 PRD:** ${metadata.sourcePRD}`);
+    lines.push(`- **출처 SRS:** ${metadata.sourceSRS}`);
+    lines.push('');
+    lines.push('### 1.2 설명');
+    lines.push('');
+    lines.push(prd.productDescription || '전체 제품 설명은 참조된 PRD를 확인하세요.');
+    lines.push('');
+    lines.push('### 1.3 범위 산정');
+    lines.push('');
+    lines.push('| 지표 | 값 |');
+    lines.push('|------|-----|');
+    lines.push(`| 소프트웨어 기능 (SRS) | ${String(srs.featureCount)} |`);
+    lines.push(`| 비기능 요구사항 (SRS) | ${String(srs.nfrCount)} |`);
+    lines.push('');
+
+    lines.push('## 2. 생명주기 모델');
+    lines.push('');
+    lines.push(`- **선택 모델:** ${lifecycle.model}`);
+    lines.push(`- **근거:** ${lifecycle.rationale}`);
+    lines.push('');
+    lines.push('### 선택 휴리스틱');
+    lines.push('');
+    lines.push('| SRS 기능 수 | 생명주기 모델 |');
+    lines.push('|-------------|---------------|');
+    lines.push('| 50 초과 | V-Model |');
+    lines.push('| 20 ~ 50 | Iterative |');
+    lines.push('| 20 미만 | Agile |');
+    lines.push('');
+    lines.push('### 2.1 단계');
+    lines.push('');
+    lines.push('1. **계획** — 요구사항 베이스라인(PRD, SRS, SDP) 확립.');
+    lines.push('2. **설계** — 시스템 및 컴포넌트 설계(SDS).');
+    lines.push('3. **구현** — 병렬 워커 에이전트를 통한 기능 인도.');
+    lines.push('4. **검증** — 자동화 테스트, 통합, 추적성 점검.');
+    lines.push('5. **출시** — 유효성 검사, 패키징, 문서 공개.');
+    lines.push('');
+
+    lines.push('## 3. 개발 환경');
+    lines.push('');
+    lines.push('### 3.1 도구');
+    lines.push('');
+    lines.push('| 분류 | 도구 |');
+    lines.push('|------|------|');
+    lines.push('| 언어 | TypeScript 5.x |');
+    lines.push('| 런타임 | Node.js 20.x LTS |');
+    lines.push('| 패키지 관리 | npm |');
+    lines.push('| 테스트 러너 | Vitest |');
+    lines.push('| 형상 관리 | Git / GitHub |');
+    lines.push('| CI/CD | GitHub Actions |');
+    lines.push('| 문서화 | Markdown + Mermaid 다이어그램 |');
+    lines.push('');
+    lines.push('### 3.2 팀 구성');
+    lines.push('');
+    lines.push('- **AD-SDLC 파이프라인 운영자** — 오케스트레이터를 구동하고 승인을 검토합니다.');
+    lines.push('- **워커 에이전트** — 개별 이슈를 병렬로 구현합니다.');
+    lines.push('- **PR 리뷰어 에이전트** — 품질 게이트를 통해 풀 리퀘스트를 검증합니다.');
+    lines.push('- **검증 에이전트** — 출시 전 인수 기준을 확인합니다.');
+    lines.push('');
+
+    lines.push('## 4. 산출물 정의');
+    lines.push('');
+    lines.push('| 산출물 | 생성자 | 소비자 | 저장 위치 |');
+    lines.push('|--------|--------|--------|-----------|');
+    lines.push('| PRD | PRD Writer Agent | SRS Writer, SDP Writer | `docs/prd/` |');
+    lines.push('| SRS | SRS Writer Agent | SDS Writer, SDP Writer | `docs/srs/` |');
+    lines.push('| SDP | SDP Writer Agent | 모든 후속 에이전트 | `docs/sdp/` |');
+    lines.push('| SDS | SDS Writer Agent | Issue Generator, Workers | `docs/sds/` |');
+    lines.push('| 이슈 | Issue Generator | Workers | GitHub Issues |');
+    lines.push('| 풀 리퀘스트 | Worker Agents | PR Reviewer | GitHub Pull Requests |');
+    lines.push('');
+
+    lines.push('## 5. 품질 보증 전략');
+    lines.push('');
+    lines.push('### 5.1 품질 목표');
+    lines.push('');
+    lines.push('- 모든 운영 모듈에서 단위 테스트 커버리지 80% 이상 유지.');
+    lines.push('- 린트, 타입 체크, 테스트 실패 시 머지 차단.');
+    lines.push('- 모든 파이프라인 단계 게이트에서 사람의 승인 요구.');
+    lines.push('');
+    lines.push('### 5.2 품질 활동');
+    lines.push('');
+    lines.push('- **정적 분석:** 모든 커밋에 TypeScript strict + ESLint 적용.');
+    lines.push('- **단위 테스트:** Vitest, 모든 PR마다 CI에서 실행.');
+    lines.push('- **코드 리뷰:** 모든 PR에 대해 PR Reviewer Agent + 사람 리뷰어.');
+    lines.push('- **문서 리뷰:** SDP/SDS/SRS를 PRD 인수 기준 대비 검토.');
+    lines.push('');
+
+    lines.push('## 6. V&V 전략');
+    lines.push('');
+    lines.push('### 6.1 V&V 대상 범위');
+    lines.push('');
+    lines.push(
+      `아래 V&V 활동은 ${metadata.sourceSRS}에 정의된 **소프트웨어 기능 ${String(srs.featureCount)}건(SF-xxx)** 과 **비기능 요구사항 ${String(srs.nfrCount)}건(NFR-xxx)** 을 대상으로 합니다.`
+    );
+    lines.push('');
+    lines.push('| 요구사항 분류 | 개수 | 출처 |');
+    lines.push('|---------------|------|------|');
+    lines.push(
+      `| 소프트웨어 기능 (SF-xxx) | ${String(srs.featureCount)} | ${metadata.sourceSRS} |`
+    );
+    lines.push(`| 비기능 요구사항 (NFR-xxx) | ${String(srs.nfrCount)} | ${metadata.sourceSRS} |`);
+    lines.push('');
+    lines.push('### 6.2 검증(Verification)');
+    lines.push('');
+    lines.push('검증은 *"제품을 올바르게 만들었는가?"* 에 대한 답입니다.');
+    lines.push('');
+    lines.push(
+      `- ${String(srs.featureCount)}개 SF 요구사항 전체 소스에 대한 정적 분석(TypeScript + ESLint).`
+    );
+    lines.push(
+      `- 모든 모듈에 대한 단위 테스트 — ${String(srs.featureCount)}개 SF 요구사항마다 최소 한 건의 단위 테스트가 필요합니다.`
+    );
+    lines.push('- 모듈 간 흐름에 대한 통합 테스트.');
+    lines.push(
+      `- ${String(srs.featureCount)}개 SF와 ${String(srs.nfrCount)}개 NFR 항목을 설계(SDS) 및 테스트와 연결하는 추적성 매트릭스.`
+    );
+    lines.push('');
+    lines.push('### 6.3 유효성 확인(Validation)');
+    lines.push('');
+    lines.push('유효성 확인은 *"올바른 제품을 만들었는가?"* 에 대한 답입니다.');
+    lines.push('');
+    lines.push(
+      `- ${metadata.sourceSRS}에 참조된 ${String(srs.featureCount)}개 SRS 사용 사례 전체에 대한 인수 테스트.`
+    );
+    lines.push(
+      `- ${String(srs.nfrCount)}개 비기능 요구사항(성능, 보안, 사용성)에 대한 NFR 검증 스위트.`
+    );
+    lines.push('- 각 마일스톤에서 이해관계자 시연.');
+    lines.push('- 출시 전 Validation Agent가 PRD 인수 기준을 강제 적용.');
+    lines.push('');
+
+    lines.push('## 7. 리스크 관리');
+    lines.push('');
+    lines.push('### 7.1 리스크 등록부');
+    lines.push('');
+    lines.push('| ID | 리스크 | 발생 가능성 | 영향 | 완화 방안 |');
+    lines.push('|----|--------|-------------|------|-----------|');
+    for (const risk of risks) {
+      lines.push(
+        `| ${risk.id} | ${risk.description} | ${risk.likelihood} | ${risk.impact} | ${risk.mitigation} |`
+      );
+    }
+    lines.push('');
+    lines.push('### 7.2 리스크 검토 주기');
+    lines.push('');
+    lines.push('- 각 마일스톤에서 리스크를 검토합니다.');
+    lines.push('- 새로운 리스크는 발견 시점에 등록부에 추가됩니다.');
+    lines.push('');
+
+    lines.push('## 8. 일정 및 마일스톤');
+    lines.push('');
+    lines.push('### 8.1 마일스톤');
+    lines.push('');
+    lines.push('| ID | 마일스톤 | 단계 | 설명 |');
+    lines.push('|----|----------|------|------|');
+    for (const milestone of milestones) {
+      lines.push(
+        `| ${milestone.id} | ${milestone.name} | ${milestone.phase} | ${milestone.description} |`
+      );
+    }
+    lines.push('');
+    lines.push('### 8.2 인도 주기');
+    lines.push('');
+    lines.push(
+      '- 마일스톤은 반복적으로 인도되며, 각 마일스톤은 사람의 승인을 통해 다음 단계로 게이트됩니다.'
+    );
+    lines.push('');
+
+    lines.push('## 9. 형상 관리');
+    lines.push('');
+    lines.push('### 9.1 소스 관리');
+    lines.push('');
+    lines.push('- 모든 코드, 문서, IaC는 Git에 저장됩니다.');
+    lines.push('- 브랜치 전략: 이슈별 피처 브랜치를 squash 머지로 `main`에 통합합니다.');
+    lines.push('');
+    lines.push('### 9.2 문서 관리');
+    lines.push('');
+    lines.push('- PRD/SRS/SDP/SDS는 YAML 프론트매터(`doc_id`, `version`, `status`)를 포함합니다.');
+    lines.push('- 변경 이력은 문서 프론트매터에 기록됩니다.');
+    lines.push('- 최종 사용자 문서는 한/영 이중 언어 변형(`.md`, `.kr.md`)으로 생성됩니다.');
+    lines.push('');
+    lines.push('### 9.3 릴리스 관리');
+    lines.push('');
+    lines.push('- 릴리스는 Git에서 시맨틱 버저닝으로 태깅됩니다.');
+    lines.push('- 각 릴리스는 범위에 포함된 PRD, SRS, SDP, SDS 문서 버전을 기록합니다.');
+    lines.push('');
+
+    return lines.join('\n');
+  }
+
+  /**
+   * Write the SDP output files (English + Korean) to scratchpad and public locations.
+   * @param projectId - Project identifier for directory and file naming
+   * @param sdp - Generated SDP document to write
+   * @returns Paths to all four written files
+   */
+  private async writeOutputFiles(
+    projectId: string,
+    sdp: GeneratedSDP
+  ): Promise<{
+    scratchpadPath: string;
+    publicPath: string;
+    scratchpadPathKorean: string;
+    publicPathKorean: string;
+  }> {
+    await Promise.resolve();
+
+    const scratchpadDir = path.join(this.config.scratchpadBasePath, 'documents', projectId);
+    const scratchpadPath = path.join(scratchpadDir, 'sdp.md');
+    const scratchpadPathKorean = path.join(scratchpadDir, 'sdp.kr.md');
+
+    const publicDir = this.config.publicDocsPath;
+    const publicPath = path.join(publicDir, `SDP-${projectId}.md`);
+    const publicPathKorean = path.join(publicDir, `SDP-${projectId}.kr.md`);
+
+    try {
+      fs.mkdirSync(scratchpadDir, { recursive: true });
+      fs.mkdirSync(publicDir, { recursive: true });
+
+      fs.writeFileSync(scratchpadPath, sdp.content, 'utf-8');
+      fs.writeFileSync(publicPath, sdp.content, 'utf-8');
+      fs.writeFileSync(scratchpadPathKorean, sdp.contentKorean, 'utf-8');
+      fs.writeFileSync(publicPathKorean, sdp.contentKorean, 'utf-8');
+
+      return { scratchpadPath, publicPath, scratchpadPathKorean, publicPathKorean };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      throw new FileWriteError(scratchpadPath, message);
+    }
+  }
+}
+
+// Singleton pattern
+let instance: SDPWriterAgent | null = null;
+
+/**
+ * Get the singleton instance of SDPWriterAgent
+ * @param config - Optional configuration (used only for the first call)
+ * @returns The singleton instance
+ */
+export function getSDPWriterAgent(config?: SDPWriterAgentConfig): SDPWriterAgent {
+  if (!instance) {
+    instance = new SDPWriterAgent(config);
+  }
+  return instance;
+}
+
+/**
+ * Reset the singleton instance (mainly for testing)
+ */
+export function resetSDPWriterAgent(): void {
+  instance = null;
+}

--- a/src/sdp-writer/errors.ts
+++ b/src/sdp-writer/errors.ts
@@ -1,0 +1,98 @@
+/**
+ * SDP Writer Agent module error definitions
+ *
+ * Custom error classes for SDP generation and validation operations.
+ */
+
+/**
+ * Base error class for SDP writer agent errors
+ */
+export class SDPWriterError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'SDPWriterError';
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
+
+/**
+ * Error thrown when the PRD document is not found
+ */
+export class PRDNotFoundError extends SDPWriterError {
+  /** The project ID that was not found */
+  public readonly projectId: string;
+  /** The path that was searched */
+  public readonly searchedPath: string;
+
+  constructor(projectId: string, searchedPath: string) {
+    super(`PRD document not found for project "${projectId}" at path: ${searchedPath}`);
+    this.name = 'PRDNotFoundError';
+    this.projectId = projectId;
+    this.searchedPath = searchedPath;
+  }
+}
+
+/**
+ * Error thrown when the SRS document is not found
+ */
+export class SRSNotFoundError extends SDPWriterError {
+  /** The project ID that was not found */
+  public readonly projectId: string;
+  /** The path that was searched */
+  public readonly searchedPath: string;
+
+  constructor(projectId: string, searchedPath: string) {
+    super(`SRS document not found for project "${projectId}" at path: ${searchedPath}`);
+    this.name = 'SRSNotFoundError';
+    this.projectId = projectId;
+    this.searchedPath = searchedPath;
+  }
+}
+
+/**
+ * Error thrown when a session is in an invalid state for an operation
+ */
+export class SessionStateError extends SDPWriterError {
+  /** Current session state */
+  public readonly currentState: string;
+  /** Expected state */
+  public readonly expectedState: string;
+
+  constructor(currentState: string, expectedState: string, action: string) {
+    super(`Cannot ${action}: session is in "${currentState}" state, expected "${expectedState}"`);
+    this.name = 'SessionStateError';
+    this.currentState = currentState;
+    this.expectedState = expectedState;
+  }
+}
+
+/**
+ * Error thrown when SDP generation fails
+ */
+export class GenerationError extends SDPWriterError {
+  /** The phase where generation failed */
+  public readonly phase: string;
+  /** The project ID */
+  public readonly projectId: string;
+
+  constructor(projectId: string, phase: string, reason: string) {
+    super(`SDP generation failed for project "${projectId}" at "${phase}": ${reason}`);
+    this.name = 'GenerationError';
+    this.projectId = projectId;
+    this.phase = phase;
+  }
+}
+
+/**
+ * Error thrown when a file write operation fails
+ */
+export class FileWriteError extends SDPWriterError {
+  /** The file path that failed */
+  public readonly filePath: string;
+
+  constructor(filePath: string, reason: string) {
+    super(`Failed to write SDP to "${filePath}": ${reason}`);
+    this.name = 'FileWriteError';
+    this.filePath = filePath;
+  }
+}

--- a/src/sdp-writer/index.ts
+++ b/src/sdp-writer/index.ts
@@ -1,0 +1,49 @@
+/**
+ * SDP Writer Agent module
+ *
+ * Generates Software Development Plan (SDP) documents from
+ * PRD and SRS inputs. The SDP captures lifecycle, tools, team,
+ * V&V strategy, and delivery milestones for a project.
+ *
+ * @module sdp-writer
+ */
+
+// Main agent class (singleton + constructor)
+export {
+  SDPWriterAgent,
+  getSDPWriterAgent,
+  resetSDPWriterAgent,
+  SDP_WRITER_AGENT_ID,
+} from './SDPWriterAgent.js';
+
+// Error classes
+export {
+  SDPWriterError,
+  PRDNotFoundError,
+  SRSNotFoundError,
+  SessionStateError,
+  GenerationError,
+  FileWriteError,
+} from './errors.js';
+
+// Type exports
+export type {
+  // Status and config
+  SDPGenerationStatus,
+  SDPDocumentStatus,
+  SDPWriterAgentConfig,
+  SDPGenerationSession,
+  SDPGenerationResult,
+  SDPGenerationStats,
+
+  // Parsed input types
+  ParsedPRDExtract,
+  ParsedSRSExtract,
+  PRDTimelineEntry,
+
+  // SDP output types
+  SDPMetadata,
+  SDPMilestone,
+  SDPRisk,
+  GeneratedSDP,
+} from './types.js';

--- a/src/sdp-writer/types.ts
+++ b/src/sdp-writer/types.ts
@@ -1,0 +1,225 @@
+/**
+ * SDP Writer Agent module type definitions
+ *
+ * Defines types for Software Development Plan (SDP) generation from PRD and
+ * SRS documents. The SDP captures lifecycle, tools, team, V&V strategy, and
+ * delivery milestones for a project.
+ */
+
+/**
+ * SDP generation status
+ */
+export type SDPGenerationStatus = 'pending' | 'parsing' | 'generating' | 'completed' | 'failed';
+
+/**
+ * Document status
+ */
+export type SDPDocumentStatus = 'Draft' | 'Review' | 'Approved';
+
+// ============================================================================
+// Parsed Input Types (lightweight extracts from PRD/SRS markdown)
+// ============================================================================
+
+/**
+ * Lightweight PRD extract used by the SDP Writer.
+ *
+ * The SDP only needs high-level product context — no need to fully parse the
+ * PRD into features and use cases.
+ */
+export interface ParsedPRDExtract {
+  /** PRD document ID, e.g., "PRD-my-project" */
+  readonly documentId: string;
+  /** Product name */
+  readonly productName: string;
+  /** Short product description (one paragraph or empty) */
+  readonly productDescription: string;
+  /** Timeline entries extracted from the PRD timeline section (empty if absent) */
+  readonly timelineEntries: readonly PRDTimelineEntry[];
+}
+
+/**
+ * A single timeline entry extracted from the PRD timeline section.
+ *
+ * The PRD writer typically renders timelines as either a markdown table
+ * (`| Phase | Date | ... |`) or a bullet list (`- Phase: description`).
+ * Both formats are normalized into this shape.
+ */
+export interface PRDTimelineEntry {
+  /** Phase or milestone label as written in the PRD */
+  readonly phase: string;
+  /** Optional description / deliverables text */
+  readonly description: string;
+}
+
+/**
+ * Lightweight SRS extract used by the SDP Writer.
+ *
+ * Captures only the SRS metadata, feature count, NFR count, and source PRD
+ * reference needed to scope the development plan.
+ */
+export interface ParsedSRSExtract {
+  /** SRS document ID, e.g., "SRS-my-project" */
+  readonly documentId: string;
+  /** Source PRD document ID */
+  readonly sourcePRD: string;
+  /** Product name (mirrored from PRD) */
+  readonly productName: string;
+  /** Number of features detected in the SRS */
+  readonly featureCount: number;
+  /** Number of non-functional requirements detected in the SRS */
+  readonly nfrCount: number;
+}
+
+// ============================================================================
+// SDP Output Types
+// ============================================================================
+
+/**
+ * SDP document metadata
+ */
+export interface SDPMetadata {
+  /** Document ID, e.g., "SDP-my-project" */
+  readonly documentId: string;
+  /** Source PRD document reference */
+  readonly sourcePRD: string;
+  /** Source SRS document reference */
+  readonly sourceSRS: string;
+  /** Document version */
+  readonly version: string;
+  /** Document status */
+  readonly status: SDPDocumentStatus;
+  /** ISO date (YYYY-MM-DD) */
+  readonly createdDate: string;
+  /** ISO date (YYYY-MM-DD) */
+  readonly updatedDate: string;
+}
+
+/**
+ * A single milestone in the project schedule
+ */
+export interface SDPMilestone {
+  /** Milestone identifier, e.g., "M1" */
+  readonly id: string;
+  /** Milestone name */
+  readonly name: string;
+  /** Description of deliverables */
+  readonly description: string;
+  /** Phase the milestone belongs to */
+  readonly phase: string;
+}
+
+/**
+ * A risk entry in the risk management section
+ */
+export interface SDPRisk {
+  /** Risk identifier, e.g., "R1" */
+  readonly id: string;
+  /** Risk description */
+  readonly description: string;
+  /** Likelihood (Low/Medium/High) */
+  readonly likelihood: 'Low' | 'Medium' | 'High';
+  /** Impact (Low/Medium/High) */
+  readonly impact: 'Low' | 'Medium' | 'High';
+  /** Mitigation strategy */
+  readonly mitigation: string;
+}
+
+/**
+ * Generated SDP document
+ */
+export interface GeneratedSDP {
+  /** SDP metadata */
+  readonly metadata: SDPMetadata;
+  /** Raw markdown content (English) */
+  readonly content: string;
+  /** Raw markdown content (Korean variant) */
+  readonly contentKorean: string;
+  /** Milestones included in the schedule section */
+  readonly milestones: readonly SDPMilestone[];
+  /** Risks included in the risk management section */
+  readonly risks: readonly SDPRisk[];
+}
+
+// ============================================================================
+// Agent Configuration and Session Types
+// ============================================================================
+
+/**
+ * SDP Writer Agent configuration options
+ */
+export interface SDPWriterAgentConfig {
+  /** Base path for scratchpad (defaults to .ad-sdlc/scratchpad) */
+  readonly scratchpadBasePath?: string;
+  /** Path to the SDP template (defaults to .ad-sdlc/templates/sdp-template.md) */
+  readonly templatePath?: string;
+  /** Output directory for public SDP docs (defaults to docs/sdp) */
+  readonly publicDocsPath?: string;
+  /** Lifecycle model name (defaults to "Iterative / Agile") */
+  readonly lifecycleModel?: string;
+}
+
+/**
+ * SDP generation session
+ */
+export interface SDPGenerationSession {
+  /** Session identifier */
+  readonly sessionId: string;
+  /** Project identifier */
+  readonly projectId: string;
+  /** Current generation status */
+  readonly status: SDPGenerationStatus;
+  /** Parsed PRD extract */
+  readonly parsedPRD: ParsedPRDExtract;
+  /** Parsed SRS extract */
+  readonly parsedSRS: ParsedSRSExtract;
+  /** Generated SDP (when completed) */
+  readonly generatedSDP?: GeneratedSDP;
+  /** Session start time (ISO timestamp) */
+  readonly startedAt: string;
+  /** Session last update time (ISO timestamp) */
+  readonly updatedAt: string;
+  /** Error message if failed */
+  readonly errorMessage?: string;
+  /** Non-fatal warnings accumulated during generation */
+  readonly warnings?: readonly string[];
+}
+
+/**
+ * SDP generation result
+ */
+export interface SDPGenerationResult {
+  /** Whether generation was successful */
+  readonly success: boolean;
+  /** Project identifier */
+  readonly projectId: string;
+  /** Path to the generated SDP in scratchpad (English) */
+  readonly scratchpadPath: string;
+  /** Path to the public SDP document (English) */
+  readonly publicPath: string;
+  /** Path to the generated SDP in scratchpad (Korean) */
+  readonly scratchpadPathKorean: string;
+  /** Path to the public SDP document (Korean) */
+  readonly publicPathKorean: string;
+  /** Generated SDP content */
+  readonly generatedSDP: GeneratedSDP;
+  /** Generation statistics */
+  readonly stats: SDPGenerationStats;
+  /** Non-fatal warnings from generation */
+  readonly warnings?: readonly string[];
+}
+
+/**
+ * Statistics about the SDP generation process
+ */
+export interface SDPGenerationStats {
+  /** Number of SRS features considered when sizing the plan */
+  readonly srsFeatureCount: number;
+  /** Number of NFRs considered when sizing the plan */
+  readonly nfrCount: number;
+  /** Number of milestones generated */
+  readonly milestonesGenerated: number;
+  /** Number of risks listed */
+  readonly risksGenerated: number;
+  /** Total processing time in milliseconds */
+  readonly processingTimeMs: number;
+}

--- a/tests/ad-sdlc-orchestrator/AdsdlcOrchestratorAgent.test.ts
+++ b/tests/ad-sdlc-orchestrator/AdsdlcOrchestratorAgent.test.ts
@@ -1212,8 +1212,8 @@ describe('AdsdlcOrchestratorAgent', () => {
 });
 
 describe('GREENFIELD_STAGES', () => {
-  it('should define 14 stages', () => {
-    expect(GREENFIELD_STAGES).toHaveLength(14);
+  it('should define 15 stages', () => {
+    expect(GREENFIELD_STAGES).toHaveLength(15);
   });
 
   it('should start with initialization and end with doc_indexing', () => {
@@ -1236,11 +1236,28 @@ describe('GREENFIELD_STAGES', () => {
     expect(stageMap.get('collection')).toBe('collector');
     expect(stageMap.get('prd_generation')).toBe('prd-writer');
     expect(stageMap.get('srs_generation')).toBe('srs-writer');
+    expect(stageMap.get('sdp_generation')).toBe('sdp-writer');
     expect(stageMap.get('sds_generation')).toBe('sds-writer');
     expect(stageMap.get('issue_generation')).toBe('issue-generator');
     expect(stageMap.get('orchestration')).toBe('controller');
     expect(stageMap.get('implementation')).toBe('worker');
     expect(stageMap.get('review')).toBe('pr-reviewer');
+  });
+
+  it('should place sdp_generation between srs_generation and repo_detection', () => {
+    const stageNames = GREENFIELD_STAGES.map((s) => s.name);
+    const srsIdx = stageNames.indexOf('srs_generation');
+    const sdpIdx = stageNames.indexOf('sdp_generation');
+    const repoIdx = stageNames.indexOf('repo_detection');
+    expect(srsIdx).toBeGreaterThanOrEqual(0);
+    expect(sdpIdx).toBeGreaterThan(srsIdx);
+    expect(repoIdx).toBeGreaterThan(sdpIdx);
+
+    const sdpStage = GREENFIELD_STAGES.find((s) => s.name === 'sdp_generation');
+    expect(sdpStage?.dependsOn).toContain('srs_generation');
+
+    const repoStage = GREENFIELD_STAGES.find((s) => s.name === 'repo_detection');
+    expect(repoStage?.dependsOn).toContain('sdp_generation');
   });
 });
 

--- a/tests/e2e/fixtures/pipeline-fixtures.ts
+++ b/tests/e2e/fixtures/pipeline-fixtures.ts
@@ -115,6 +115,50 @@ export const srsOutput = [
 ].join('\n');
 
 /**
+ * Output from the sdp-writer agent.
+ * Generates a Software Development Plan document from PRD and SRS.
+ */
+export const sdpOutput = [
+  '# Software Development Plan',
+  '',
+  '## 1. Project Overview',
+  '- Project: smoke-test-project',
+  '- Stakeholders: Product, Engineering, QA',
+  '',
+  '## 2. Development Lifecycle Model',
+  '- Model: Iterative',
+  '- Sprint length: 2 weeks',
+  '',
+  '## 3. Development Environment',
+  '- Language: TypeScript',
+  '- VCS: Git / GitHub',
+  '- CI: GitHub Actions',
+  '',
+  '## 4. Artifact Definitions',
+  '- PRD, SRS, SDS, Source Code, Test Suite',
+  '',
+  '## 5. Quality Assurance Strategy',
+  '- Code review on every PR',
+  '- Coverage threshold: 80%',
+  '',
+  '## 6. Verification & Validation Strategy',
+  '- Derived from 2 SRS features',
+  '- Unit, integration, and E2E test levels',
+  '',
+  '## 7. Risk Management',
+  '- Schedule risk: medium',
+  '',
+  '## 8. Schedule & Milestones',
+  '- M1: PRD approved',
+  '- M2: SRS approved',
+  '- M3: Implementation complete',
+  '',
+  '## 9. Configuration Management',
+  '- Branch strategy: feature branches from main',
+  '- Release tagging: semver',
+].join('\n');
+
+/**
  * Output from the repo-detector agent.
  * Checks for existing repository presence.
  */
@@ -263,6 +307,7 @@ export const GREENFIELD_RESPONSES: Record<string, string> = {
   collector: collectorOutput,
   'prd-writer': prdOutput,
   'srs-writer': srsOutput,
+  'sdp-writer': sdpOutput,
   'repo-detector': repoDetectorOutput,
   'github-repo-setup': githubRepoSetupOutput,
   'sds-writer': sdsOutput,

--- a/tests/sdp-writer/SDPWriterAgent.test.ts
+++ b/tests/sdp-writer/SDPWriterAgent.test.ts
@@ -1,0 +1,720 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import {
+  SDPWriterAgent,
+  getSDPWriterAgent,
+  resetSDPWriterAgent,
+  SDP_WRITER_AGENT_ID,
+} from '../../src/sdp-writer/SDPWriterAgent.js';
+import {
+  PRDNotFoundError,
+  SRSNotFoundError,
+  SessionStateError,
+} from '../../src/sdp-writer/errors.js';
+
+describe('SDPWriterAgent', () => {
+  const testBasePath = path.join(process.cwd(), 'tests', 'sdp-writer', 'test-scratchpad');
+  const testDocsPath = path.join(process.cwd(), 'tests', 'sdp-writer', 'test-docs');
+
+  const samplePRD = `---
+doc_id: PRD-test-project
+title: Test Product
+version: 1.0.0
+status: Approved
+---
+
+# Product Requirements Document: Test Product
+
+## Overview
+
+Test Product is a sample product used for SDP generation tests. It includes a small set of features and non-functional requirements to verify scope sizing.
+
+## Goals
+
+- Goal 1
+- Goal 2
+`;
+
+  const sampleSRS = `---
+doc_id: SRS-test-project
+title: Test Product
+version: 1.0.0
+status: Approved
+---
+
+# Software Requirements Specification: Test Product
+
+## 2. Software Features
+
+### SF-001: User Authentication
+
+Description for SF-001.
+
+### SF-002: Data Export
+
+Description for SF-002.
+
+### SF-003: Reporting
+
+Description for SF-003.
+
+## 4. Non-Functional Requirements
+
+### NFR-001: Performance
+
+Performance description.
+
+### NFR-002: Security
+
+Security description.
+`;
+
+  const setupPRDAndSRS = (projectId: string): void => {
+    const docsDir = path.join(testBasePath, 'documents', projectId);
+    fs.mkdirSync(docsDir, { recursive: true });
+    fs.writeFileSync(path.join(docsDir, 'prd.md'), samplePRD, 'utf-8');
+    fs.writeFileSync(path.join(docsDir, 'srs.md'), sampleSRS, 'utf-8');
+  };
+
+  beforeEach(() => {
+    if (fs.existsSync(testBasePath)) {
+      fs.rmSync(testBasePath, { recursive: true, force: true });
+    }
+    if (fs.existsSync(testDocsPath)) {
+      fs.rmSync(testDocsPath, { recursive: true, force: true });
+    }
+    resetSDPWriterAgent();
+  });
+
+  afterEach(() => {
+    if (fs.existsSync(testBasePath)) {
+      fs.rmSync(testBasePath, { recursive: true, force: true });
+    }
+    if (fs.existsSync(testDocsPath)) {
+      fs.rmSync(testDocsPath, { recursive: true, force: true });
+    }
+    resetSDPWriterAgent();
+  });
+
+  describe('constructor and IAgent interface', () => {
+    it('should construct with default config', () => {
+      const agent = new SDPWriterAgent();
+      expect(agent.agentId).toBe(SDP_WRITER_AGENT_ID);
+      expect(agent.name).toBe('SDP Writer Agent');
+    });
+
+    it('should accept custom config overrides', () => {
+      const agent = new SDPWriterAgent({
+        scratchpadBasePath: testBasePath,
+        publicDocsPath: testDocsPath,
+        lifecycleModel: 'Waterfall',
+      });
+      expect(agent.agentId).toBe(SDP_WRITER_AGENT_ID);
+    });
+
+    it('should initialize and dispose without error', async () => {
+      const agent = new SDPWriterAgent();
+      await agent.initialize();
+      await agent.initialize(); // idempotent
+      expect(agent.getSession()).toBeNull();
+      await agent.dispose();
+      expect(agent.getSession()).toBeNull();
+    });
+  });
+
+  describe('singleton', () => {
+    it('should return the same instance on repeated calls', () => {
+      const a = getSDPWriterAgent();
+      const b = getSDPWriterAgent();
+      expect(a).toBe(b);
+    });
+
+    it('should return a fresh instance after reset', () => {
+      const a = getSDPWriterAgent();
+      resetSDPWriterAgent();
+      const b = getSDPWriterAgent();
+      expect(a).not.toBe(b);
+    });
+  });
+
+  describe('startSession', () => {
+    it('should create a session when PRD and SRS exist', async () => {
+      const projectId = 'test-project';
+      setupPRDAndSRS(projectId);
+
+      const agent = new SDPWriterAgent({
+        scratchpadBasePath: testBasePath,
+        publicDocsPath: testDocsPath,
+      });
+      await agent.initialize();
+
+      const session = await agent.startSession(projectId);
+
+      expect(session.projectId).toBe(projectId);
+      expect(session.status).toBe('pending');
+      expect(session.parsedPRD.documentId).toBe('PRD-test-project');
+      expect(session.parsedSRS.documentId).toBe('SRS-test-project');
+      expect(session.parsedSRS.featureCount).toBe(3);
+      expect(session.parsedSRS.nfrCount).toBe(2);
+      expect(session.sessionId).toBeTruthy();
+    });
+
+    it('should throw PRDNotFoundError when PRD is missing', async () => {
+      const projectId = 'no-prd';
+      const docsDir = path.join(testBasePath, 'documents', projectId);
+      fs.mkdirSync(docsDir, { recursive: true });
+      fs.writeFileSync(path.join(docsDir, 'srs.md'), sampleSRS, 'utf-8');
+
+      const agent = new SDPWriterAgent({
+        scratchpadBasePath: testBasePath,
+        publicDocsPath: testDocsPath,
+      });
+
+      await expect(agent.startSession(projectId)).rejects.toThrow(PRDNotFoundError);
+    });
+
+    it('should throw SRSNotFoundError when SRS is missing', async () => {
+      const projectId = 'no-srs';
+      const docsDir = path.join(testBasePath, 'documents', projectId);
+      fs.mkdirSync(docsDir, { recursive: true });
+      fs.writeFileSync(path.join(docsDir, 'prd.md'), samplePRD, 'utf-8');
+
+      const agent = new SDPWriterAgent({
+        scratchpadBasePath: testBasePath,
+        publicDocsPath: testDocsPath,
+      });
+
+      await expect(agent.startSession(projectId)).rejects.toThrow(SRSNotFoundError);
+    });
+
+    it('should add a warning when SRS has zero features', async () => {
+      const projectId = 'empty-srs';
+      const docsDir = path.join(testBasePath, 'documents', projectId);
+      fs.mkdirSync(docsDir, { recursive: true });
+      fs.writeFileSync(path.join(docsDir, 'prd.md'), samplePRD, 'utf-8');
+      fs.writeFileSync(
+        path.join(docsDir, 'srs.md'),
+        `---
+doc_id: SRS-empty-srs
+title: Empty
+---
+# Software Requirements Specification: Empty
+`,
+        'utf-8'
+      );
+
+      const agent = new SDPWriterAgent({
+        scratchpadBasePath: testBasePath,
+        publicDocsPath: testDocsPath,
+      });
+
+      const session = await agent.startSession(projectId);
+      expect(session.parsedSRS.featureCount).toBe(0);
+      expect(session.warnings).toBeDefined();
+      expect(session.warnings?.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('generateFromProject', () => {
+    it('should generate SDP and write four output files', async () => {
+      const projectId = 'gen-project';
+      setupPRDAndSRS(projectId);
+
+      const agent = new SDPWriterAgent({
+        scratchpadBasePath: testBasePath,
+        publicDocsPath: testDocsPath,
+      });
+
+      const result = await agent.generateFromProject(projectId);
+
+      expect(result.success).toBe(true);
+      expect(result.projectId).toBe(projectId);
+      expect(fs.existsSync(result.scratchpadPath)).toBe(true);
+      expect(fs.existsSync(result.publicPath)).toBe(true);
+      expect(fs.existsSync(result.scratchpadPathKorean)).toBe(true);
+      expect(fs.existsSync(result.publicPathKorean)).toBe(true);
+
+      expect(result.publicPath).toContain(`SDP-${projectId}.md`);
+      expect(result.publicPathKorean).toContain(`SDP-${projectId}.kr.md`);
+    });
+
+    it('should generate metadata referencing PRD and SRS', async () => {
+      const projectId = 'meta-project';
+      setupPRDAndSRS(projectId);
+
+      const agent = new SDPWriterAgent({
+        scratchpadBasePath: testBasePath,
+        publicDocsPath: testDocsPath,
+      });
+
+      const result = await agent.generateFromProject(projectId);
+
+      expect(result.generatedSDP.metadata.documentId).toBe(`SDP-${projectId}`);
+      expect(result.generatedSDP.metadata.sourcePRD).toBe('PRD-test-project');
+      expect(result.generatedSDP.metadata.sourceSRS).toBe('SRS-test-project');
+      expect(result.generatedSDP.metadata.version).toBe('1.0.0');
+      expect(result.generatedSDP.metadata.status).toBe('Draft');
+    });
+
+    it('should generate the standard set of milestones', async () => {
+      const projectId = 'milestone-project';
+      setupPRDAndSRS(projectId);
+
+      const agent = new SDPWriterAgent({
+        scratchpadBasePath: testBasePath,
+        publicDocsPath: testDocsPath,
+      });
+
+      const result = await agent.generateFromProject(projectId);
+
+      expect(result.generatedSDP.milestones.length).toBeGreaterThanOrEqual(5);
+      const ids = result.generatedSDP.milestones.map((m) => m.id);
+      expect(ids).toContain('M1');
+      expect(ids).toContain('M5');
+    });
+
+    it('should generate base risks and conditional risks based on scope', async () => {
+      const projectId = 'risk-project';
+      setupPRDAndSRS(projectId);
+
+      const agent = new SDPWriterAgent({
+        scratchpadBasePath: testBasePath,
+        publicDocsPath: testDocsPath,
+      });
+
+      const result = await agent.generateFromProject(projectId);
+      // 3 features + 2 NFRs - only base risks (R1-R3) expected
+      expect(result.generatedSDP.risks.length).toBe(3);
+      const ids = result.generatedSDP.risks.map((r) => r.id);
+      expect(ids).toContain('R1');
+      expect(ids).toContain('R2');
+      expect(ids).toContain('R3');
+    });
+
+    it('should add scope risks for large feature/NFR counts', async () => {
+      const projectId = 'large-project';
+      const docsDir = path.join(testBasePath, 'documents', projectId);
+      fs.mkdirSync(docsDir, { recursive: true });
+      fs.writeFileSync(path.join(docsDir, 'prd.md'), samplePRD, 'utf-8');
+
+      const features = Array.from(
+        { length: 12 },
+        (_, i) => `### SF-${String(i + 1).padStart(3, '0')}: Feature ${i + 1}\n\nDescription.\n`
+      ).join('\n');
+      const nfrs = Array.from(
+        { length: 6 },
+        (_, i) => `### NFR-${String(i + 1).padStart(3, '0')}: NFR ${i + 1}\n\nDescription.\n`
+      ).join('\n');
+
+      fs.writeFileSync(
+        path.join(docsDir, 'srs.md'),
+        `---\ndoc_id: SRS-${projectId}\n---\n# SRS\n\n## Features\n\n${features}\n\n## NFRs\n\n${nfrs}\n`,
+        'utf-8'
+      );
+
+      const agent = new SDPWriterAgent({
+        scratchpadBasePath: testBasePath,
+        publicDocsPath: testDocsPath,
+      });
+
+      const result = await agent.generateFromProject(projectId);
+      // Base 3 + scope-based 2 = 5
+      expect(result.generatedSDP.risks.length).toBe(5);
+    });
+
+    it('should populate generation stats', async () => {
+      const projectId = 'stats-project';
+      setupPRDAndSRS(projectId);
+
+      const agent = new SDPWriterAgent({
+        scratchpadBasePath: testBasePath,
+        publicDocsPath: testDocsPath,
+      });
+
+      const result = await agent.generateFromProject(projectId);
+
+      expect(result.stats.srsFeatureCount).toBe(3);
+      expect(result.stats.nfrCount).toBe(2);
+      expect(result.stats.milestonesGenerated).toBe(result.generatedSDP.milestones.length);
+      expect(result.stats.risksGenerated).toBe(result.generatedSDP.risks.length);
+      expect(result.stats.processingTimeMs).toBeGreaterThanOrEqual(0);
+    });
+  });
+
+  describe('content checks', () => {
+    it('should produce English content with all 9 sections', async () => {
+      const projectId = 'sections-project';
+      setupPRDAndSRS(projectId);
+
+      const agent = new SDPWriterAgent({
+        scratchpadBasePath: testBasePath,
+        publicDocsPath: testDocsPath,
+      });
+
+      const result = await agent.generateFromProject(projectId);
+      const content = result.generatedSDP.content;
+
+      expect(content).toContain('## 1. Project Overview');
+      expect(content).toContain('## 2. Lifecycle Model');
+      expect(content).toContain('## 3. Development Environment');
+      expect(content).toContain('## 4. Artifact Definitions');
+      expect(content).toContain('## 5. QA Strategy');
+      expect(content).toContain('## 6. V&V Strategy');
+      expect(content).toContain('## 7. Risk Management');
+      expect(content).toContain('## 8. Schedule and Milestones');
+      expect(content).toContain('## 9. Configuration Management');
+    });
+
+    it('should produce Korean content with all 9 sections', async () => {
+      const projectId = 'kr-sections';
+      setupPRDAndSRS(projectId);
+
+      const agent = new SDPWriterAgent({
+        scratchpadBasePath: testBasePath,
+        publicDocsPath: testDocsPath,
+      });
+
+      const result = await agent.generateFromProject(projectId);
+      const content = result.generatedSDP.contentKorean;
+
+      expect(content).toContain('## 1. 프로젝트 개요');
+      expect(content).toContain('## 2. 생명주기 모델');
+      expect(content).toContain('## 3. 개발 환경');
+      expect(content).toContain('## 4. 산출물 정의');
+      expect(content).toContain('## 5. 품질 보증 전략');
+      expect(content).toContain('## 6. V&V 전략');
+      expect(content).toContain('## 7. 리스크 관리');
+      expect(content).toContain('## 8. 일정 및 마일스톤');
+      expect(content).toContain('## 9. 형상 관리');
+    });
+
+    it('should include YAML frontmatter in both English and Korean output', async () => {
+      const projectId = 'frontmatter-project';
+      setupPRDAndSRS(projectId);
+
+      const agent = new SDPWriterAgent({
+        scratchpadBasePath: testBasePath,
+        publicDocsPath: testDocsPath,
+      });
+
+      const result = await agent.generateFromProject(projectId);
+
+      expect(result.generatedSDP.content.startsWith('---')).toBe(true);
+      expect(result.generatedSDP.content).toContain(`doc_id: SDP-${projectId}`);
+      expect(result.generatedSDP.contentKorean.startsWith('---')).toBe(true);
+      expect(result.generatedSDP.contentKorean).toContain(`doc_id: SDP-${projectId}`);
+    });
+
+    it('should write identical content to scratchpad and public locations', async () => {
+      const projectId = 'parity-project';
+      setupPRDAndSRS(projectId);
+
+      const agent = new SDPWriterAgent({
+        scratchpadBasePath: testBasePath,
+        publicDocsPath: testDocsPath,
+      });
+
+      const result = await agent.generateFromProject(projectId);
+
+      const scratchpadContent = fs.readFileSync(result.scratchpadPath, 'utf-8');
+      const publicContent = fs.readFileSync(result.publicPath, 'utf-8');
+      expect(scratchpadContent).toBe(publicContent);
+
+      const scratchpadKr = fs.readFileSync(result.scratchpadPathKorean, 'utf-8');
+      const publicKr = fs.readFileSync(result.publicPathKorean, 'utf-8');
+      expect(scratchpadKr).toBe(publicKr);
+    });
+  });
+
+  describe('lifecycle model selection', () => {
+    const buildSRS = (featureCount: number): string => {
+      const features = Array.from(
+        { length: featureCount },
+        (_, i) =>
+          `### SF-${String(i + 1).padStart(3, '0')}: Feature ${String(i + 1)}\n\nDescription.\n`
+      ).join('\n');
+      return `---\ndoc_id: SRS-test\n---\n# SRS\n\n## Features\n\n${features}\n`;
+    };
+
+    const writeProject = (projectId: string, srsContent: string): void => {
+      const docsDir = path.join(testBasePath, 'documents', projectId);
+      fs.mkdirSync(docsDir, { recursive: true });
+      fs.writeFileSync(path.join(docsDir, 'prd.md'), samplePRD, 'utf-8');
+      fs.writeFileSync(path.join(docsDir, 'srs.md'), srsContent, 'utf-8');
+    };
+
+    it('should select Agile when feature count is below 20', async () => {
+      const projectId = 'lifecycle-agile';
+      writeProject(projectId, buildSRS(5));
+
+      const agent = new SDPWriterAgent({
+        scratchpadBasePath: testBasePath,
+        publicDocsPath: testDocsPath,
+      });
+
+      const result = await agent.generateFromProject(projectId);
+      expect(result.generatedSDP.content).toContain('**Selected Model:** Agile');
+      expect(result.generatedSDP.content).toContain('< 20');
+      expect(result.generatedSDP.contentKorean).toContain('**선택 모델:** Agile');
+    });
+
+    it('should select Iterative when feature count is between 20 and 50', async () => {
+      const projectId = 'lifecycle-iterative';
+      writeProject(projectId, buildSRS(25));
+
+      const agent = new SDPWriterAgent({
+        scratchpadBasePath: testBasePath,
+        publicDocsPath: testDocsPath,
+      });
+
+      const result = await agent.generateFromProject(projectId);
+      expect(result.generatedSDP.content).toContain('**Selected Model:** Iterative');
+      expect(result.generatedSDP.content).toContain('20-50');
+    });
+
+    it('should select V-Model when feature count exceeds 50', async () => {
+      const projectId = 'lifecycle-vmodel';
+      writeProject(projectId, buildSRS(60));
+
+      const agent = new SDPWriterAgent({
+        scratchpadBasePath: testBasePath,
+        publicDocsPath: testDocsPath,
+      });
+
+      const result = await agent.generateFromProject(projectId);
+      expect(result.generatedSDP.content).toContain('**Selected Model:** V-Model');
+      expect(result.generatedSDP.content).toContain('> 50');
+    });
+
+    it('should honour explicit lifecycleModel config override', async () => {
+      const projectId = 'lifecycle-override';
+      writeProject(projectId, buildSRS(60)); // would normally pick V-Model
+
+      const agent = new SDPWriterAgent({
+        scratchpadBasePath: testBasePath,
+        publicDocsPath: testDocsPath,
+        lifecycleModel: 'Waterfall',
+      });
+
+      const result = await agent.generateFromProject(projectId);
+      expect(result.generatedSDP.content).toContain('**Selected Model:** Waterfall');
+      expect(result.generatedSDP.content).toContain('explicitly configured');
+    });
+
+    it('should render the selection heuristic table in both languages', async () => {
+      const projectId = 'lifecycle-table';
+      setupPRDAndSRS(projectId);
+
+      const agent = new SDPWriterAgent({
+        scratchpadBasePath: testBasePath,
+        publicDocsPath: testDocsPath,
+      });
+
+      const result = await agent.generateFromProject(projectId);
+      expect(result.generatedSDP.content).toContain('### Selection Heuristic');
+      expect(result.generatedSDP.content).toContain('| SRS Feature Count | Lifecycle Model |');
+      expect(result.generatedSDP.contentKorean).toContain('### 선택 휴리스틱');
+      expect(result.generatedSDP.contentKorean).toContain('| SRS 기능 수 | 생명주기 모델 |');
+    });
+  });
+
+  describe('PRD timeline extraction', () => {
+    const writeProject = (projectId: string, prdContent: string): void => {
+      const docsDir = path.join(testBasePath, 'documents', projectId);
+      fs.mkdirSync(docsDir, { recursive: true });
+      fs.writeFileSync(path.join(docsDir, 'prd.md'), prdContent, 'utf-8');
+      fs.writeFileSync(path.join(docsDir, 'srs.md'), sampleSRS, 'utf-8');
+    };
+
+    it('should derive milestones from a PRD timeline table', async () => {
+      const projectId = 'timeline-table';
+      const prd = `---
+doc_id: PRD-${projectId}
+title: Timeline Table Project
+---
+
+# Product Requirements Document: Timeline Table Project
+
+## Overview
+
+A project with a timeline table.
+
+## 7. Timeline
+
+| Phase | Date | Deliverables |
+|-------|------|--------------|
+| Discovery | 2026-01 | Requirements gathering |
+| Build | 2026-02 | Implementation |
+| Launch | 2026-03 | Go-live |
+`;
+      writeProject(projectId, prd);
+
+      const agent = new SDPWriterAgent({
+        scratchpadBasePath: testBasePath,
+        publicDocsPath: testDocsPath,
+      });
+
+      const result = await agent.generateFromProject(projectId);
+      const milestoneNames = result.generatedSDP.milestones.map((m) => m.name);
+      expect(result.generatedSDP.milestones.length).toBe(3);
+      expect(milestoneNames).toEqual(['Discovery', 'Build', 'Launch']);
+      expect(result.generatedSDP.milestones[0]?.description).toContain('2026-01');
+      // No fallback warning expected when timeline exists
+      expect(result.warnings ?? []).not.toContain(
+        expect.stringContaining('PRD timeline section was empty')
+      );
+    });
+
+    it('should derive milestones from a PRD timeline bullet list', async () => {
+      const projectId = 'timeline-bullets';
+      const prd = `---
+doc_id: PRD-${projectId}
+title: Bullet Timeline
+---
+
+# Product Requirements Document: Bullet Timeline
+
+## Overview
+
+A project with bullet timeline.
+
+## Schedule
+
+- Alpha: prototype with mock data
+- Beta: integration with backend
+- GA: production release with monitoring
+`;
+      writeProject(projectId, prd);
+
+      const agent = new SDPWriterAgent({
+        scratchpadBasePath: testBasePath,
+        publicDocsPath: testDocsPath,
+      });
+
+      const result = await agent.generateFromProject(projectId);
+      expect(result.generatedSDP.milestones.length).toBe(3);
+      const phases = result.generatedSDP.milestones.map((m) => m.phase);
+      expect(phases).toEqual(['Alpha', 'Beta', 'GA']);
+      expect(result.generatedSDP.milestones[1]?.description).toBe('integration with backend');
+    });
+
+    it('should fall back to default milestones with warning when timeline is missing', async () => {
+      const projectId = 'timeline-missing';
+      // samplePRD has no timeline section
+      setupPRDAndSRS(projectId);
+
+      const agent = new SDPWriterAgent({
+        scratchpadBasePath: testBasePath,
+        publicDocsPath: testDocsPath,
+      });
+
+      const result = await agent.generateFromProject(projectId);
+      expect(result.generatedSDP.milestones.length).toBe(5);
+      expect(result.generatedSDP.milestones[0]?.id).toBe('M1');
+      expect(result.generatedSDP.milestones[4]?.id).toBe('M5');
+      expect(result.warnings).toBeDefined();
+      expect(result.warnings?.some((w) => w.includes('PRD timeline section was empty'))).toBe(true);
+    });
+
+    it('should support Korean timeline section heading', async () => {
+      const projectId = 'timeline-korean';
+      const prd = `---
+doc_id: PRD-${projectId}
+title: 한국어 일정
+---
+
+# Product Requirements Document: 한국어 일정
+
+## 개요
+
+설명.
+
+## 일정
+
+- 1단계: 요구사항 수집
+- 2단계: 구현
+`;
+      writeProject(projectId, prd);
+
+      const agent = new SDPWriterAgent({
+        scratchpadBasePath: testBasePath,
+        publicDocsPath: testDocsPath,
+      });
+
+      const result = await agent.generateFromProject(projectId);
+      expect(result.generatedSDP.milestones.length).toBe(2);
+      expect(result.generatedSDP.milestones[0]?.phase).toBe('1단계');
+    });
+  });
+
+  describe('V&V section content', () => {
+    it('should reference actual SRS feature and NFR counts in English V&V section', async () => {
+      const projectId = 'vv-en';
+      setupPRDAndSRS(projectId);
+
+      const agent = new SDPWriterAgent({
+        scratchpadBasePath: testBasePath,
+        publicDocsPath: testDocsPath,
+      });
+
+      const result = await agent.generateFromProject(projectId);
+      const content = result.generatedSDP.content;
+
+      expect(content).toContain('### 6.1 Scope Under V&V');
+      expect(content).toContain('**3 software feature(s) (SF-xxx)**');
+      expect(content).toContain('**2 non-functional requirement(s) (NFR-xxx)**');
+      expect(content).toContain('| Software Features (SF-xxx) | 3 |');
+      expect(content).toContain('| Non-Functional Requirements (NFR-xxx) | 2 |');
+      // Verification subsection should also reference counts
+      expect(content).toMatch(/3 SF requirements requires at least one dedicated unit test/);
+    });
+
+    it('should reference actual SRS feature and NFR counts in Korean V&V section', async () => {
+      const projectId = 'vv-kr';
+      setupPRDAndSRS(projectId);
+
+      const agent = new SDPWriterAgent({
+        scratchpadBasePath: testBasePath,
+        publicDocsPath: testDocsPath,
+      });
+
+      const result = await agent.generateFromProject(projectId);
+      const content = result.generatedSDP.contentKorean;
+
+      expect(content).toContain('### 6.1 V&V 대상 범위');
+      expect(content).toContain('소프트웨어 기능 3건(SF-xxx)');
+      expect(content).toContain('비기능 요구사항 2건(NFR-xxx)');
+      expect(content).toContain('| 소프트웨어 기능 (SF-xxx) | 3 |');
+      expect(content).toContain('| 비기능 요구사항 (NFR-xxx) | 2 |');
+    });
+  });
+
+  describe('finalize', () => {
+    it('should re-write outputs from a completed session', async () => {
+      const projectId = 'finalize-project';
+      setupPRDAndSRS(projectId);
+
+      const agent = new SDPWriterAgent({
+        scratchpadBasePath: testBasePath,
+        publicDocsPath: testDocsPath,
+      });
+
+      await agent.generateFromProject(projectId);
+      const result = await agent.finalize();
+
+      expect(result.success).toBe(true);
+      expect(result.projectId).toBe(projectId);
+      expect(fs.existsSync(result.publicPath)).toBe(true);
+    });
+
+    it('should throw SessionStateError when no session is active', async () => {
+      const agent = new SDPWriterAgent({
+        scratchpadBasePath: testBasePath,
+        publicDocsPath: testDocsPath,
+      });
+
+      await expect(agent.finalize()).rejects.toThrow(SessionStateError);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds the SDP Writer pipeline agent that consumes the project's PRD and SRS and emits a 9-section Software Development Plan with bilingual outputs (English + Korean). The agent slots into the greenfield orchestrator pipeline between `srs_generation` and `repo_detection`.

Closes #750

## What

- New `src/sdp-writer/` module: `types.ts`, `errors.ts`, `SDPWriterAgent.ts`, `index.ts`
- New `tests/sdp-writer/SDPWriterAgent.test.ts` (32 vitest cases)
- Pipeline integration:
  - `src/agents/AgentTypeMapping.ts` registers the `sdp-writer` agent type
  - `src/ad-sdlc-orchestrator/types.ts` adds the `sdp_generation` greenfield stage with `dependsOn: ['srs_generation']` and rewires `repo_detection` to depend on it
  - `tests/ad-sdlc-orchestrator/AdsdlcOrchestratorAgent.test.ts` updates the stage count and adds an ordering test
- New agent prompt: `.claude/agents/sdp-writer.md`
- Documentation (separate commit): README, system architecture, agent reference pages

## Why

Issue #750 requested a Software Development Plan writer to fill the gap between SRS and SDS in the AD-SDLC pipeline so that downstream stages have a documented plan covering scope, lifecycle model, schedule, V&V strategy, risk register, and configuration management. This unblocks IEC 62304 / ISO 12207 / CMMI alignment for projects generated through the orchestrator.

## How

### Lifecycle Model Selection
`selectLifecycleModel(srs)` picks a lifecycle from SRS feature count:

| SRS Feature Count | Lifecycle Model |
|---|---|
| > 50 | V-Model |
| 20 – 50 | Iterative |
| < 20 | Agile |

An explicit `config.lifecycleModel` value overrides the heuristic.

### PRD Timeline Extraction
`extractPRDTimeline()` parses the PRD's Timeline / Schedule / Milestones section (also supports Korean headings such as `## 일정`). It accepts both markdown table form and bullet list form. When the PRD has no timeline section, `generateMilestones` falls back to a default 5-phase lifecycle and records a warning.

### V&V Citations
The V&V section (6.1 Scope Under V&V, 6.2 Verification, 6.3 Validation) now cites the actual SF and NFR counts from the parsed SRS rather than hard-coded text.

### Outputs
Four files per project: scratchpad EN/KR + public EN/KR. Frontmatter is applied via the shared `prependFrontmatter()` utility introduced in #748.

## Acceptance Criteria

| # | Criterion | Status |
|---|---|---|
| AC1 | New `sdp-writer` agent module with `IAgent` implementation | Done |
| AC2 | 9-section SDP document generated in English and Korean | Done |
| AC3 | Lifecycle model selected via documented heuristic with override | Done |
| AC4 | V&V section cites actual SRS feature and NFR counts | Done |
| AC5 | Schedule milestones derived from PRD timeline section with fallback warning | Done |
| AC6 | YAML frontmatter via `prependFrontmatter()` utility | Done |
| AC7 | Pipeline integration: `sdp_generation` stage between `srs_generation` and `repo_detection` | Done |
| AC8 | Vitest coverage > 80% on the new module | Done (>95%) |

## Test Plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run tests/sdp-writer/` — 32/32 passing
- [x] `npx vitest run tests/ad-sdlc-orchestrator/ tests/agents/` — 431/431 passing (no regression)
- [x] `npx eslint src/sdp-writer/` — 0 errors
- [ ] CI green on all platforms