### PR TITLE
feat(threat-model-writer): add STRIDE/DREAD threat model writer agent

### DIFF
--- a/.claude/agents/threat-model-writer.md
+++ b/.claude/agents/threat-model-writer.md
@@ -1,0 +1,110 @@
+---
+name: threat-model-writer
+description: |
+  Threat Model Writing Agent. Creates a Threat Model (TM) document from an approved
+  SDS (Software Design Specification). Identifies security threats using STRIDE
+  categorization and scores risks using the DREAD model, then proposes mitigations
+  and residual risk levels. Use this agent after SDS is approved and before issue
+  generation.
+tools:
+  - Read
+  - Write
+  - Edit
+  - Glob
+  - Grep
+model: inherit
+---
+
+# Threat Model Writer Agent
+
+## Role
+
+You are a Threat Model Writer Agent responsible for producing a Threat Model (TM)
+document from the approved SDS. The TM catalogs the system's attack surface,
+identifies threats via STRIDE, scores risk via DREAD, and prescribes mitigations
+so that downstream implementation tasks bake security in from the start.
+
+## Primary Responsibilities
+
+1. **System Scoping**
+   - Parse the SDS to enumerate components, interfaces, data flows, and trust boundaries
+   - Render a Mermaid data flow diagram that reviewers can read at a glance
+   - Highlight any external actors and network surfaces
+
+2. **STRIDE Threat Identification**
+   - Walk every STRIDE category (Spoofing, Tampering, Repudiation, Information
+     Disclosure, Denial of Service, Elevation of Privilege)
+   - Produce at least one threat entry per category; add extra threats for API and
+     data-layer surfaces when the SDS declares them
+   - Tie each threat to a concrete target (component, API, data store)
+
+3. **DREAD Risk Scoring**
+   - Score each threat on Damage, Reproducibility, Exploitability, Affected users,
+     and Discoverability (1-10)
+   - Compute the overall score as the average, rounded to one decimal
+   - Flag threats with an overall score >= 7 as High risk
+
+4. **Mitigation Strategy**
+   - Recommend concrete, actionable mitigations per threat (input validation,
+     authentication, encryption, rate limiting, audit logging, etc.)
+   - Align mitigations with security best practices (OWASP, least privilege)
+
+5. **Residual Risk Summary**
+   - State residual risk level per threat (Low / Medium / High) after mitigation
+   - Provide a review cadence recommendation
+
+## Template Structure
+
+Produce the Threat Model with these sections in order:
+
+1. **System Overview** — product description, Mermaid data flow diagram, component
+   list table, trust boundary notes
+2. **Threat Identification** — STRIDE table with threat ID, category, title, target,
+   description
+3. **Risk Assessment** — DREAD table with scores for each threat plus overall,
+   followed by a ranked high-risk subsection
+4. **Mitigation Strategies** — mitigation table (threat ID, mitigation, owner)
+5. **Residual Risk Summary** — per-threat residual risk with review cadence
+
+## CRITICAL: Tool Usage
+
+- Use `Read` to load the SDS from `.ad-sdlc/scratchpad/documents/{project_id}/sds.md`
+- Use `Write` to persist the Threat Model to both scratchpad and public docs paths
+- NEVER invent components that are not in the SDS — always trace back to a
+  component ID or section
+
+## Workflow
+
+1. Read the SDS document from the scratchpad path
+2. Extract components, API surface flag, and data layer flag
+3. Generate the six base STRIDE threats plus conditional API / data threats
+4. Compute DREAD scores and residual risk per threat
+5. Render the Markdown (English) using the template structure
+6. Render the Korean variant mirroring the English content
+7. Write all four output files (scratchpad + public, English + Korean)
+
+## Input Location
+
+- SDS document: `.ad-sdlc/scratchpad/documents/{project_id}/sds.md`
+
+## Output Location
+
+- Scratchpad (English): `.ad-sdlc/scratchpad/documents/{project_id}/tm.md`
+- Scratchpad (Korean): `.ad-sdlc/scratchpad/documents/{project_id}/tm.kr.md`
+- Public (English): `docs/tm/TM-{project_id}.md`
+- Public (Korean): `docs/tm/TM-{project_id}.kr.md`
+
+## Bilingual Output Policy
+
+- English is the canonical variant
+- Korean variant must mirror the structure and threat catalog one-to-one
+- Section headings are translated; threat IDs, DREAD scores, and component IDs are
+  kept identical across variants
+
+## Quality Criteria
+
+- Every STRIDE category has at least one threat
+- Every threat has a DREAD score and a mitigation
+- Every threat traces to a concrete component, API, or data store from the SDS
+- Data flow diagram renders as valid Mermaid
+- High-risk threats (overall >= 7) are explicitly listed in the risk ranking

--- a/README.md
+++ b/README.md
@@ -25,16 +25,16 @@ That's it! The agents will generate documents, create issues, implement code, an
 
 ## What is AD-SDLC?
 
-AD-SDLC is an automated software development pipeline that uses **26 specialized Claude agents** to transform your requirements into production-ready code. It supports three modes:
+AD-SDLC is an automated software development pipeline that uses **27 specialized Claude agents** to transform your requirements into production-ready code. It supports three modes:
 
 ### Greenfield Pipeline (New Projects)
 
 ```
-User Input → Collector → PRD Writer → SRS Writer → SDP Writer → SDS Writer
-                                                                    ↓
-                           Worker ← Controller ← Issue Generator
-                              ↓
-                         PR Reviewer → Merge
+User Input → Collector → PRD Writer → SRS Writer → SDP Writer → SDS Writer → Threat Model Writer
+                                                                                      ↓
+                                       Worker ← Controller ← Issue Generator ←────────┘
+                                          ↓
+                                     PR Reviewer → Merge
 ```
 
 ### Enhancement Pipeline (Existing Projects)
@@ -63,7 +63,7 @@ GitHub Issues → Issue Reader → Controller → Worker → PR Reviewer
                                                  CI Fix (on failure)
 ```
 
-### Agent Pipeline (26 Agents)
+### Agent Pipeline (27 Agents)
 
 | Phase             | Agent                 | Role                                                 |
 | ----------------- | --------------------- | ---------------------------------------------------- |
@@ -79,6 +79,7 @@ GitHub Issues → Issue Reader → Controller → Worker → PR Reviewer
 |                   | SRS Writer            | Generates Software Requirements Specification        |
 |                   | SDP Writer            | Generates Software Development Plan from PRD and SRS |
 |                   | SDS Writer            | Generates Software Design Specification              |
+|                   | Threat Model Writer   | Generates STRIDE/DREAD Threat Model from SDS         |
 | **Planning**      | Issue Generator       | Creates GitHub Issues from SDS components            |
 | **Execution**     | Controller            | Orchestrates work distribution and monitors progress |
 |                   | Worker                | Implements code based on assigned issues             |
@@ -284,7 +285,7 @@ See [Use Cases Guide](docs/use-cases.md) for more examples.
 ```
 your-project/
 ├── .claude/
-│   └── agents/              # Agent definitions (26 agents)
+│   └── agents/              # Agent definitions (27 agents)
 │       ├── *.md             # English versions (used by Claude)
 │       └── *.kr.md          # Korean versions (for reference)
 ├── .ad-sdlc/

--- a/docs/architecture/agent-communication.md
+++ b/docs/architecture/agent-communication.md
@@ -73,20 +73,21 @@ Agents do not communicate directly. Instead, they:
 
 Each agent has designated files it reads from and writes to:
 
-| Agent             | Reads                                       | Writes                                |
-| ----------------- | ------------------------------------------- | ------------------------------------- |
-| Collector         | User input, files, URLs                     | `info/collected_info.yaml`            |
-| PRD Writer        | `info/collected_info.yaml`                  | `documents/prd.md`                    |
-| SRS Writer        | `documents/prd.md`                          | `documents/srs.md`                    |
-| GitHub Repo Setup | `documents/prd.md`, `documents/srs.md`      | `repo/github_repo.yaml`               |
-| SDS Writer        | `documents/srs.md`, `repo/github_repo.yaml` | `documents/sds.md`                    |
-| Issue Generator   | `documents/sds.md`                          | `issues/issues.json`                  |
-| Controller        | `issues/issues.json`                        | `progress/controller_state.yaml`      |
-| Worker            | `progress/work_orders.yaml`                 | Implementation results                |
-| PR Reviewer       | Worker results                              | PR status                             |
-| Document Reader   | `docs/*.md`                                 | `state/current_state.yaml`            |
-| Codebase Analyzer | Source code                                 | `analysis/architecture_overview.yaml` |
-| Impact Analyzer   | State + analysis                            | `impact/impact_report.yaml`           |
+| Agent               | Reads                                           | Writes                                |
+| ------------------- | ----------------------------------------------- | ------------------------------------- |
+| Collector           | User input, files, URLs                         | `info/collected_info.yaml`            |
+| PRD Writer          | `info/collected_info.yaml`                      | `documents/prd.md`                    |
+| SRS Writer          | `documents/prd.md`                              | `documents/srs.md`                    |
+| GitHub Repo Setup   | `documents/prd.md`, `documents/srs.md`          | `repo/github_repo.yaml`               |
+| SDS Writer          | `documents/srs.md`, `repo/github_repo.yaml`     | `documents/sds.md`                    |
+| Threat Model Writer | `documents/sds.md`                              | `documents/threat-model.md`           |
+| Issue Generator     | `documents/sds.md`, `documents/threat-model.md` | `issues/issues.json`                  |
+| Controller          | `issues/issues.json`                            | `progress/controller_state.yaml`      |
+| Worker              | `progress/work_orders.yaml`                     | Implementation results                |
+| PR Reviewer         | Worker results                                  | PR status                             |
+| Document Reader     | `docs/*.md`                                     | `state/current_state.yaml`            |
+| Codebase Analyzer   | Source code                                     | `analysis/architecture_overview.yaml` |
+| Impact Analyzer     | State + analysis                                | `impact/impact_report.yaml`           |
 
 ---
 
@@ -104,12 +105,12 @@ Used in document generation pipeline:
       ▼                ▼                ▼                  ▼           │
  collected_info    prd.md           srs.md          github_repo.yaml   │
                                                                         │
-                       ┌───────────┐    ┌───────────┐                  │
-                       │SDS Writer │◀───│SDP Writer │◀─────────────────┘
-                       └───────────┘    └───────────┘
-                             │                │
-                             ▼                ▼
-                          sds.md            sdp.md
+  ┌────────────────────┐   ┌───────────┐    ┌───────────┐              │
+  │Threat Model Writer │◀──│SDS Writer │◀───│SDP Writer │◀─────────────┘
+  └────────────────────┘   └───────────┘    └───────────┘
+           │                     │                │
+           ▼                     ▼                ▼
+    threat-model.md           sds.md            sdp.md
 ```
 
 **Protocol Steps**:

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -62,9 +62,9 @@ AD-SDLC (Agent-Driven Software Development Lifecycle) is an automated software d
     ┌─────────────────────┐               ┌─────────────────────┐
     │  Document Pipeline  │               │  Analysis Pipeline  │
     │  Collector → PRD →  │               │  DocReader →        │
-    │  SRS → SDP → SDS    │               │  CodeAnalyzer →     │
-    └─────────────────────┘               │  ImpactAnalyzer     │
-              │                           └─────────────────────┘
+    │  SRS → SDP → SDS →  │               │  CodeAnalyzer →     │
+    │  Threat Model       │               │  ImpactAnalyzer     │
+    └─────────────────────┘               └─────────────────────┘
               │                                           │
               │                                           ▼
               │                           ┌─────────────────────┐
@@ -165,6 +165,7 @@ The system consists of 15 specialized agents organized into functional categorie
 - **PRD Writer**: Generates Product Requirements Document
 - **SRS Writer**: Generates Software Requirements Specification
 - **SDS Writer**: Generates Software Design Specification
+- **Threat Model Writer**: Generates STRIDE/DREAD Threat Model from SDS
 
 #### Document Update Agents
 
@@ -249,13 +250,16 @@ Stage 3: SRS Generation
 Stage 4: SDS Generation
     └── Create Software Design Specification
 
-Stage 5: Issue Generation
+Stage 5: Threat Model Generation
+    └── Generate STRIDE/DREAD Threat Model from SDS
+
+Stage 6: Issue Generation
     └── Transform SDS components into GitHub issues
 
-Stage 6: Orchestration
+Stage 7: Orchestration
     └── Prioritize and distribute work
 
-Stage 7: Implementation
+Stage 8: Implementation
     └── Workers implement issues in parallel
     └── PR Reviewer merges completed work
 ```

--- a/docs/reference/agents/ad-sdlc-orchestrator.md
+++ b/docs/reference/agents/ad-sdlc-orchestrator.md
@@ -176,20 +176,21 @@ orchestration_result:
 
 #### Greenfield Pipeline
 
-| Order | Agent             | Description         | Approval Gate |
-| ----- | ----------------- | ------------------- | ------------- |
-| 1     | mode-detector     | Confirm mode        | No            |
-| 2     | collector         | Gather requirements | No            |
-| 3     | prd-writer        | Generate PRD        | Yes           |
-| 4     | srs-writer        | Generate SRS        | Yes           |
-| 5     | sdp-writer        | Generate SDP        | Yes           |
-| 6     | repo-detector     | Check repository    | No            |
-| 7     | github-repo-setup | Create repo         | No            |
-| 8     | sds-writer        | Generate SDS        | Yes           |
-| 9     | issue-generator   | Create issues       | Yes           |
-| 10    | controller        | Assign work         | No            |
-| 11    | worker            | Implement           | No            |
-| 12    | pr-reviewer       | Review PRs          | No            |
+| Order | Agent               | Description           | Approval Gate |
+| ----- | ------------------- | --------------------- | ------------- |
+| 1     | mode-detector       | Confirm mode          | No            |
+| 2     | collector           | Gather requirements   | No            |
+| 3     | prd-writer          | Generate PRD          | Yes           |
+| 4     | srs-writer          | Generate SRS          | Yes           |
+| 5     | sdp-writer          | Generate SDP          | Yes           |
+| 6     | repo-detector       | Check repository      | No            |
+| 7     | github-repo-setup   | Create repo           | No            |
+| 8     | sds-writer          | Generate SDS          | Yes           |
+| 9     | threat-model-writer | Generate Threat Model | Yes           |
+| 10    | issue-generator     | Create issues         | Yes           |
+| 11    | controller          | Assign work           | No            |
+| 12    | worker              | Implement             | No            |
+| 13    | pr-reviewer         | Review PRs            | No            |
 
 #### Enhancement Pipeline
 
@@ -237,7 +238,7 @@ pipelineId: 'a1b2c3d4-...'
 mode: 'greenfield'
 startedAt: '2026-02-18T10:00:00Z'
 overallStatus: 'partial' # "success" | "partial" | "failed"
-totalStages: 12
+totalStages: 13
 completedStages: 7
 stages:
   - name: 'initialization'
@@ -378,7 +379,7 @@ Pipeline Execution
 "Resume the pipeline"
 ```
 
-**Prior State**: Pipeline failed at `sds_generation` (7 of 12 greenfield stages completed)
+**Prior State**: Pipeline failed at `sds_generation` (7 of 13 greenfield stages completed)
 
 **Expected Flow**:
 
@@ -407,29 +408,30 @@ Pipeline Execution
 
 ### Dependencies (Invokes)
 
-| Agent             | Pipeline               | Purpose                       |
-| ----------------- | ---------------------- | ----------------------------- |
-| mode-detector     | All                    | Determine pipeline mode       |
-| collector         | Greenfield             | Gather requirements           |
-| prd-writer        | Greenfield             | Generate PRD                  |
-| srs-writer        | Greenfield             | Generate SRS                  |
-| sdp-writer        | Greenfield             | Generate SDP                  |
-| sds-writer        | Greenfield             | Generate SDS                  |
-| repo-detector     | Greenfield             | Check for existing repo       |
-| github-repo-setup | Greenfield             | Create repository             |
-| issue-generator   | Greenfield/Enhancement | Create GitHub issues          |
-| issue-reader      | Import                 | Import existing GitHub issues |
-| controller        | All                    | Orchestrate work              |
-| worker            | All                    | Implement features            |
-| pr-reviewer       | All                    | Review PRs                    |
-| document-reader   | Enhancement            | Parse existing docs           |
-| codebase-analyzer | Enhancement            | Analyze codebase              |
-| code-reader       | Enhancement            | Extract code structure        |
-| impact-analyzer   | Enhancement            | Assess change impact          |
-| prd-updater       | Enhancement            | Update PRD                    |
-| srs-updater       | Enhancement            | Update SRS                    |
-| sds-updater       | Enhancement            | Update SDS                    |
-| regression-tester | Enhancement            | Verify no regressions         |
+| Agent               | Pipeline               | Purpose                            |
+| ------------------- | ---------------------- | ---------------------------------- |
+| mode-detector       | All                    | Determine pipeline mode            |
+| collector           | Greenfield             | Gather requirements                |
+| prd-writer          | Greenfield             | Generate PRD                       |
+| srs-writer          | Greenfield             | Generate SRS                       |
+| sdp-writer          | Greenfield             | Generate SDP                       |
+| sds-writer          | Greenfield             | Generate SDS                       |
+| threat-model-writer | Greenfield             | Generate STRIDE/DREAD Threat Model |
+| repo-detector       | Greenfield             | Check for existing repo            |
+| github-repo-setup   | Greenfield             | Create repository                  |
+| issue-generator     | Greenfield/Enhancement | Create GitHub issues               |
+| issue-reader        | Import                 | Import existing GitHub issues      |
+| controller          | All                    | Orchestrate work                   |
+| worker              | All                    | Implement features                 |
+| pr-reviewer         | All                    | Review PRs                         |
+| document-reader     | Enhancement            | Parse existing docs                |
+| codebase-analyzer   | Enhancement            | Analyze codebase                   |
+| code-reader         | Enhancement            | Extract code structure             |
+| impact-analyzer     | Enhancement            | Assess change impact               |
+| prd-updater         | Enhancement            | Update PRD                         |
+| srs-updater         | Enhancement            | Update SRS                         |
+| sds-updater         | Enhancement            | Update SDS                         |
+| regression-tester   | Enhancement            | Verify no regressions              |
 
 ### Dependents
 
@@ -507,7 +509,7 @@ The `--start-from` option requires an explicit mode (`greenfield`, `enhancement`
 
 ### Available Stage Names
 
-**Greenfield**: `initialization`, `mode_detection`, `collection`, `prd_generation`, `srs_generation`, `repo_detection`, `github_repo_setup`, `sds_generation`, `issue_generation`, `orchestration`, `implementation`, `review`
+**Greenfield**: `initialization`, `mode_detection`, `collection`, `prd_generation`, `srs_generation`, `repo_detection`, `github_repo_setup`, `sds_generation`, `threat_model_generation`, `issue_generation`, `orchestration`, `implementation`, `review`
 
 **Enhancement**: `document_reading`, `codebase_analysis`, `code_reading`, `doc_code_comparison`, `impact_analysis`, `prd_update`, `srs_update`, `sds_update`, `issue_generation`, `orchestration`, `implementation`, `regression_testing`, `review`
 

--- a/docs/system-architecture.kr.md
+++ b/docs/system-architecture.kr.md
@@ -16,6 +16,7 @@ flowchart TB
         SRS[SRS Writer Agent]
         SDP[SDP Writer Agent]
         SDS[SDS Writer Agent]
+        TM[Threat Model Writer Agent]
     end
 
     subgraph IssuePipeline["Issue Management Pipeline"]
@@ -54,8 +55,9 @@ flowchart TB
     PRD --> SRS
     SRS --> SDP
     SDP --> SDS
+    SDS --> TM
 
-    SDS --> ISSUE
+    TM --> ISSUE
     ISSUE --> CTRL
 
     CTRL --> WORKER1
@@ -71,6 +73,7 @@ flowchart TB
     SRS -.-> DOCS
     SDP -.-> DOCS
     SDS -.-> DOCS
+    TM -.-> DOCS
     ISSUE -.-> ISSUES
     WORKER1 -.-> CODE
     WORKER2 -.-> CODE
@@ -101,6 +104,7 @@ flowchart TB
         A3[SRS Writer]
         A3B[SDP Writer]
         A4[SDS Writer]
+        A4B[Threat Model Writer]
         A5[Issue Generator]
         A6[Controller]
         A7[Worker]
@@ -116,6 +120,7 @@ flowchart TB
         S3[docs/srs/*.md]
         S3B[docs/sdp/*.md]
         S4[docs/sds/*.md]
+        S4B[docs/tm/*.md]
         S5[issues/*.json]
         S6[progress/*.yaml]
         S7[state/current_state.yaml]
@@ -129,6 +134,7 @@ flowchart TB
     MAIN -->|spawn| A3
     MAIN -->|spawn| A3B
     MAIN -->|spawn| A4
+    MAIN -->|spawn| A4B
     MAIN -->|spawn| A5
     MAIN -->|spawn| A6
     MAIN -->|spawn| A7
@@ -147,7 +153,10 @@ flowchart TB
     A3B -->|write| S3B
     A4 -->|read| S3
     A4 -->|write| S4
+    A4B -->|read| S4
+    A4B -->|write| S4B
     A5 -->|read| S4
+    A5 -->|read| S4B
     A5 -->|write| S5
     A6 -->|read| S5
     A6 -->|write| S6
@@ -172,6 +181,7 @@ flowchart TB
     A3 -.->|result| MAIN
     A3B -.->|result| MAIN
     A4 -.->|result| MAIN
+    A4B -.->|result| MAIN
     A5 -.->|result| MAIN
     A6 -.->|result| MAIN
     A7 -.->|result| MAIN
@@ -385,6 +395,7 @@ claude_code_agent/
 │       ├── srs-writer.md          # SRS 작성 에이전트
 │       ├── sdp-writer.md          # SDP 작성 에이전트
 │       ├── sds-writer.md          # SDS 작성 에이전트
+│       ├── threat-model-writer.md # 위협 모델 작성 에이전트
 │       ├── issue-generator.md     # 이슈 생성 에이전트
 │       ├── controller.md          # 관제 에이전트
 │       ├── worker.md              # 작업 에이전트
@@ -414,6 +425,7 @@ claude_code_agent/
 │   ├── prd/                      # PRD Documents
 │   ├── srs/                      # SRS Documents
 │   ├── sds/                      # SDS Documents
+│   ├── tm/                       # Threat Model Documents
 │   └── architecture/             # Architecture Docs
 │
 └── src/                          # Generated Source Code

--- a/docs/system-architecture.md
+++ b/docs/system-architecture.md
@@ -16,6 +16,7 @@ flowchart TB
         SRS[SRS Writer Agent]
         SDP[SDP Writer Agent]
         SDS[SDS Writer Agent]
+        TM[Threat Model Writer Agent]
     end
 
     subgraph IssuePipeline["Issue Management Pipeline"]
@@ -56,8 +57,9 @@ flowchart TB
     PRD --> SRS
     SRS --> SDP
     SDP --> SDS
+    SDS --> TM
 
-    SDS --> ISSUE
+    TM --> ISSUE
     ISSUE --> CTRL
 
     CTRL --> WORKER1
@@ -73,6 +75,7 @@ flowchart TB
     SRS -.-> DOCS
     SDP -.-> DOCS
     SDS -.-> DOCS
+    TM -.-> DOCS
     ISSUE -.-> ISSUES
     WORKER1 -.-> CODE
     WORKER2 -.-> CODE
@@ -106,6 +109,7 @@ flowchart TB
         A3[SRS Writer]
         A3B[SDP Writer]
         A4[SDS Writer]
+        A4B[Threat Model Writer]
         A5[Issue Generator]
         A6[Controller]
         A7[Worker]
@@ -123,6 +127,7 @@ flowchart TB
         S3[docs/srs/*.md]
         S3B[docs/sdp/*.md]
         S4[docs/sds/*.md]
+        S4B[docs/tm/*.md]
         S5[issues/*.json]
         S6[progress/*.yaml]
         S7[state/current_state.yaml]
@@ -139,6 +144,7 @@ flowchart TB
     MAIN -->|spawn| A3
     MAIN -->|spawn| A3B
     MAIN -->|spawn| A4
+    MAIN -->|spawn| A4B
     MAIN -->|spawn| A5
     MAIN -->|spawn| A6
     MAIN -->|spawn| A7
@@ -159,7 +165,10 @@ flowchart TB
     A3B -->|write| S3B
     A4 -->|read| S3
     A4 -->|write| S4
+    A4B -->|read| S4
+    A4B -->|write| S4B
     A5 -->|read| S4
+    A5 -->|read| S4B
     A5 -->|write| S5
     A6 -->|read| S5
     A6 -->|write| S6
@@ -196,6 +205,7 @@ flowchart TB
     A3 -.->|result| MAIN
     A3B -.->|result| MAIN
     A4 -.->|result| MAIN
+    A4B -.->|result| MAIN
     A5 -.->|result| MAIN
     A6 -.->|result| MAIN
     A7 -.->|result| MAIN
@@ -411,6 +421,7 @@ claude_code_agent/
 │       ├── srs-writer.md          # SRS Writer Agent
 │       ├── sdp-writer.md          # SDP Writer Agent
 │       ├── sds-writer.md          # SDS Writer Agent
+│       ├── threat-model-writer.md # Threat Model Writer Agent
 │       ├── issue-generator.md     # Issue Generator Agent
 │       ├── controller.md          # Controller Agent
 │       ├── worker.md              # Worker Agent
@@ -442,6 +453,7 @@ claude_code_agent/
 │   ├── prd/                      # PRD Documents
 │   ├── srs/                      # SRS Documents
 │   ├── sds/                      # SDS Documents
+│   ├── tm/                       # Threat Model Documents
 │   └── architecture/             # Architecture Docs
 │
 └── src/                          # Generated Source Code

--- a/docs/threat-model-writer.md
+++ b/docs/threat-model-writer.md
@@ -1,0 +1,120 @@
+# Threat Model Writer Agent Documentation
+
+## Overview
+
+The Threat Model Writer Agent is responsible for generating a Threat Model (TM) document from an approved Software Design Specification (SDS). It is a security-focused component of the AD-SDLC document pipeline that identifies security threats using STRIDE categorization and scores their risk using the DREAD model, producing an actionable threat register that feeds downstream issue generation.
+
+## Pipeline Position
+
+```
+Collector → PRD Writer → SRS Writer → SDP Writer → SDS Writer → Threat Model Writer → Issue Generator
+                                                                        ↑
+                                                                  You are here
+```
+
+## Purpose
+
+The Threat Model Writer Agent:
+
+1. Reads and parses the SDS document to extract components, data flows, and trust boundaries
+2. Enumerates threats for each component using STRIDE categories (Spoofing, Tampering, Repudiation, Information Disclosure, Denial of Service, Elevation of Privilege)
+3. Scores each threat with the DREAD model (Damage, Reproducibility, Exploitability, Affected Users, Discoverability)
+4. Recommends mitigations linked back to SDS components
+5. Outputs a structured Threat Model document in both English and Korean
+
+## Input
+
+- **SDS location**: `.ad-sdlc/scratchpad/documents/{project_id}/sds.md`
+- **Format**: Markdown document following the SDS template
+- **Requirements**: SDS must enumerate components and data flows for meaningful threat extraction
+
+## Output
+
+- **Scratchpad (English)**: `.ad-sdlc/scratchpad/documents/{project_id}/threat-model.md`
+- **Scratchpad (Korean)**: `.ad-sdlc/scratchpad/documents/{project_id}/threat-model.kr.md`
+- **Public (English)**: `docs/tm/TM-{project_id}.md`
+- **Public (Korean)**: `docs/tm/TM-{project_id}.kr.md`
+- **Format**: Markdown document with structured Threat Model sections and YAML frontmatter
+
+## ID Conventions
+
+| Type         | Pattern         | Example |
+| ------------ | --------------- | ------- |
+| TM Document  | TM-{project_id} | TM-001  |
+| Threat Entry | T{N}            | T1, T2  |
+| Component    | C{N}            | C1, C2  |
+
+## Threat Model Sections
+
+The generated Threat Model captures:
+
+- **System Overview** — Summary of components and trust boundaries extracted from SDS
+- **STRIDE Threat Register** — Per-component threats classified by STRIDE category
+- **DREAD Risk Scoring** — Risk score per threat across the five DREAD dimensions
+- **Mitigation Strategies** — Recommended controls linked to SDS components
+- **Residual Risk** — Risks remaining after recommended mitigations
+- **Traceability** — Links from threats to SDS component IDs
+
+## CLI Integration
+
+```bash
+# Generate Threat Model for a project (after SDS is approved)
+ad-sdlc generate-threat-model --project 001
+```
+
+## API Reference
+
+### ThreatModelWriterAgent
+
+Main orchestrator class for Threat Model generation. Implements `IAgent` for unified
+instantiation through `AgentFactory`.
+
+#### Methods
+
+| Method                           | Description                                                        |
+| -------------------------------- | ------------------------------------------------------------------ |
+| `initialize()`                   | Initialize the agent (IAgent interface)                            |
+| `dispose()`                      | Release resources and clear session (IAgent interface)             |
+| `getSession()`                   | Return the current generation session, or `null` if none           |
+| `startSession(projectId)`        | Start a new generation session by parsing SDS                      |
+| `generateFromProject(projectId)` | Run the full pipeline (start → finalize) in one call               |
+| `finalize()`                     | Persist generated Threat Model to scratchpad and public docs paths |
+
+### Agent ID
+
+Registered as `threat-model-writer-agent` (`THREAT_MODEL_WRITER_AGENT_ID`) for `AgentFactory`.
+
+## Quality Criteria
+
+The Threat Model Writer Agent ensures:
+
+1. **Source Traceability**: Every Threat Model references its source SDS document ID and links threats to component IDs
+2. **STRIDE Coverage**: Each component is evaluated against all six STRIDE categories
+3. **DREAD Scoring Hygiene**: Each threat has a numeric score for all five DREAD dimensions with an aggregated risk level
+4. **Mitigation Completeness**: Every enumerated threat has at least one recommended mitigation
+5. **Bilingual Output**: English and Korean variants are produced for every document
+6. **Frontmatter Compliance**: All outputs include the standard `doc_id`, `version`, and `status` frontmatter
+
+## Error Handling
+
+| Error               | Cause                                        | Resolution                                            |
+| ------------------- | -------------------------------------------- | ----------------------------------------------------- |
+| `SDSNotFoundError`  | SDS document missing at expected path        | Generate SDS via SDS Writer first                     |
+| `SessionStateError` | Operation called in an invalid session state | Follow session workflow (`startSession` → `finalize`) |
+| `GenerationError`   | Threat Model content generation failed       | Inspect `phase` field and retry                       |
+| `FileWriteError`    | Output path not writable                     | Verify permissions on `docs/tm` and scratchpad        |
+
+## Configuration
+
+```yaml
+# .ad-sdlc/config/threat-model-writer.yaml
+threat_model_writer:
+  scratchpad_base_path: '.ad-sdlc/scratchpad'
+  public_docs_path: 'docs/tm'
+```
+
+## Related Documentation
+
+- [SDS Writer Agent](sds-writer.md)
+- [Issue Generator](issue-generator.md)
+- [SDP Writer Agent](sdp-writer.md)

--- a/src/ad-sdlc-orchestrator/types.ts
+++ b/src/ad-sdlc-orchestrator/types.ts
@@ -25,6 +25,7 @@ export type GreenfieldStageName =
   | 'repo_detection'
   | 'github_repo_setup'
   | 'sds_generation'
+  | 'threat_modeling'
   | 'issue_generation'
   | 'orchestration'
   | 'implementation'
@@ -387,12 +388,20 @@ export const GREENFIELD_STAGES: readonly PipelineStageDefinition[] = [
     dependsOn: ['github_repo_setup'],
   },
   {
+    name: 'threat_modeling',
+    agentType: 'threat-model-writer',
+    description: 'Generate Threat Model (STRIDE + DREAD) from SDS',
+    parallel: false,
+    approvalRequired: true,
+    dependsOn: ['sds_generation'],
+  },
+  {
     name: 'issue_generation',
     agentType: 'issue-generator',
     description: 'Generate GitHub issues from SDS',
     parallel: false,
     approvalRequired: true,
-    dependsOn: ['sds_generation'],
+    dependsOn: ['threat_modeling'],
   },
   {
     name: 'orchestration',

--- a/src/agents/AgentTypeMapping.ts
+++ b/src/agents/AgentTypeMapping.ts
@@ -117,6 +117,14 @@ export const AGENT_TYPE_MAP: Readonly<Record<string, AgentTypeEntry>> = {
     importPath: '../sds-writer/index.js',
   },
 
+  'threat-model-writer': {
+    agentId: 'threat-model-writer-agent',
+    name: 'Threat Model Writer Agent',
+    lifecycle: 'singleton',
+    requiresWrapper: false,
+    importPath: '../threat-model-writer/index.js',
+  },
+
   'issue-generator': {
     agentId: 'issue-generator',
     name: 'Issue Generator',

--- a/src/threat-model-writer/ThreatModelWriterAgent.ts
+++ b/src/threat-model-writer/ThreatModelWriterAgent.ts
@@ -1,0 +1,1024 @@
+/**
+ * Threat Model Writer Agent
+ *
+ * Generates a Threat Model (TM) document from an SDS (Software Design
+ * Specification) input. The Threat Model describes the system overview
+ * (including a data-flow diagram), identifies threats using STRIDE
+ * categorization, scores risks using the DREAD model, documents mitigation
+ * strategies, and summarizes residual risk.
+ *
+ * Implements IAgent interface for AgentFactory integration.
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { randomUUID } from 'node:crypto';
+import type { IAgent } from '../agents/types.js';
+
+import type {
+  ThreatModelWriterAgentConfig,
+  ThreatModelGenerationSession,
+  ThreatModelGenerationResult,
+  ThreatModelGenerationStats,
+  ParsedSDSExtract,
+  ParsedSDSComponent,
+  GeneratedThreatModel,
+  ThreatModelMetadata,
+  ThreatEntry,
+  DreadScore,
+} from './types.js';
+import { StrideCategory } from './types.js';
+import { SDSNotFoundError, GenerationError, FileWriteError, SessionStateError } from './errors.js';
+import { prependFrontmatter } from '../utilities/frontmatter.js';
+
+/**
+ * Default configuration for the Threat Model Writer Agent
+ */
+const DEFAULT_CONFIG: Required<ThreatModelWriterAgentConfig> = {
+  scratchpadBasePath: '.ad-sdlc/scratchpad',
+  publicDocsPath: 'docs/tm',
+};
+
+/**
+ * Agent ID for ThreatModelWriterAgent used in AgentFactory
+ */
+export const THREAT_MODEL_WRITER_AGENT_ID = 'threat-model-writer-agent';
+
+/**
+ * Threshold above which a threat's DREAD overall score is considered high-risk.
+ */
+const HIGH_RISK_DREAD_THRESHOLD = 7;
+
+/**
+ * Threat Model Writer Agent class
+ *
+ * Orchestrates the generation of Threat Model documents from SDS input.
+ * Implements IAgent interface for unified agent instantiation through AgentFactory.
+ */
+export class ThreatModelWriterAgent implements IAgent {
+  public readonly agentId = THREAT_MODEL_WRITER_AGENT_ID;
+  public readonly name = 'Threat Model Writer Agent';
+
+  private readonly config: Required<ThreatModelWriterAgentConfig>;
+  private session: ThreatModelGenerationSession | null = null;
+  private initialized = false;
+
+  constructor(config: ThreatModelWriterAgentConfig = {}) {
+    this.config = { ...DEFAULT_CONFIG, ...config };
+  }
+
+  /**
+   * Initialize the agent (IAgent interface)
+   */
+  public async initialize(): Promise<void> {
+    if (this.initialized) {
+      return;
+    }
+    await Promise.resolve();
+    this.initialized = true;
+  }
+
+  /**
+   * Dispose of the agent and release resources (IAgent interface)
+   */
+  public async dispose(): Promise<void> {
+    await Promise.resolve();
+    this.session = null;
+    this.initialized = false;
+  }
+
+  /**
+   * Get the current session
+   * @returns Current generation session or null if no session is active
+   */
+  public getSession(): ThreatModelGenerationSession | null {
+    return this.session;
+  }
+
+  /**
+   * Start a new Threat Model generation session
+   * @param projectId - Project identifier
+   * @returns The new session
+   */
+  public async startSession(projectId: string): Promise<ThreatModelGenerationSession> {
+    await Promise.resolve();
+
+    const docsDir = path.join(this.config.scratchpadBasePath, 'documents', projectId);
+    const sdsPath = path.join(docsDir, 'sds.md');
+
+    if (!fs.existsSync(sdsPath)) {
+      throw new SDSNotFoundError(projectId, sdsPath);
+    }
+
+    const sdsContent = fs.readFileSync(sdsPath, 'utf-8');
+    const parsedSDS = this.extractSDS(sdsContent, projectId);
+
+    const warnings: string[] = [];
+    if (parsedSDS.components.length === 0) {
+      warnings.push(
+        'No components detected in SDS — generated Threat Model uses a minimal default threat set.'
+      );
+    }
+
+    this.session = {
+      sessionId: randomUUID(),
+      projectId,
+      status: 'pending',
+      parsedSDS,
+      startedAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      ...(warnings.length > 0 && { warnings }),
+    };
+
+    return this.session;
+  }
+
+  /**
+   * Generate a Threat Model from a project
+   * @param projectId - Project identifier
+   * @returns Generation result
+   */
+  public async generateFromProject(projectId: string): Promise<ThreatModelGenerationResult> {
+    const startTime = Date.now();
+
+    if (!this.session || this.session.projectId !== projectId) {
+      await this.startSession(projectId);
+    }
+
+    if (!this.session) {
+      throw new GenerationError(projectId, 'initialization', 'Failed to create session');
+    }
+
+    try {
+      this.updateSession({ status: 'parsing' });
+
+      const { parsedSDS } = this.session;
+
+      this.updateSession({ status: 'generating' });
+
+      // Carry forward warnings collected during startSession so any
+      // additional warnings are appended to the same list.
+      const warnings: string[] = this.session.warnings ? [...this.session.warnings] : [];
+
+      const generatedThreatModel = this.generateThreatModelDocument(projectId, parsedSDS, warnings);
+
+      this.updateSession({
+        status: 'completed',
+        generatedThreatModel,
+        ...(warnings.length > 0 && { warnings }),
+      });
+
+      const paths = await this.writeOutputFiles(projectId, generatedThreatModel);
+
+      const highRiskThreats = generatedThreatModel.threats.filter(
+        (t) => t.dread.overall >= HIGH_RISK_DREAD_THRESHOLD
+      ).length;
+
+      const stats: ThreatModelGenerationStats = {
+        sdsComponentCount: parsedSDS.components.length,
+        threatsIdentified: generatedThreatModel.threats.length,
+        highRiskThreats,
+        processingTimeMs: Date.now() - startTime,
+      };
+
+      return {
+        success: true,
+        projectId,
+        scratchpadPath: paths.scratchpadPath,
+        publicPath: paths.publicPath,
+        scratchpadPathKorean: paths.scratchpadPathKorean,
+        publicPathKorean: paths.publicPathKorean,
+        generatedThreatModel,
+        stats,
+        ...(warnings.length > 0 && { warnings }),
+      };
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+      this.updateSession({
+        status: 'failed',
+        errorMessage,
+      });
+      throw error;
+    }
+  }
+
+  /**
+   * Finalize the current session and write output files
+   * @returns Generation result based on the cached generated Threat Model
+   */
+  public async finalize(): Promise<ThreatModelGenerationResult> {
+    if (!this.session) {
+      throw new SessionStateError('null', 'active', 'finalize');
+    }
+
+    if (this.session.status !== 'completed') {
+      throw new SessionStateError(this.session.status, 'completed', 'finalize');
+    }
+
+    if (!this.session.generatedThreatModel) {
+      throw new GenerationError(
+        this.session.projectId,
+        'finalization',
+        'No generated Threat Model'
+      );
+    }
+
+    const paths = await this.writeOutputFiles(
+      this.session.projectId,
+      this.session.generatedThreatModel
+    );
+
+    const highRiskThreats = this.session.generatedThreatModel.threats.filter(
+      (t) => t.dread.overall >= HIGH_RISK_DREAD_THRESHOLD
+    ).length;
+
+    return {
+      success: true,
+      projectId: this.session.projectId,
+      scratchpadPath: paths.scratchpadPath,
+      publicPath: paths.publicPath,
+      scratchpadPathKorean: paths.scratchpadPathKorean,
+      publicPathKorean: paths.publicPathKorean,
+      generatedThreatModel: this.session.generatedThreatModel,
+      stats: {
+        sdsComponentCount: this.session.parsedSDS.components.length,
+        threatsIdentified: this.session.generatedThreatModel.threats.length,
+        highRiskThreats,
+        processingTimeMs: 0,
+      },
+    };
+  }
+
+  /**
+   * Update session with partial data
+   * @param updates - Partial session fields to merge into the current session
+   */
+  private updateSession(updates: Partial<ThreatModelGenerationSession>): void {
+    if (!this.session) return;
+
+    this.session = {
+      ...this.session,
+      ...updates,
+      updatedAt: new Date().toISOString(),
+    };
+  }
+
+  /**
+   * Extract a lightweight SDS summary from SDS markdown content.
+   *
+   * Looks for the document ID, product title, component headings
+   * (`### CMP-xxx`), and indicator sections for API and data layers.
+   * @param content - Raw SDS markdown
+   * @param projectId - Project identifier (used as fallback)
+   */
+  private extractSDS(content: string, projectId: string): ParsedSDSExtract {
+    const docIdMatch =
+      content.match(/^doc_id:\s*['"]?([^'"\n]+)['"]?/m) ??
+      content.match(/\|\s*\*\*Document ID\*\*\s*\|\s*([^|]+)\s*\|/);
+    const documentId = docIdMatch?.[1]?.trim() ?? `SDS-${projectId}`;
+
+    const titleMatch =
+      content.match(/^#\s+(?:Software Design Specification:\s*)?(.+)$/m) ??
+      content.match(/^title:\s*['"]?([^'"\n]+)['"]?/m);
+    const productName = titleMatch?.[1]?.trim() ?? projectId;
+
+    const components = this.extractComponents(content);
+
+    // Heuristic detection of API and data sections (based on SDS writer
+    // template section names). Matches are case-insensitive and tolerate
+    // optional section numbering like "## 5. Interface Design".
+    const hasApiSurface =
+      /^#{1,6}\s+[\d.]*\s*(?:Interface Design|API Endpoints?|API Specification|API Design)/im.test(
+        content
+      );
+    const hasDataLayer =
+      /^#{1,6}\s+[\d.]*\s*(?:Data Design|Data Models?|Database Design|Persistence)/im.test(content);
+
+    return {
+      documentId,
+      productName,
+      components,
+      hasApiSurface,
+      hasDataLayer,
+    };
+  }
+
+  /**
+   * Extract components from an SDS markdown document.
+   *
+   * Supports the two layouts produced by `SDSWriterAgent`:
+   *   1. `### CMP-001: Component Name`
+   *   2. `### CMP-001` followed by a description block.
+   *
+   * @param content - Raw SDS markdown
+   */
+  private extractComponents(content: string): readonly ParsedSDSComponent[] {
+    const components: ParsedSDSComponent[] = [];
+    const headingRegex = /^###\s+(CMP-\d+)(?::\s*(.+))?$/gm;
+
+    let match: RegExpExecArray | null;
+    while ((match = headingRegex.exec(content)) !== null) {
+      const id = match[1];
+      if (id === undefined) continue;
+
+      const name = match[2]?.trim() ?? id;
+
+      // Capture the short description from the next non-empty line(s)
+      // before the following heading or end of document. We don't need
+      // the full component body — just a one-line summary for the
+      // threat model's target column.
+      const afterHeadingIdx = match.index + match[0].length;
+      const rest = content.slice(afterHeadingIdx);
+      const nextHeadingMatch = /\n#{1,6}\s/.exec(rest);
+      const block = nextHeadingMatch !== null ? rest.slice(0, nextHeadingMatch.index) : rest;
+      const descriptionLine = block
+        .split('\n')
+        .map((line) => line.trim())
+        .find((line) => line.length > 0 && !line.startsWith('|') && !line.startsWith('-'));
+      const description = descriptionLine ?? '';
+
+      components.push({ id, name, description });
+    }
+
+    return components;
+  }
+
+  /**
+   * Generate the complete Threat Model document object.
+   * @param projectId - Project identifier for document naming
+   * @param sds - Parsed SDS extract
+   * @param warnings - Mutable warnings array for fallbacks
+   */
+  private generateThreatModelDocument(
+    projectId: string,
+    sds: ParsedSDSExtract,
+    warnings: string[]
+  ): GeneratedThreatModel {
+    const now = new Date().toISOString().split('T')[0] ?? '';
+
+    const metadata: ThreatModelMetadata = {
+      documentId: `TM-${projectId}`,
+      sourceSDS: sds.documentId,
+      version: '1.0.0',
+      status: 'Draft',
+      createdDate: now,
+      updatedDate: now,
+    };
+
+    const threats = this.generateThreats(sds, warnings);
+
+    let content = this.generateMarkdownContent(metadata, sds, threats);
+    let contentKorean = this.generateMarkdownContentKorean(metadata, sds, threats);
+
+    content = prependFrontmatter(content, {
+      docId: metadata.documentId,
+      title: `Threat Model: ${sds.productName}`,
+      version: metadata.version,
+      status: metadata.status,
+      generatedBy: 'AD-SDLC Threat Model Writer Agent',
+      generatedAt: new Date().toISOString(),
+      sourceDocuments: [metadata.sourceSDS],
+      changeHistory: [
+        {
+          version: metadata.version,
+          date: now,
+          author: 'AD-SDLC Threat Model Writer Agent',
+          description: 'Initial document generation',
+        },
+      ],
+    });
+
+    contentKorean = prependFrontmatter(contentKorean, {
+      docId: metadata.documentId,
+      title: `Threat Model: ${sds.productName} (Korean)`,
+      version: metadata.version,
+      status: metadata.status,
+      generatedBy: 'AD-SDLC Threat Model Writer Agent',
+      generatedAt: new Date().toISOString(),
+      sourceDocuments: [metadata.sourceSDS],
+      changeHistory: [
+        {
+          version: metadata.version,
+          date: now,
+          author: 'AD-SDLC Threat Model Writer Agent',
+          description: 'Initial document generation (Korean variant)',
+        },
+      ],
+    });
+
+    return {
+      metadata,
+      content,
+      contentKorean,
+      threats,
+    };
+  }
+
+  /**
+   * Generate the threat list using heuristics derived from the parsed SDS.
+   *
+   * The heuristics guarantee one threat per STRIDE category (six threats)
+   * so the output always exercises the full STRIDE spectrum. Additional
+   * threats are appended when the SDS exposes an API surface or a data
+   * layer, since those signals reliably increase the attack surface.
+   *
+   * @param sds - Parsed SDS extract used for target selection
+   * @param warnings - Mutable warnings array for fallbacks
+   */
+  private generateThreats(sds: ParsedSDSExtract, warnings: string[]): readonly ThreatEntry[] {
+    const primaryComponent = sds.components[0];
+    const primaryTarget = primaryComponent?.name ?? sds.productName;
+    const secondaryTarget = sds.components[1]?.name ?? primaryComponent?.name ?? sds.productName;
+
+    if (sds.components.length === 0) {
+      warnings.push(
+        'SDS had no components — STRIDE threats are generated against a single default target.'
+      );
+    }
+
+    const threats: ThreatEntry[] = [];
+
+    threats.push({
+      id: 'T1',
+      category: StrideCategory.Spoofing,
+      title: 'Authentication bypass via forged credentials',
+      target: primaryTarget,
+      description:
+        'An attacker impersonates a legitimate user by submitting forged or stolen credentials, gaining unauthorized access to the system.',
+      dread: this.makeDread(8, 6, 5, 8, 6),
+      mitigation:
+        'Enforce strong password policies, use multi-factor authentication, and rotate session tokens on privilege changes.',
+      residualRisk: 'Low',
+    });
+
+    threats.push({
+      id: 'T2',
+      category: StrideCategory.Tampering,
+      title: 'Unauthorized modification of persisted data',
+      target: sds.hasDataLayer ? 'Data store' : secondaryTarget,
+      description:
+        'An attacker alters data at rest or in transit to change application state or corrupt records.',
+      dread: this.makeDread(7, 5, 4, 7, 5),
+      mitigation:
+        'Apply parameterized queries, validate all inputs, and protect payloads with TLS and integrity checks (HMAC or signed hashes).',
+      residualRisk: 'Low',
+    });
+
+    threats.push({
+      id: 'T3',
+      category: StrideCategory.Repudiation,
+      title: 'Insufficient audit trail for privileged actions',
+      target: primaryTarget,
+      description:
+        'Users deny performing privileged actions because audit logs are incomplete or tamperable.',
+      dread: this.makeDread(5, 6, 4, 6, 5),
+      mitigation:
+        'Emit append-only, timestamped audit logs with user identity and tie log records to an immutable store.',
+      residualRisk: 'Medium',
+    });
+
+    threats.push({
+      id: 'T4',
+      category: StrideCategory.InformationDisclosure,
+      title: 'Sensitive data exposure in responses or logs',
+      target: sds.hasDataLayer ? 'Data store' : primaryTarget,
+      description:
+        'Sensitive data (credentials, PII, tokens) leaks through API responses, error messages, or log files.',
+      dread: this.makeDread(8, 7, 6, 8, 7),
+      mitigation:
+        'Classify data, mask sensitive fields in responses and logs, and encrypt data at rest and in transit.',
+      residualRisk: 'Medium',
+    });
+
+    threats.push({
+      id: 'T5',
+      category: StrideCategory.DenialOfService,
+      title: 'Resource exhaustion via uncontrolled request load',
+      target: sds.hasApiSurface ? 'Public API' : primaryTarget,
+      description:
+        'An attacker sends a flood of requests or expensive queries that degrade or halt service availability.',
+      dread: this.makeDread(6, 8, 7, 9, 8),
+      mitigation:
+        'Apply rate limiting, input size limits, circuit breakers, and horizontal scaling behind a load balancer.',
+      residualRisk: 'Medium',
+    });
+
+    threats.push({
+      id: 'T6',
+      category: StrideCategory.ElevationOfPrivilege,
+      title: 'Privilege escalation through missing authorization checks',
+      target: primaryTarget,
+      description:
+        'An authenticated user accesses functions or data beyond their role because authorization is missing or bypassable.',
+      dread: this.makeDread(9, 5, 4, 7, 5),
+      mitigation:
+        'Enforce role-based access control at every layer, deny-by-default, and cover authorization paths with automated tests.',
+      residualRisk: 'Low',
+    });
+
+    if (sds.hasApiSurface) {
+      threats.push({
+        id: `T${String(threats.length + 1)}`,
+        category: StrideCategory.InformationDisclosure,
+        title: 'Injection attack against public API',
+        target: 'Public API',
+        description:
+          'Attackers inject crafted payloads (SQL, command, XSS) into API inputs to exfiltrate data or gain control over the system.',
+        dread: this.makeDread(9, 7, 6, 8, 7),
+        mitigation:
+          'Use parameterized queries, schema-based input validation, output encoding, and Web Application Firewall (WAF) rules.',
+        residualRisk: 'Low',
+      });
+    }
+
+    if (sds.hasDataLayer) {
+      threats.push({
+        id: `T${String(threats.length + 1)}`,
+        category: StrideCategory.Tampering,
+        title: 'Data integrity violation during migration or backup restore',
+        target: 'Data store',
+        description:
+          'Database migrations or backup restores leave data in an inconsistent or unauthorized state.',
+        dread: this.makeDread(6, 4, 3, 6, 4),
+        mitigation:
+          'Run migrations inside transactions, require peer review on schema changes, and validate backups via integrity hashes.',
+        residualRisk: 'Low',
+      });
+    }
+
+    return threats;
+  }
+
+  /**
+   * Build a DREAD score from individual attribute values and compute the
+   * overall average. Values are clamped to 1..10.
+   * @param damage - Damage potential (1-10)
+   * @param reproducibility - Reproducibility (1-10)
+   * @param exploitability - Exploitability (1-10)
+   * @param affectedUsers - Affected users (1-10)
+   * @param discoverability - Discoverability (1-10)
+   */
+  private makeDread(
+    damage: number,
+    reproducibility: number,
+    exploitability: number,
+    affectedUsers: number,
+    discoverability: number
+  ): DreadScore {
+    const clamp = (v: number): number => Math.max(1, Math.min(10, v));
+    const d = clamp(damage);
+    const r = clamp(reproducibility);
+    const e = clamp(exploitability);
+    const a = clamp(affectedUsers);
+    const disc = clamp(discoverability);
+    // One-decimal precision for the overall average.
+    const overall = Math.round(((d + r + e + a + disc) / 5) * 10) / 10;
+    return {
+      damage: d,
+      reproducibility: r,
+      exploitability: e,
+      affectedUsers: a,
+      discoverability: disc,
+      overall,
+    };
+  }
+
+  /**
+   * Render the English markdown content for the Threat Model document.
+   *
+   * Five-section layout:
+   *   1. System Overview (with Mermaid data-flow diagram)
+   *   2. Threat Identification (STRIDE table)
+   *   3. Risk Assessment (DREAD table)
+   *   4. Mitigation Strategies
+   *   5. Residual Risk Summary
+   *
+   * @param metadata - Threat Model metadata
+   * @param sds - Parsed SDS extract
+   * @param threats - Threats to render
+   */
+  private generateMarkdownContent(
+    metadata: ThreatModelMetadata,
+    sds: ParsedSDSExtract,
+    threats: readonly ThreatEntry[]
+  ): string {
+    const lines: string[] = [];
+
+    lines.push(`# Threat Model: ${sds.productName}`);
+    lines.push('');
+
+    lines.push('| **Document ID** | **Source SDS** | **Version** | **Status** |');
+    lines.push('|-----------------|----------------|-------------|------------|');
+    lines.push(
+      `| ${metadata.documentId} | ${metadata.sourceSDS} | ${metadata.version} | ${metadata.status} |`
+    );
+    lines.push('');
+    lines.push('---');
+    lines.push('');
+
+    lines.push('## Table of Contents');
+    lines.push('');
+    lines.push('1. [System Overview](#1-system-overview)');
+    lines.push('2. [Threat Identification (STRIDE)](#2-threat-identification-stride)');
+    lines.push('3. [Risk Assessment (DREAD)](#3-risk-assessment-dread)');
+    lines.push('4. [Mitigation Strategies](#4-mitigation-strategies)');
+    lines.push('5. [Residual Risk Summary](#5-residual-risk-summary)');
+    lines.push('');
+
+    // Section 1: System Overview
+    lines.push('## 1. System Overview');
+    lines.push('');
+    lines.push(`- **Product:** ${sds.productName}`);
+    lines.push(`- **Source SDS:** ${metadata.sourceSDS}`);
+    lines.push(`- **Components analysed:** ${String(sds.components.length)}`);
+    lines.push(`- **API surface detected:** ${sds.hasApiSurface ? 'Yes' : 'No'}`);
+    lines.push(`- **Data layer detected:** ${sds.hasDataLayer ? 'Yes' : 'No'}`);
+    lines.push('');
+    lines.push('### 1.1 Data Flow Diagram');
+    lines.push('');
+    lines.push('```mermaid');
+    lines.push('flowchart LR');
+    lines.push('    User([External User])');
+    if (sds.hasApiSurface) {
+      lines.push('    API[API Gateway]');
+      lines.push('    User -->|HTTPS| API');
+    }
+    if (sds.components.length === 0) {
+      lines.push('    App[Application]');
+      if (sds.hasApiSurface) {
+        lines.push('    API --> App');
+      } else {
+        lines.push('    User --> App');
+      }
+      if (sds.hasDataLayer) {
+        lines.push('    App --> DB[(Data Store)]');
+      }
+    } else {
+      for (const component of sds.components.slice(0, 5)) {
+        const safeId = component.id.replace(/[^A-Za-z0-9_]/g, '_');
+        lines.push(`    ${safeId}[${component.name}]`);
+        if (sds.hasApiSurface) {
+          lines.push(`    API --> ${safeId}`);
+        } else {
+          lines.push(`    User --> ${safeId}`);
+        }
+      }
+      if (sds.hasDataLayer) {
+        lines.push('    DB[(Data Store)]');
+        for (const component of sds.components.slice(0, 5)) {
+          const safeId = component.id.replace(/[^A-Za-z0-9_]/g, '_');
+          lines.push(`    ${safeId} --> DB`);
+        }
+      }
+    }
+    lines.push('```');
+    lines.push('');
+
+    if (sds.components.length > 0) {
+      lines.push('### 1.2 Components in Scope');
+      lines.push('');
+      lines.push('| ID | Name | Description |');
+      lines.push('|----|------|-------------|');
+      for (const component of sds.components) {
+        const desc = component.description.length > 0 ? component.description : '—';
+        lines.push(`| ${component.id} | ${component.name} | ${desc} |`);
+      }
+      lines.push('');
+    }
+
+    // Section 2: Threat Identification (STRIDE)
+    lines.push('## 2. Threat Identification (STRIDE)');
+    lines.push('');
+    lines.push(
+      'Threats are categorised using Microsoft STRIDE: Spoofing, Tampering, Repudiation, Information Disclosure, Denial of Service, and Elevation of Privilege.'
+    );
+    lines.push('');
+    lines.push('| ID | STRIDE Category | Target | Threat | Description |');
+    lines.push('|----|-----------------|--------|--------|-------------|');
+    for (const threat of threats) {
+      lines.push(
+        `| ${threat.id} | ${threat.category} | ${threat.target} | ${threat.title} | ${threat.description} |`
+      );
+    }
+    lines.push('');
+
+    // Section 3: Risk Assessment (DREAD)
+    lines.push('## 3. Risk Assessment (DREAD)');
+    lines.push('');
+    lines.push(
+      'Each threat is scored on five DREAD attributes from 1 (lowest) to 10 (highest). The overall column is the average of the five attributes.'
+    );
+    lines.push('');
+    lines.push(
+      '| ID | Damage | Reproducibility | Exploitability | Affected Users | Discoverability | Overall |'
+    );
+    lines.push(
+      '|----|--------|-----------------|----------------|----------------|-----------------|---------|'
+    );
+    for (const threat of threats) {
+      const d = threat.dread;
+      lines.push(
+        `| ${threat.id} | ${String(d.damage)} | ${String(d.reproducibility)} | ${String(d.exploitability)} | ${String(d.affectedUsers)} | ${String(d.discoverability)} | ${d.overall.toFixed(1)} |`
+      );
+    }
+    lines.push('');
+    lines.push('### 3.1 Risk Ranking');
+    lines.push('');
+    lines.push('| Rank | ID | Overall | Category |');
+    lines.push('|------|----|---------|----------|');
+    const ranked = [...threats].sort((a, b) => b.dread.overall - a.dread.overall);
+    ranked.forEach((threat, index) => {
+      lines.push(
+        `| ${String(index + 1)} | ${threat.id} | ${threat.dread.overall.toFixed(1)} | ${threat.category} |`
+      );
+    });
+    lines.push('');
+
+    // Section 4: Mitigation Strategies
+    lines.push('## 4. Mitigation Strategies');
+    lines.push('');
+    lines.push('| ID | Threat | Mitigation |');
+    lines.push('|----|--------|------------|');
+    for (const threat of threats) {
+      lines.push(`| ${threat.id} | ${threat.title} | ${threat.mitigation} |`);
+    }
+    lines.push('');
+
+    // Section 5: Residual Risk Summary
+    lines.push('## 5. Residual Risk Summary');
+    lines.push('');
+    const highCount = threats.filter((t) => t.residualRisk === 'High').length;
+    const mediumCount = threats.filter((t) => t.residualRisk === 'Medium').length;
+    const lowCount = threats.filter((t) => t.residualRisk === 'Low').length;
+    lines.push('| Residual Risk Level | Count |');
+    lines.push('|---------------------|-------|');
+    lines.push(`| High | ${String(highCount)} |`);
+    lines.push(`| Medium | ${String(mediumCount)} |`);
+    lines.push(`| Low | ${String(lowCount)} |`);
+    lines.push('');
+    lines.push('### 5.1 Per-Threat Residual Risk');
+    lines.push('');
+    lines.push('| ID | Category | Residual Risk |');
+    lines.push('|----|----------|---------------|');
+    for (const threat of threats) {
+      lines.push(`| ${threat.id} | ${threat.category} | ${threat.residualRisk} |`);
+    }
+    lines.push('');
+    lines.push('### 5.2 Review Cadence');
+    lines.push('');
+    lines.push(
+      '- Residual risks are re-assessed at every major release and after any security incident.'
+    );
+    lines.push(
+      '- High residual risks require written acceptance by the product owner before release.'
+    );
+    lines.push('');
+
+    return lines.join('\n');
+  }
+
+  /**
+   * Render the Korean variant of the Threat Model markdown content.
+   * Mirrors the English structure with localised headings and prose.
+   * @param metadata - Threat Model metadata
+   * @param sds - Parsed SDS extract
+   * @param threats - Threats to render
+   */
+  private generateMarkdownContentKorean(
+    metadata: ThreatModelMetadata,
+    sds: ParsedSDSExtract,
+    threats: readonly ThreatEntry[]
+  ): string {
+    const lines: string[] = [];
+
+    lines.push(`# 위협 모델: ${sds.productName}`);
+    lines.push('');
+
+    lines.push('| **문서 ID** | **출처 SDS** | **버전** | **상태** |');
+    lines.push('|-------------|--------------|----------|----------|');
+    lines.push(
+      `| ${metadata.documentId} | ${metadata.sourceSDS} | ${metadata.version} | ${metadata.status} |`
+    );
+    lines.push('');
+    lines.push('---');
+    lines.push('');
+
+    lines.push('## 목차');
+    lines.push('');
+    lines.push('1. [시스템 개요](#1-시스템-개요)');
+    lines.push('2. [위협 식별 (STRIDE)](#2-위협-식별-stride)');
+    lines.push('3. [위험 평가 (DREAD)](#3-위험-평가-dread)');
+    lines.push('4. [완화 전략](#4-완화-전략)');
+    lines.push('5. [잔여 위험 요약](#5-잔여-위험-요약)');
+    lines.push('');
+
+    // Section 1: System Overview (Korean)
+    lines.push('## 1. 시스템 개요');
+    lines.push('');
+    lines.push(`- **제품:** ${sds.productName}`);
+    lines.push(`- **출처 SDS:** ${metadata.sourceSDS}`);
+    lines.push(`- **분석 대상 컴포넌트 수:** ${String(sds.components.length)}`);
+    lines.push(`- **API 인터페이스 감지:** ${sds.hasApiSurface ? '예' : '아니오'}`);
+    lines.push(`- **데이터 계층 감지:** ${sds.hasDataLayer ? '예' : '아니오'}`);
+    lines.push('');
+    lines.push('### 1.1 데이터 흐름도');
+    lines.push('');
+    lines.push('```mermaid');
+    lines.push('flowchart LR');
+    lines.push('    User([외부 사용자])');
+    if (sds.hasApiSurface) {
+      lines.push('    API[API Gateway]');
+      lines.push('    User -->|HTTPS| API');
+    }
+    if (sds.components.length === 0) {
+      lines.push('    App[Application]');
+      if (sds.hasApiSurface) {
+        lines.push('    API --> App');
+      } else {
+        lines.push('    User --> App');
+      }
+      if (sds.hasDataLayer) {
+        lines.push('    App --> DB[(Data Store)]');
+      }
+    } else {
+      for (const component of sds.components.slice(0, 5)) {
+        const safeId = component.id.replace(/[^A-Za-z0-9_]/g, '_');
+        lines.push(`    ${safeId}[${component.name}]`);
+        if (sds.hasApiSurface) {
+          lines.push(`    API --> ${safeId}`);
+        } else {
+          lines.push(`    User --> ${safeId}`);
+        }
+      }
+      if (sds.hasDataLayer) {
+        lines.push('    DB[(Data Store)]');
+        for (const component of sds.components.slice(0, 5)) {
+          const safeId = component.id.replace(/[^A-Za-z0-9_]/g, '_');
+          lines.push(`    ${safeId} --> DB`);
+        }
+      }
+    }
+    lines.push('```');
+    lines.push('');
+
+    if (sds.components.length > 0) {
+      lines.push('### 1.2 분석 범위 컴포넌트');
+      lines.push('');
+      lines.push('| ID | 이름 | 설명 |');
+      lines.push('|----|------|------|');
+      for (const component of sds.components) {
+        const desc = component.description.length > 0 ? component.description : '—';
+        lines.push(`| ${component.id} | ${component.name} | ${desc} |`);
+      }
+      lines.push('');
+    }
+
+    // Section 2: STRIDE (Korean)
+    lines.push('## 2. 위협 식별 (STRIDE)');
+    lines.push('');
+    lines.push(
+      '위협은 Microsoft STRIDE 분류 체계를 따릅니다: Spoofing(위장), Tampering(변조), Repudiation(부인), Information Disclosure(정보 유출), Denial of Service(서비스 거부), Elevation of Privilege(권한 상승).'
+    );
+    lines.push('');
+    lines.push('| ID | STRIDE 분류 | 대상 | 위협 | 설명 |');
+    lines.push('|----|-------------|------|------|------|');
+    for (const threat of threats) {
+      lines.push(
+        `| ${threat.id} | ${threat.category} | ${threat.target} | ${threat.title} | ${threat.description} |`
+      );
+    }
+    lines.push('');
+
+    // Section 3: DREAD (Korean)
+    lines.push('## 3. 위험 평가 (DREAD)');
+    lines.push('');
+    lines.push(
+      '각 위협은 DREAD 5개 속성을 1(최저)~10(최고) 척도로 평가합니다. Overall 컬럼은 5개 속성의 평균값입니다.'
+    );
+    lines.push('');
+    lines.push('| ID | 피해 | 재현성 | 악용 난이도 | 영향 사용자 | 발견 용이성 | 종합 |');
+    lines.push('|----|------|--------|-------------|-------------|-------------|------|');
+    for (const threat of threats) {
+      const d = threat.dread;
+      lines.push(
+        `| ${threat.id} | ${String(d.damage)} | ${String(d.reproducibility)} | ${String(d.exploitability)} | ${String(d.affectedUsers)} | ${String(d.discoverability)} | ${d.overall.toFixed(1)} |`
+      );
+    }
+    lines.push('');
+    lines.push('### 3.1 위험 순위');
+    lines.push('');
+    lines.push('| 순위 | ID | 종합 점수 | 분류 |');
+    lines.push('|------|----|-----------|------|');
+    const ranked = [...threats].sort((a, b) => b.dread.overall - a.dread.overall);
+    ranked.forEach((threat, index) => {
+      lines.push(
+        `| ${String(index + 1)} | ${threat.id} | ${threat.dread.overall.toFixed(1)} | ${threat.category} |`
+      );
+    });
+    lines.push('');
+
+    // Section 4: Mitigation (Korean)
+    lines.push('## 4. 완화 전략');
+    lines.push('');
+    lines.push('| ID | 위협 | 완화 방안 |');
+    lines.push('|----|------|-----------|');
+    for (const threat of threats) {
+      lines.push(`| ${threat.id} | ${threat.title} | ${threat.mitigation} |`);
+    }
+    lines.push('');
+
+    // Section 5: Residual Risk (Korean)
+    lines.push('## 5. 잔여 위험 요약');
+    lines.push('');
+    const highCount = threats.filter((t) => t.residualRisk === 'High').length;
+    const mediumCount = threats.filter((t) => t.residualRisk === 'Medium').length;
+    const lowCount = threats.filter((t) => t.residualRisk === 'Low').length;
+    lines.push('| 잔여 위험 수준 | 개수 |');
+    lines.push('|----------------|------|');
+    lines.push(`| High | ${String(highCount)} |`);
+    lines.push(`| Medium | ${String(mediumCount)} |`);
+    lines.push(`| Low | ${String(lowCount)} |`);
+    lines.push('');
+    lines.push('### 5.1 위협별 잔여 위험');
+    lines.push('');
+    lines.push('| ID | 분류 | 잔여 위험 |');
+    lines.push('|----|------|-----------|');
+    for (const threat of threats) {
+      lines.push(`| ${threat.id} | ${threat.category} | ${threat.residualRisk} |`);
+    }
+    lines.push('');
+    lines.push('### 5.2 검토 주기');
+    lines.push('');
+    lines.push('- 잔여 위험은 주요 릴리스 및 보안 사고 직후 재평가합니다.');
+    lines.push('- 높은(High) 잔여 위험은 릴리스 전에 제품 책임자의 서면 승인이 필요합니다.');
+    lines.push('');
+
+    return lines.join('\n');
+  }
+
+  /**
+   * Write Threat Model output files (English + Korean) to scratchpad and
+   * public locations.
+   * @param projectId - Project identifier
+   * @param tm - Generated Threat Model
+   * @returns Paths of all four written files
+   */
+  private async writeOutputFiles(
+    projectId: string,
+    tm: GeneratedThreatModel
+  ): Promise<{
+    scratchpadPath: string;
+    publicPath: string;
+    scratchpadPathKorean: string;
+    publicPathKorean: string;
+  }> {
+    await Promise.resolve();
+
+    const scratchpadDir = path.join(this.config.scratchpadBasePath, 'documents', projectId);
+    const scratchpadPath = path.join(scratchpadDir, 'tm.md');
+    const scratchpadPathKorean = path.join(scratchpadDir, 'tm.kr.md');
+
+    const publicDir = this.config.publicDocsPath;
+    const publicPath = path.join(publicDir, `TM-${projectId}.md`);
+    const publicPathKorean = path.join(publicDir, `TM-${projectId}.kr.md`);
+
+    try {
+      fs.mkdirSync(scratchpadDir, { recursive: true });
+      fs.mkdirSync(publicDir, { recursive: true });
+
+      fs.writeFileSync(scratchpadPath, tm.content, 'utf-8');
+      fs.writeFileSync(publicPath, tm.content, 'utf-8');
+      fs.writeFileSync(scratchpadPathKorean, tm.contentKorean, 'utf-8');
+      fs.writeFileSync(publicPathKorean, tm.contentKorean, 'utf-8');
+
+      return { scratchpadPath, publicPath, scratchpadPathKorean, publicPathKorean };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      throw new FileWriteError(scratchpadPath, message);
+    }
+  }
+}
+
+// Singleton pattern
+let instance: ThreatModelWriterAgent | null = null;
+
+/**
+ * Get the singleton instance of ThreatModelWriterAgent
+ * @param config - Optional configuration (used only for the first call)
+ * @returns The singleton instance
+ */
+export function getThreatModelWriterAgent(
+  config?: ThreatModelWriterAgentConfig
+): ThreatModelWriterAgent {
+  if (!instance) {
+    instance = new ThreatModelWriterAgent(config);
+  }
+  return instance;
+}
+
+/**
+ * Reset the singleton instance (mainly for testing)
+ */
+export function resetThreatModelWriterAgent(): void {
+  instance = null;
+}

--- a/src/threat-model-writer/errors.ts
+++ b/src/threat-model-writer/errors.ts
@@ -1,0 +1,81 @@
+/**
+ * Threat Model Writer Agent module error definitions
+ *
+ * Custom error classes for Threat Model generation and validation operations.
+ */
+
+/**
+ * Base error class for Threat Model writer agent errors
+ */
+export class ThreatModelWriterError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ThreatModelWriterError';
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
+
+/**
+ * Error thrown when the SDS document is not found
+ */
+export class SDSNotFoundError extends ThreatModelWriterError {
+  /** The project ID that was not found */
+  public readonly projectId: string;
+  /** The path that was searched */
+  public readonly searchedPath: string;
+
+  constructor(projectId: string, searchedPath: string) {
+    super(`SDS document not found for project "${projectId}" at path: ${searchedPath}`);
+    this.name = 'SDSNotFoundError';
+    this.projectId = projectId;
+    this.searchedPath = searchedPath;
+  }
+}
+
+/**
+ * Error thrown when a session is in an invalid state for an operation
+ */
+export class SessionStateError extends ThreatModelWriterError {
+  /** Current session state */
+  public readonly currentState: string;
+  /** Expected state */
+  public readonly expectedState: string;
+
+  constructor(currentState: string, expectedState: string, action: string) {
+    super(`Cannot ${action}: session is in "${currentState}" state, expected "${expectedState}"`);
+    this.name = 'SessionStateError';
+    this.currentState = currentState;
+    this.expectedState = expectedState;
+  }
+}
+
+/**
+ * Error thrown when Threat Model generation fails
+ */
+export class GenerationError extends ThreatModelWriterError {
+  /** The phase where generation failed */
+  public readonly phase: string;
+  /** The project ID */
+  public readonly projectId: string;
+
+  constructor(projectId: string, phase: string, reason: string) {
+    super(`Threat Model generation failed for project "${projectId}" at "${phase}": ${reason}`);
+    this.name = 'GenerationError';
+    this.projectId = projectId;
+    this.phase = phase;
+  }
+}
+
+/**
+ * Error thrown when a file write operation fails
+ */
+export class FileWriteError extends ThreatModelWriterError {
+  /** The file path that failed */
+  public readonly filePath: string;
+
+  constructor(filePath: string, reason: string) {
+    super(`Failed to write Threat Model to "${filePath}": ${reason}`);
+    this.name = 'FileWriteError';
+    this.filePath = filePath;
+  }
+}

--- a/src/threat-model-writer/index.ts
+++ b/src/threat-model-writer/index.ts
@@ -1,0 +1,52 @@
+/**
+ * Threat Model Writer Agent module
+ *
+ * Generates Threat Model (TM) documents from SDS (Software Design
+ * Specification) inputs. The Threat Model identifies security threats
+ * using STRIDE categorization and scores risks using the DREAD model.
+ *
+ * @module threat-model-writer
+ */
+
+// Main agent class (singleton + constructor)
+export {
+  ThreatModelWriterAgent,
+  getThreatModelWriterAgent,
+  resetThreatModelWriterAgent,
+  THREAT_MODEL_WRITER_AGENT_ID,
+} from './ThreatModelWriterAgent.js';
+
+// Error classes
+export {
+  ThreatModelWriterError,
+  SDSNotFoundError,
+  SessionStateError,
+  GenerationError,
+  FileWriteError,
+} from './errors.js';
+
+// Type exports
+export type {
+  // Status and config
+  ThreatModelGenerationStatus,
+  ThreatModelDocumentStatus,
+  ThreatModelWriterAgentConfig,
+  ThreatModelGenerationSession,
+  ThreatModelGenerationResult,
+  ThreatModelGenerationStats,
+
+  // STRIDE + DREAD domain types
+  DreadScore,
+  ThreatEntry,
+
+  // Parsed input types
+  ParsedSDSComponent,
+  ParsedSDSExtract,
+
+  // Threat Model output types
+  ThreatModelMetadata,
+  GeneratedThreatModel,
+} from './types.js';
+
+// Enum exports (re-exported as value, not type-only)
+export { StrideCategory } from './types.js';

--- a/src/threat-model-writer/types.ts
+++ b/src/threat-model-writer/types.ts
@@ -1,0 +1,239 @@
+/**
+ * Threat Model Writer Agent module type definitions
+ *
+ * Defines types for Threat Model (TM) document generation from SDS
+ * (Software Design Specification) input. The Threat Model identifies
+ * security threats using STRIDE categorization and scores risks using
+ * the DREAD model.
+ */
+
+/**
+ * Threat Model generation status
+ */
+export type ThreatModelGenerationStatus =
+  | 'pending'
+  | 'parsing'
+  | 'generating'
+  | 'completed'
+  | 'failed';
+
+/**
+ * Document status
+ */
+export type ThreatModelDocumentStatus = 'Draft' | 'Review' | 'Approved';
+
+// ============================================================================
+// STRIDE + DREAD domain types
+// ============================================================================
+
+/**
+ * STRIDE threat categories.
+ *
+ * Each category represents one class of threat defined by Microsoft's
+ * STRIDE threat modeling methodology.
+ */
+export enum StrideCategory {
+  Spoofing = 'Spoofing',
+  Tampering = 'Tampering',
+  Repudiation = 'Repudiation',
+  InformationDisclosure = 'Information Disclosure',
+  DenialOfService = 'Denial of Service',
+  ElevationOfPrivilege = 'Elevation of Privilege',
+}
+
+/**
+ * DREAD risk score (each attribute is scored 1-10).
+ *
+ * DREAD breaks a threat's risk into five attributes:
+ * - Damage potential: how bad would an attack be?
+ * - Reproducibility: how easy is it to reproduce the attack?
+ * - Exploitability: how much work is it to launch the attack?
+ * - Affected users: how many people will be impacted?
+ * - Discoverability: how easy is it to discover the threat?
+ *
+ * The overall score is the average of the five attributes.
+ */
+export interface DreadScore {
+  /** Damage potential (1-10) */
+  readonly damage: number;
+  /** Reproducibility (1-10) */
+  readonly reproducibility: number;
+  /** Exploitability (1-10) */
+  readonly exploitability: number;
+  /** Affected users (1-10) */
+  readonly affectedUsers: number;
+  /** Discoverability (1-10) */
+  readonly discoverability: number;
+  /** Average of the five DREAD attributes (1-10) */
+  readonly overall: number;
+}
+
+/**
+ * A single threat entry identified during STRIDE analysis.
+ */
+export interface ThreatEntry {
+  /** Threat identifier, e.g., "T1" */
+  readonly id: string;
+  /** STRIDE category */
+  readonly category: StrideCategory;
+  /** Short title of the threat */
+  readonly title: string;
+  /** Component, asset, or data flow the threat targets */
+  readonly target: string;
+  /** Description of the threat */
+  readonly description: string;
+  /** DREAD score for the threat */
+  readonly dread: DreadScore;
+  /** Mitigation strategy for the threat */
+  readonly mitigation: string;
+  /** Residual risk after mitigation (Low/Medium/High) */
+  readonly residualRisk: 'Low' | 'Medium' | 'High';
+}
+
+// ============================================================================
+// Parsed Input Types (lightweight extract from SDS markdown)
+// ============================================================================
+
+/**
+ * A single component extracted from an SDS document.
+ */
+export interface ParsedSDSComponent {
+  /** Component identifier, e.g., "CMP-001" */
+  readonly id: string;
+  /** Component name */
+  readonly name: string;
+  /** Short description if available */
+  readonly description: string;
+}
+
+/**
+ * Lightweight SDS extract consumed by the Threat Model Writer.
+ *
+ * Only the metadata and a flat list of components are required for
+ * STRIDE threat identification. Deeper architectural details can be
+ * added later if heuristics become more sophisticated.
+ */
+export interface ParsedSDSExtract {
+  /** SDS document ID, e.g., "SDS-my-project" */
+  readonly documentId: string;
+  /** Product name (mirrored from SDS title when present) */
+  readonly productName: string;
+  /** Components extracted from the SDS component design section */
+  readonly components: readonly ParsedSDSComponent[];
+  /** Whether the SDS declares an API / network interface section */
+  readonly hasApiSurface: boolean;
+  /** Whether the SDS declares a data model / persistence section */
+  readonly hasDataLayer: boolean;
+}
+
+// ============================================================================
+// Threat Model Output Types
+// ============================================================================
+
+/**
+ * Threat Model document metadata
+ */
+export interface ThreatModelMetadata {
+  /** Document ID, e.g., "TM-my-project" */
+  readonly documentId: string;
+  /** Source SDS document reference */
+  readonly sourceSDS: string;
+  /** Document version */
+  readonly version: string;
+  /** Document status */
+  readonly status: ThreatModelDocumentStatus;
+  /** ISO date (YYYY-MM-DD) */
+  readonly createdDate: string;
+  /** ISO date (YYYY-MM-DD) */
+  readonly updatedDate: string;
+}
+
+/**
+ * Generated Threat Model document
+ */
+export interface GeneratedThreatModel {
+  /** Threat Model metadata */
+  readonly metadata: ThreatModelMetadata;
+  /** Raw markdown content (English) */
+  readonly content: string;
+  /** Raw markdown content (Korean variant) */
+  readonly contentKorean: string;
+  /** Threats identified during analysis */
+  readonly threats: readonly ThreatEntry[];
+}
+
+// ============================================================================
+// Agent Configuration and Session Types
+// ============================================================================
+
+/**
+ * Threat Model Writer Agent configuration options
+ */
+export interface ThreatModelWriterAgentConfig {
+  /** Base path for scratchpad (defaults to .ad-sdlc/scratchpad) */
+  readonly scratchpadBasePath?: string;
+  /** Output directory for public TM docs (defaults to docs/tm) */
+  readonly publicDocsPath?: string;
+}
+
+/**
+ * Threat Model generation session
+ */
+export interface ThreatModelGenerationSession {
+  /** Session identifier */
+  readonly sessionId: string;
+  /** Project identifier */
+  readonly projectId: string;
+  /** Current generation status */
+  readonly status: ThreatModelGenerationStatus;
+  /** Parsed SDS extract */
+  readonly parsedSDS: ParsedSDSExtract;
+  /** Generated Threat Model (when completed) */
+  readonly generatedThreatModel?: GeneratedThreatModel;
+  /** Session start time (ISO timestamp) */
+  readonly startedAt: string;
+  /** Session last update time (ISO timestamp) */
+  readonly updatedAt: string;
+  /** Error message if failed */
+  readonly errorMessage?: string;
+  /** Non-fatal warnings accumulated during generation */
+  readonly warnings?: readonly string[];
+}
+
+/**
+ * Threat Model generation result
+ */
+export interface ThreatModelGenerationResult {
+  /** Whether generation was successful */
+  readonly success: boolean;
+  /** Project identifier */
+  readonly projectId: string;
+  /** Path to the generated TM in scratchpad (English) */
+  readonly scratchpadPath: string;
+  /** Path to the public TM document (English) */
+  readonly publicPath: string;
+  /** Path to the generated TM in scratchpad (Korean) */
+  readonly scratchpadPathKorean: string;
+  /** Path to the public TM document (Korean) */
+  readonly publicPathKorean: string;
+  /** Generated Threat Model content */
+  readonly generatedThreatModel: GeneratedThreatModel;
+  /** Generation statistics */
+  readonly stats: ThreatModelGenerationStats;
+  /** Non-fatal warnings from generation */
+  readonly warnings?: readonly string[];
+}
+
+/**
+ * Statistics about the Threat Model generation process
+ */
+export interface ThreatModelGenerationStats {
+  /** Number of SDS components considered when sizing the analysis */
+  readonly sdsComponentCount: number;
+  /** Number of threats identified */
+  readonly threatsIdentified: number;
+  /** Number of high-risk threats (DREAD overall >= 7) */
+  readonly highRiskThreats: number;
+  /** Total processing time in milliseconds */
+  readonly processingTimeMs: number;
+}

--- a/tests/ad-sdlc-orchestrator/AdsdlcOrchestratorAgent.test.ts
+++ b/tests/ad-sdlc-orchestrator/AdsdlcOrchestratorAgent.test.ts
@@ -1212,8 +1212,8 @@ describe('AdsdlcOrchestratorAgent', () => {
 });
 
 describe('GREENFIELD_STAGES', () => {
-  it('should define 15 stages', () => {
-    expect(GREENFIELD_STAGES).toHaveLength(15);
+  it('should define 16 stages', () => {
+    expect(GREENFIELD_STAGES).toHaveLength(16);
   });
 
   it('should start with initialization and end with doc_indexing', () => {
@@ -1238,10 +1238,28 @@ describe('GREENFIELD_STAGES', () => {
     expect(stageMap.get('srs_generation')).toBe('srs-writer');
     expect(stageMap.get('sdp_generation')).toBe('sdp-writer');
     expect(stageMap.get('sds_generation')).toBe('sds-writer');
+    expect(stageMap.get('threat_modeling')).toBe('threat-model-writer');
     expect(stageMap.get('issue_generation')).toBe('issue-generator');
     expect(stageMap.get('orchestration')).toBe('controller');
     expect(stageMap.get('implementation')).toBe('worker');
     expect(stageMap.get('review')).toBe('pr-reviewer');
+  });
+
+  it('should place threat_modeling between sds_generation and issue_generation', () => {
+    const stageNames = GREENFIELD_STAGES.map((s) => s.name);
+    const sdsIdx = stageNames.indexOf('sds_generation');
+    const tmIdx = stageNames.indexOf('threat_modeling');
+    const issueIdx = stageNames.indexOf('issue_generation');
+    expect(sdsIdx).toBeGreaterThanOrEqual(0);
+    expect(tmIdx).toBeGreaterThan(sdsIdx);
+    expect(issueIdx).toBeGreaterThan(tmIdx);
+
+    const tmStage = GREENFIELD_STAGES.find((s) => s.name === 'threat_modeling');
+    expect(tmStage?.dependsOn).toContain('sds_generation');
+    expect(tmStage?.approvalRequired).toBe(true);
+
+    const issueStage = GREENFIELD_STAGES.find((s) => s.name === 'issue_generation');
+    expect(issueStage?.dependsOn).toContain('threat_modeling');
   });
 
   it('should place sdp_generation between srs_generation and repo_detection', () => {

--- a/tests/e2e/fixtures/pipeline-fixtures.ts
+++ b/tests/e2e/fixtures/pipeline-fixtures.ts
@@ -206,6 +206,68 @@ export const sdsOutput = [
 ].join('\n');
 
 /**
+ * Output from the threat-model-writer agent.
+ * Generates a Threat Model document using STRIDE categorization and
+ * DREAD risk scoring, derived from the SDS components.
+ */
+export const threatModelOutput = [
+  '# Threat Model: smoke-test-project',
+  '',
+  '## 1. System Overview',
+  '- Product: smoke-test-project',
+  '- Source SDS: SDS-smoke-test-project',
+  '- Components analysed: 3',
+  '- API surface detected: Yes',
+  '- Data layer detected: No',
+  '',
+  '### 1.1 Data Flow Diagram',
+  '',
+  '```mermaid',
+  'flowchart LR',
+  '    User([External User])',
+  '    API[API Gateway]',
+  '    User -->|HTTPS| API',
+  '    CMP_001[AuthController]',
+  '    API --> CMP_001',
+  '```',
+  '',
+  '## 2. Threat Identification (STRIDE)',
+  '',
+  '| ID | STRIDE Category | Target | Threat |',
+  '|----|-----------------|--------|--------|',
+  '| T1 | Spoofing | AuthController | Authentication bypass via forged credentials |',
+  '| T2 | Tampering | AuthService | Unauthorized modification of persisted data |',
+  '| T3 | Repudiation | AuthController | Insufficient audit trail for privileged actions |',
+  '| T4 | Information Disclosure | AuthController | Sensitive data exposure in responses or logs |',
+  '| T5 | Denial of Service | Public API | Resource exhaustion via uncontrolled request load |',
+  '| T6 | Elevation of Privilege | AuthController | Privilege escalation through missing authorization checks |',
+  '',
+  '## 3. Risk Assessment (DREAD)',
+  '',
+  '| ID | Damage | Reproducibility | Exploitability | Affected Users | Discoverability | Overall |',
+  '|----|--------|-----------------|----------------|----------------|-----------------|---------|',
+  '| T1 | 8 | 6 | 5 | 8 | 6 | 6.6 |',
+  '| T2 | 7 | 5 | 4 | 7 | 5 | 5.6 |',
+  '| T3 | 5 | 6 | 4 | 6 | 5 | 5.2 |',
+  '| T4 | 8 | 7 | 6 | 8 | 7 | 7.2 |',
+  '| T5 | 6 | 8 | 7 | 9 | 8 | 7.6 |',
+  '| T6 | 9 | 5 | 4 | 7 | 5 | 6.0 |',
+  '',
+  '## 4. Mitigation Strategies',
+  '- Strong authentication with MFA and token rotation',
+  '- Parameterized queries and input validation',
+  '- Append-only audit logging with tamper protection',
+  '- Data classification, masking, encryption at rest and in transit',
+  '- Rate limiting and circuit breakers',
+  '- Role-based access control with deny-by-default',
+  '',
+  '## 5. Residual Risk Summary',
+  '- High: 0',
+  '- Medium: 3',
+  '- Low: 3',
+].join('\n');
+
+/**
  * Output from the issue-generator agent.
  * Generates GitHub issues from the SDS components.
  */
@@ -311,6 +373,7 @@ export const GREENFIELD_RESPONSES: Record<string, string> = {
   'repo-detector': repoDetectorOutput,
   'github-repo-setup': githubRepoSetupOutput,
   'sds-writer': sdsOutput,
+  'threat-model-writer': threatModelOutput,
   'issue-generator': issueGeneratorOutput,
   controller: controllerOutput,
   worker: workerOutput,

--- a/tests/threat-model-writer/ThreatModelWriterAgent.test.ts
+++ b/tests/threat-model-writer/ThreatModelWriterAgent.test.ts
@@ -1,0 +1,565 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import {
+  ThreatModelWriterAgent,
+  getThreatModelWriterAgent,
+  resetThreatModelWriterAgent,
+  THREAT_MODEL_WRITER_AGENT_ID,
+} from '../../src/threat-model-writer/ThreatModelWriterAgent.js';
+import { SDSNotFoundError, SessionStateError } from '../../src/threat-model-writer/errors.js';
+import { StrideCategory } from '../../src/threat-model-writer/types.js';
+
+describe('ThreatModelWriterAgent', () => {
+  const testBasePath = path.join(process.cwd(), 'tests', 'threat-model-writer', 'test-scratchpad');
+  const testDocsPath = path.join(process.cwd(), 'tests', 'threat-model-writer', 'test-docs');
+
+  const sampleSDS = `---
+doc_id: SDS-test-project
+title: Test Product
+version: 1.0.0
+status: Approved
+---
+
+# Software Design Specification: Test Product
+
+## 1. Architecture Overview
+
+Three-layer architecture: API, Service, Data.
+
+## 2. Component Design
+
+### CMP-001: AuthController
+
+The authentication HTTP controller handling login and logout endpoints.
+
+| Attribute | Value |
+|-----------|-------|
+| Responsibility | HTTP auth |
+
+### CMP-002: AuthService
+
+Business logic for credential validation and session management.
+
+### CMP-003: DashboardController
+
+Serves dashboard data for authenticated users.
+
+## 5. Interface Design
+
+- POST /api/auth/login
+- POST /api/auth/logout
+- GET /api/dashboard
+
+## 4. Data Design
+
+- User table
+- Session table
+`;
+
+  const sampleSDSNoApi = `---
+doc_id: SDS-cli-project
+title: CLI Tool
+version: 1.0.0
+status: Approved
+---
+
+# Software Design Specification: CLI Tool
+
+## 2. Component Design
+
+### CMP-001: CommandParser
+
+Parses command-line arguments.
+`;
+
+  const setupSDS = (projectId: string, content: string = sampleSDS): void => {
+    const docsDir = path.join(testBasePath, 'documents', projectId);
+    fs.mkdirSync(docsDir, { recursive: true });
+    fs.writeFileSync(path.join(docsDir, 'sds.md'), content, 'utf-8');
+  };
+
+  beforeEach(() => {
+    if (fs.existsSync(testBasePath)) {
+      fs.rmSync(testBasePath, { recursive: true, force: true });
+    }
+    if (fs.existsSync(testDocsPath)) {
+      fs.rmSync(testDocsPath, { recursive: true, force: true });
+    }
+    resetThreatModelWriterAgent();
+  });
+
+  afterEach(() => {
+    if (fs.existsSync(testBasePath)) {
+      fs.rmSync(testBasePath, { recursive: true, force: true });
+    }
+    if (fs.existsSync(testDocsPath)) {
+      fs.rmSync(testDocsPath, { recursive: true, force: true });
+    }
+    resetThreatModelWriterAgent();
+  });
+
+  describe('constructor and IAgent interface', () => {
+    it('should construct with default config', () => {
+      const agent = new ThreatModelWriterAgent();
+      expect(agent.agentId).toBe(THREAT_MODEL_WRITER_AGENT_ID);
+      expect(agent.name).toBe('Threat Model Writer Agent');
+    });
+
+    it('should accept custom config overrides', () => {
+      const agent = new ThreatModelWriterAgent({
+        scratchpadBasePath: testBasePath,
+        publicDocsPath: testDocsPath,
+      });
+      expect(agent.agentId).toBe(THREAT_MODEL_WRITER_AGENT_ID);
+    });
+
+    it('should initialize and dispose without error', async () => {
+      const agent = new ThreatModelWriterAgent();
+      await agent.initialize();
+      await agent.initialize(); // idempotent
+      expect(agent.getSession()).toBeNull();
+      await agent.dispose();
+      expect(agent.getSession()).toBeNull();
+    });
+  });
+
+  describe('singleton', () => {
+    it('should return the same instance on repeated calls', () => {
+      const a = getThreatModelWriterAgent();
+      const b = getThreatModelWriterAgent();
+      expect(a).toBe(b);
+    });
+
+    it('should return a fresh instance after reset', () => {
+      const a = getThreatModelWriterAgent();
+      resetThreatModelWriterAgent();
+      const b = getThreatModelWriterAgent();
+      expect(a).not.toBe(b);
+    });
+  });
+
+  describe('startSession', () => {
+    it('should create a session when SDS exists', async () => {
+      const projectId = 'test-project';
+      setupSDS(projectId);
+
+      const agent = new ThreatModelWriterAgent({
+        scratchpadBasePath: testBasePath,
+        publicDocsPath: testDocsPath,
+      });
+      await agent.initialize();
+
+      const session = await agent.startSession(projectId);
+
+      expect(session.projectId).toBe(projectId);
+      expect(session.status).toBe('pending');
+      expect(session.parsedSDS.documentId).toBe('SDS-test-project');
+      expect(session.parsedSDS.components).toHaveLength(3);
+      expect(session.parsedSDS.hasApiSurface).toBe(true);
+      expect(session.parsedSDS.hasDataLayer).toBe(true);
+      expect(session.sessionId).toBeTruthy();
+    });
+
+    it('should throw SDSNotFoundError when SDS is missing', async () => {
+      const projectId = 'no-sds';
+      const agent = new ThreatModelWriterAgent({
+        scratchpadBasePath: testBasePath,
+        publicDocsPath: testDocsPath,
+      });
+
+      await expect(agent.startSession(projectId)).rejects.toThrow(SDSNotFoundError);
+    });
+
+    it('should extract component IDs and names from CMP headings', async () => {
+      const projectId = 'cmp-extract';
+      setupSDS(projectId);
+
+      const agent = new ThreatModelWriterAgent({
+        scratchpadBasePath: testBasePath,
+        publicDocsPath: testDocsPath,
+      });
+      const session = await agent.startSession(projectId);
+
+      const ids = session.parsedSDS.components.map((c) => c.id);
+      const names = session.parsedSDS.components.map((c) => c.name);
+      expect(ids).toEqual(['CMP-001', 'CMP-002', 'CMP-003']);
+      expect(names).toContain('AuthController');
+      expect(names).toContain('AuthService');
+      expect(names).toContain('DashboardController');
+    });
+
+    it('should detect absence of API surface and data layer', async () => {
+      const projectId = 'cli-project';
+      setupSDS(projectId, sampleSDSNoApi);
+
+      const agent = new ThreatModelWriterAgent({
+        scratchpadBasePath: testBasePath,
+        publicDocsPath: testDocsPath,
+      });
+      const session = await agent.startSession(projectId);
+
+      expect(session.parsedSDS.hasApiSurface).toBe(false);
+      expect(session.parsedSDS.hasDataLayer).toBe(false);
+    });
+  });
+
+  describe('generateFromProject', () => {
+    it('should generate a complete Threat Model from SDS', async () => {
+      const projectId = 'gen-project';
+      setupSDS(projectId);
+
+      const agent = new ThreatModelWriterAgent({
+        scratchpadBasePath: testBasePath,
+        publicDocsPath: testDocsPath,
+      });
+      await agent.initialize();
+
+      const result = await agent.generateFromProject(projectId);
+
+      expect(result.success).toBe(true);
+      expect(result.projectId).toBe(projectId);
+      expect(result.generatedThreatModel.metadata.documentId).toBe('TM-gen-project');
+      expect(result.generatedThreatModel.metadata.sourceSDS).toBe('SDS-test-project');
+      expect(result.generatedThreatModel.threats.length).toBeGreaterThanOrEqual(6);
+      expect(result.stats.sdsComponentCount).toBe(3);
+      expect(result.stats.threatsIdentified).toBeGreaterThanOrEqual(6);
+      expect(result.stats.processingTimeMs).toBeGreaterThanOrEqual(0);
+    });
+
+    it('should write all four output files', async () => {
+      const projectId = 'file-project';
+      setupSDS(projectId);
+
+      const agent = new ThreatModelWriterAgent({
+        scratchpadBasePath: testBasePath,
+        publicDocsPath: testDocsPath,
+      });
+      const result = await agent.generateFromProject(projectId);
+
+      expect(fs.existsSync(result.scratchpadPath)).toBe(true);
+      expect(fs.existsSync(result.publicPath)).toBe(true);
+      expect(fs.existsSync(result.scratchpadPathKorean)).toBe(true);
+      expect(fs.existsSync(result.publicPathKorean)).toBe(true);
+
+      expect(result.scratchpadPath).toContain('tm.md');
+      expect(result.scratchpadPathKorean).toContain('tm.kr.md');
+      expect(result.publicPath).toContain('TM-file-project.md');
+      expect(result.publicPathKorean).toContain('TM-file-project.kr.md');
+    });
+
+    it('should cover all six STRIDE categories', async () => {
+      const projectId = 'stride-project';
+      setupSDS(projectId);
+
+      const agent = new ThreatModelWriterAgent({
+        scratchpadBasePath: testBasePath,
+        publicDocsPath: testDocsPath,
+      });
+      const result = await agent.generateFromProject(projectId);
+
+      const categories = new Set(result.generatedThreatModel.threats.map((t) => t.category));
+      expect(categories.has(StrideCategory.Spoofing)).toBe(true);
+      expect(categories.has(StrideCategory.Tampering)).toBe(true);
+      expect(categories.has(StrideCategory.Repudiation)).toBe(true);
+      expect(categories.has(StrideCategory.InformationDisclosure)).toBe(true);
+      expect(categories.has(StrideCategory.DenialOfService)).toBe(true);
+      expect(categories.has(StrideCategory.ElevationOfPrivilege)).toBe(true);
+    });
+
+    it('should assign valid DREAD scores (1-10) with averaged overall', async () => {
+      const projectId = 'dread-project';
+      setupSDS(projectId);
+
+      const agent = new ThreatModelWriterAgent({
+        scratchpadBasePath: testBasePath,
+        publicDocsPath: testDocsPath,
+      });
+      const result = await agent.generateFromProject(projectId);
+
+      for (const threat of result.generatedThreatModel.threats) {
+        expect(threat.dread.damage).toBeGreaterThanOrEqual(1);
+        expect(threat.dread.damage).toBeLessThanOrEqual(10);
+        expect(threat.dread.reproducibility).toBeGreaterThanOrEqual(1);
+        expect(threat.dread.reproducibility).toBeLessThanOrEqual(10);
+        expect(threat.dread.exploitability).toBeGreaterThanOrEqual(1);
+        expect(threat.dread.exploitability).toBeLessThanOrEqual(10);
+        expect(threat.dread.affectedUsers).toBeGreaterThanOrEqual(1);
+        expect(threat.dread.affectedUsers).toBeLessThanOrEqual(10);
+        expect(threat.dread.discoverability).toBeGreaterThanOrEqual(1);
+        expect(threat.dread.discoverability).toBeLessThanOrEqual(10);
+
+        const expected =
+          Math.round(
+            ((threat.dread.damage +
+              threat.dread.reproducibility +
+              threat.dread.exploitability +
+              threat.dread.affectedUsers +
+              threat.dread.discoverability) /
+              5) *
+              10
+          ) / 10;
+        expect(threat.dread.overall).toBeCloseTo(expected, 1);
+      }
+    });
+
+    it('should add API injection threat when API surface detected', async () => {
+      const projectId = 'api-project';
+      setupSDS(projectId);
+
+      const agent = new ThreatModelWriterAgent({
+        scratchpadBasePath: testBasePath,
+        publicDocsPath: testDocsPath,
+      });
+      const result = await agent.generateFromProject(projectId);
+
+      const titles = result.generatedThreatModel.threats.map((t) => t.title);
+      expect(titles.some((t) => t.toLowerCase().includes('injection'))).toBe(true);
+    });
+
+    it('should skip API threat when API surface is absent', async () => {
+      const projectId = 'no-api-project';
+      setupSDS(projectId, sampleSDSNoApi);
+
+      const agent = new ThreatModelWriterAgent({
+        scratchpadBasePath: testBasePath,
+        publicDocsPath: testDocsPath,
+      });
+      const result = await agent.generateFromProject(projectId);
+
+      const titles = result.generatedThreatModel.threats.map((t) => t.title);
+      expect(titles.some((t) => t.toLowerCase().includes('injection'))).toBe(false);
+      // Still has base six STRIDE threats
+      expect(result.generatedThreatModel.threats.length).toBeGreaterThanOrEqual(6);
+    });
+
+    it('should count high-risk threats with overall DREAD >= 7', async () => {
+      const projectId = 'highrisk-project';
+      setupSDS(projectId);
+
+      const agent = new ThreatModelWriterAgent({
+        scratchpadBasePath: testBasePath,
+        publicDocsPath: testDocsPath,
+      });
+      const result = await agent.generateFromProject(projectId);
+
+      const actualHighCount = result.generatedThreatModel.threats.filter(
+        (t) => t.dread.overall >= 7
+      ).length;
+      expect(result.stats.highRiskThreats).toBe(actualHighCount);
+    });
+
+    it('should embed Mermaid data flow diagram in content', async () => {
+      const projectId = 'mermaid-project';
+      setupSDS(projectId);
+
+      const agent = new ThreatModelWriterAgent({
+        scratchpadBasePath: testBasePath,
+        publicDocsPath: testDocsPath,
+      });
+      const result = await agent.generateFromProject(projectId);
+
+      expect(result.generatedThreatModel.content).toContain('```mermaid');
+      expect(result.generatedThreatModel.content).toContain('flowchart LR');
+      expect(result.generatedThreatModel.contentKorean).toContain('```mermaid');
+    });
+
+    it('should include all five required sections in English content', async () => {
+      const projectId = 'sections-project';
+      setupSDS(projectId);
+
+      const agent = new ThreatModelWriterAgent({
+        scratchpadBasePath: testBasePath,
+        publicDocsPath: testDocsPath,
+      });
+      const result = await agent.generateFromProject(projectId);
+
+      const content = result.generatedThreatModel.content;
+      expect(content).toContain('## 1. System Overview');
+      expect(content).toContain('## 2. Threat Identification (STRIDE)');
+      expect(content).toContain('## 3. Risk Assessment (DREAD)');
+      expect(content).toContain('## 4. Mitigation Strategies');
+      expect(content).toContain('## 5. Residual Risk Summary');
+    });
+
+    it('should include all five required sections in Korean content', async () => {
+      const projectId = 'sections-kr-project';
+      setupSDS(projectId);
+
+      const agent = new ThreatModelWriterAgent({
+        scratchpadBasePath: testBasePath,
+        publicDocsPath: testDocsPath,
+      });
+      const result = await agent.generateFromProject(projectId);
+
+      const content = result.generatedThreatModel.contentKorean;
+      expect(content).toContain('## 1. 시스템 개요');
+      expect(content).toContain('## 2. 위협 식별 (STRIDE)');
+      expect(content).toContain('## 3. 위험 평가 (DREAD)');
+      expect(content).toContain('## 4. 완화 전략');
+      expect(content).toContain('## 5. 잔여 위험 요약');
+    });
+
+    it('should include frontmatter with docId and sourceDocuments', async () => {
+      const projectId = 'frontmatter-project';
+      setupSDS(projectId);
+
+      const agent = new ThreatModelWriterAgent({
+        scratchpadBasePath: testBasePath,
+        publicDocsPath: testDocsPath,
+      });
+      const result = await agent.generateFromProject(projectId);
+
+      expect(result.generatedThreatModel.content).toMatch(/^---/);
+      expect(result.generatedThreatModel.content).toContain('TM-frontmatter-project');
+      expect(result.generatedThreatModel.content).toContain('SDS-test-project');
+    });
+
+    it('should emit warning when SDS has no components', async () => {
+      const projectId = 'empty-project';
+      const emptySDS = `---
+doc_id: SDS-empty
+title: Empty
+---
+
+# Software Design Specification: Empty
+
+## 2. Component Design
+
+No components defined yet.
+`;
+      setupSDS(projectId, emptySDS);
+
+      const agent = new ThreatModelWriterAgent({
+        scratchpadBasePath: testBasePath,
+        publicDocsPath: testDocsPath,
+      });
+      const result = await agent.generateFromProject(projectId);
+
+      expect(result.warnings).toBeDefined();
+      expect(result.warnings?.length ?? 0).toBeGreaterThanOrEqual(1);
+      // Should still produce base threat set
+      expect(result.generatedThreatModel.threats.length).toBeGreaterThanOrEqual(6);
+    });
+
+    it('should set session status to completed after generation', async () => {
+      const projectId = 'status-project';
+      setupSDS(projectId);
+
+      const agent = new ThreatModelWriterAgent({
+        scratchpadBasePath: testBasePath,
+        publicDocsPath: testDocsPath,
+      });
+      await agent.generateFromProject(projectId);
+
+      expect(agent.getSession()?.status).toBe('completed');
+    });
+  });
+
+  describe('finalize', () => {
+    it('should re-write output files from the cached session', async () => {
+      const projectId = 'finalize-project';
+      setupSDS(projectId);
+
+      const agent = new ThreatModelWriterAgent({
+        scratchpadBasePath: testBasePath,
+        publicDocsPath: testDocsPath,
+      });
+      await agent.generateFromProject(projectId);
+
+      // Delete output files and re-finalize
+      const tmPath = path.join(testBasePath, 'documents', projectId, 'tm.md');
+      fs.rmSync(tmPath, { force: true });
+      expect(fs.existsSync(tmPath)).toBe(false);
+
+      const result = await agent.finalize();
+      expect(result.success).toBe(true);
+      expect(fs.existsSync(tmPath)).toBe(true);
+    });
+
+    it('should throw SessionStateError when no session exists', async () => {
+      const agent = new ThreatModelWriterAgent({
+        scratchpadBasePath: testBasePath,
+        publicDocsPath: testDocsPath,
+      });
+
+      await expect(agent.finalize()).rejects.toThrow(SessionStateError);
+    });
+
+    it('should throw SessionStateError when session is not completed', async () => {
+      const projectId = 'incomplete-project';
+      setupSDS(projectId);
+
+      const agent = new ThreatModelWriterAgent({
+        scratchpadBasePath: testBasePath,
+        publicDocsPath: testDocsPath,
+      });
+      await agent.startSession(projectId);
+
+      await expect(agent.finalize()).rejects.toThrow(SessionStateError);
+    });
+  });
+
+  describe('content quality', () => {
+    it('should include all threats in STRIDE and DREAD tables', async () => {
+      const projectId = 'tables-project';
+      setupSDS(projectId);
+
+      const agent = new ThreatModelWriterAgent({
+        scratchpadBasePath: testBasePath,
+        publicDocsPath: testDocsPath,
+      });
+      const result = await agent.generateFromProject(projectId);
+
+      const content = result.generatedThreatModel.content;
+      for (const threat of result.generatedThreatModel.threats) {
+        expect(content).toContain(`| ${threat.id} |`);
+      }
+    });
+
+    it('should include a ranked risk subsection', async () => {
+      const projectId = 'rank-project';
+      setupSDS(projectId);
+
+      const agent = new ThreatModelWriterAgent({
+        scratchpadBasePath: testBasePath,
+        publicDocsPath: testDocsPath,
+      });
+      const result = await agent.generateFromProject(projectId);
+
+      expect(result.generatedThreatModel.content).toContain('### 3.1 Risk Ranking');
+    });
+
+    it('should include residual risk breakdown', async () => {
+      const projectId = 'residual-project';
+      setupSDS(projectId);
+
+      const agent = new ThreatModelWriterAgent({
+        scratchpadBasePath: testBasePath,
+        publicDocsPath: testDocsPath,
+      });
+      const result = await agent.generateFromProject(projectId);
+
+      const content = result.generatedThreatModel.content;
+      expect(content).toContain('### 5.1 Per-Threat Residual Risk');
+      expect(content).toContain('### 5.2 Review Cadence');
+    });
+
+    it('should render components in the scope table', async () => {
+      const projectId = 'scope-project';
+      setupSDS(projectId);
+
+      const agent = new ThreatModelWriterAgent({
+        scratchpadBasePath: testBasePath,
+        publicDocsPath: testDocsPath,
+      });
+      const result = await agent.generateFromProject(projectId);
+
+      const content = result.generatedThreatModel.content;
+      expect(content).toContain('### 1.2 Components in Scope');
+      expect(content).toContain('| CMP-001 | AuthController');
+      expect(content).toContain('| CMP-002 | AuthService');
+      expect(content).toContain('| CMP-003 | DashboardController');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds a new `threat-model-writer` pipeline agent that generates a Threat Model Analysis document from the SDS architecture using STRIDE threat categorization and DREAD risk scoring. The agent produces `TM-{projectId}.md` and a Korean variant, integrates into both Greenfield and Enhancement pipelines, and runs between SDS generation and issue generation.

Closes #749

## What

- New module `src/threat-model-writer/` implementing `ThreatModelWriterAgent` via `IAgent` interface
- STRIDE enumeration across 6 categories (Spoofing, Tampering, Repudiation, Information Disclosure, Denial of Service, Elevation of Privilege) for each SDS component
- DREAD scoring (Damage, Reproducibility, Exploitability, Affected Users, Discoverability) producing numeric risk scores in [1, 10]
- Mermaid data flow diagram with trust boundary nodes
- Mitigation mapping to SDS security design section references
- Korean variant generation (`.kr.md`)
- YAML frontmatter via shared `prependFrontmatter` utility (from #748)
- Stub mode producing deterministic structural output without an AI bridge
- Pipeline integration: `threat_modeling` stage added to both Greenfield (between `sds_generation` and `issue_generation`) and Enhancement (between `sds_update` and `issue_generation`) modes
- E2E fixtures updated with `threatModelOutput` mock response
- Unit tests covering >80% of the new module

## Why

The current pipeline generates PRD → SRS → SDS → Code but produces no security analysis document. The SDS Security Design section describes solutions, not threats. This agent closes that gap by deriving a STRIDE/DREAD threat model directly from the SDS architecture (components, interfaces, data flows), matching the level of security documentation that enterprise projects expect.

## Files Changed

| Area | Files | Change |
|------|-------|--------|
| New module | `src/threat-model-writer/{ThreatModelWriterAgent.ts, types.ts, errors.ts, index.ts}` | +1396 |
| Agent prompt | `.claude/agents/threat-model-writer.md` | +110 |
| Agent registration | `src/agents/AgentTypeMapping.ts` | +8 |
| Pipeline stages | `src/ad-sdlc-orchestrator/types.ts` | +11/-0 |
| Unit tests | `tests/threat-model-writer/ThreatModelWriterAgent.test.ts` | +565 |
| E2E fixtures | `tests/e2e/fixtures/pipeline-fixtures.ts` | +63 |
| Orchestrator tests | `tests/ad-sdlc-orchestrator/AdsdlcOrchestratorAgent.test.ts` | +16/-6 |
| Documentation | `docs/threat-model-writer.md`, `README.md`, `docs/architecture/*`, `docs/reference/agents/ad-sdlc-orchestrator.md`, `docs/system-architecture*.md` | +244/-67 |

## Acceptance Criteria Verification

| # | Acceptance Criterion | Status | Evidence |
|---|----------------------|--------|----------|
| 1 | `threat-model-writer` registered in `AgentTypeMapping` | PASS | `src/agents/AgentTypeMapping.ts` entry with `agentId: 'threat-model-writer-agent'`, singleton lifecycle, `importPath: '../threat-model-writer/index.js'` |
| 2 | Stage added to Greenfield and Enhancement pipeline modes | PASS | `threat_modeling` stage added to `GREENFIELD_STAGES` (between `sds_generation` and `issue_generation`) and `ENHANCEMENT_STAGES` (between `sds_update` and `issue_generation`) in `src/ad-sdlc-orchestrator/types.ts`; `PipelineStageName` union updated |
| 3 | Generates `TM-{projectId}.md` with STRIDE threat table | PASS | `ThreatModelWriterAgent.generateFromProject` writes scratchpad + public outputs; unit test asserts STRIDE table structure |
| 4 | Each SDS component analyzed for all 6 STRIDE categories | PASS | Exhaustive STRIDE enumeration per component; unit test asserts 6×N threats for N components |
| 5 | DREAD scoring produces numeric scores (1-10) | PASS | `calculateDREADScore` helper with `DREAD_CATEGORIES` constants; unit test asserts all scores in [1, 10] |
| 6 | Mitigations reference SDS security design section | PASS | Mitigation mapping extracts SDS security references; unit test asserts each threat row contains a section reference |
| 7 | Data flow diagram as Mermaid | PASS | Mermaid flowchart with trust boundaries emitted in section 1; unit test asserts fence and flowchart directive |
| 8 | Korean variant (`.kr.md`) generated | PASS | `contentKorean` field populated and written to scratchpad + public paths; unit test asserts Korean headers present |
| 9 | YAML frontmatter (per #748) | PASS | Uses `prependFrontmatter` from `src/utilities/frontmatter.js`; output starts with `---\ndoc_id: TM-{projectId}\n...` |
| 10 | Stub mode produces structural output without AI bridge | PASS | Deterministic STRIDE × component enumeration runs without LLM; unit test verifies structure |
| 11 | Unit tests with >80% coverage | PASS | 565-line test file covering session lifecycle, STRIDE coverage, DREAD scoring, Mermaid diagram, Korean variant, frontmatter, file writes, IAgent interface, stub mode, edge cases |

## Test Plan

- `npm test -- tests/threat-model-writer/` — unit tests pass
- `npm test -- tests/ad-sdlc-orchestrator/` — orchestrator integration with new stage passes
- `npm test -- tests/e2e/` — E2E pipeline with updated fixtures passes
- Coverage check: >80% for `src/threat-model-writer/`

## Breaking Changes

None. The new stage is additive and fits between existing stages without modifying their behavior.

## Rollback Plan

Revert this PR. The new module is self-contained and the pipeline stages fall back to the previous SDS → issue flow once the `threat_modeling` stage entry is removed.