### PR TITLE
feat(ui-spec-writer): add UI Specification Writer agent for screen and flow documentation

### DIFF
--- a/.claude/agents/ui-spec-writer.md
+++ b/.claude/agents/ui-spec-writer.md
@@ -1,0 +1,101 @@
+---
+name: ui-spec-writer
+description: |
+  UI Specification Writer Agent. Generates UI screen specifications, user flow
+  documents, and design system references from SRS use cases. Produces structured
+  wireframe descriptions and interaction flows for web/mobile projects. Auto-skips
+  for CLI, API, and library projects. Use this agent after SDS is approved and
+  before issue generation.
+tools:
+  - Read
+  - Write
+  - Edit
+  - Glob
+  - Grep
+model: inherit
+---
+
+# UI Specification Writer Agent
+
+## Role
+
+You are a UI Specification Writer Agent responsible for producing UI screen
+specifications, user flow documents, and a design system reference from the
+approved SRS (Software Requirements Specification). Your output gives downstream
+implementation agents a clear blueprint of what to build in the UI layer.
+
+## Primary Responsibilities
+
+1. **Screen Detection**
+   - Parse SRS use cases and features to identify distinct UI screens
+   - Each user-facing interaction maps to a screen specification
+   - Detect UI elements (buttons, inputs, displays, lists) from step descriptions
+   - Link screens to their originating use cases and features
+
+2. **Flow Mapping**
+   - Transform multi-step use cases into navigation flow documents
+   - Map screen-to-screen transitions with actions and conditions
+   - Generate Mermaid flow diagrams for visual review
+   - Document preconditions and expected outcomes per flow
+
+3. **Design System Generation**
+   - Select design tokens appropriate for the project type (web, mobile, desktop)
+   - Derive reusable components from detected screen elements
+   - Document token categories: color, spacing, typography, border-radius
+   - List component variants for implementation reference
+
+4. **Auto-Skip Logic**
+   - Detect project type from SRS content (web, mobile, desktop, CLI, API, library)
+   - Skip generation for CLI, API, and library projects (no UI surface)
+   - Report skip reason in the generation result
+
+## Output Structure
+
+```
+docs/ui/
+  README.md                    -- UI document index
+  screens/
+    SCR-001-{name}.md          -- Per-screen specification
+    SCR-002-{name}.md
+  flows/
+    FLW-001-{name}.md          -- Per-flow specification
+    FLW-002-{name}.md
+  design-system.md             -- Design tokens and component library
+```
+
+## Screen Specification Format
+
+Each screen document includes:
+
+- **Purpose**: What the screen is for
+- **Related Use Cases**: SRS use case IDs that drive this screen
+- **Related Features**: SRS feature IDs
+- **UI Elements**: Table of elements (ID, type, label, behavior)
+- **Navigation**: List of reachable screens
+
+## Flow Specification Format
+
+Each flow document includes:
+
+- **Description**: What the flow accomplishes
+- **Related Use Cases**: Source use case IDs
+- **Preconditions**: Required state before the flow
+- **Flow Steps**: Table of transitions (from, to, action, condition)
+- **Flow Diagram**: Mermaid graph of screen transitions
+- **Expected Outcomes**: Results after completing the flow
+
+## Design System Format
+
+The design system document includes:
+
+- **Technology Stack**: Platform reference
+- **Design Tokens**: Color, spacing, typography, border-radius tokens
+- **Component Library**: Reusable components with variants
+
+## Constraints
+
+- Do not invent screens that are not traceable to SRS use cases or features
+- Do not assume specific UI frameworks unless the SRS names one
+- Use English for all document content
+- Use Mermaid (not ASCII art) for diagrams
+- Keep screen names concise and descriptive

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- UI Specification Writer agent for generating screen specifications, user flow documents, and design system references from SRS use cases (#754)

--- a/README.md
+++ b/README.md
@@ -25,14 +25,16 @@ That's it! The agents will generate documents, create issues, implement code, an
 
 ## What is AD-SDLC?
 
-AD-SDLC is an automated software development pipeline that uses **29 specialized Claude agents** to transform your requirements into production-ready code. It supports three modes:
+AD-SDLC is an automated software development pipeline that uses **30 specialized Claude agents** to transform your requirements into production-ready code. It supports three modes:
 
 ### Greenfield Pipeline (New Projects)
 
 ```
 User Input → Collector → PRD Writer → SRS Writer → SDP Writer → SDS Writer ─┬─▶ Threat Model Writer ─┐
                                                                              │                        │
-                                                                             └─▶ Tech Decision Writer ─┤
+                                                                             ├─▶ Tech Decision Writer ─┤
+                                                                             │                        │
+                                                                             └─▶ UI Spec Writer ──────┤
                                                                                                       ↓
                            Worker ← Controller ← SVP Writer ← Issue Generator ←──────────────────────┘
                               ↓
@@ -65,7 +67,7 @@ GitHub Issues → Issue Reader → Controller → Worker → PR Reviewer
                                                  CI Fix (on failure)
 ```
 
-### Agent Pipeline (29 Agents)
+### Agent Pipeline (30 Agents)
 
 | Phase             | Agent                 | Role                                                                                             |
 | ----------------- | --------------------- | ------------------------------------------------------------------------------------------------ |
@@ -83,6 +85,7 @@ GitHub Issues → Issue Reader → Controller → Worker → PR Reviewer
 |                   | SDS Writer            | Generates Software Design Specification (SDS) and a separate Database Schema Specification (DBS) |
 |                   | Threat Model Writer   | Generates STRIDE/DREAD Threat Model from SDS                                                     |
 |                   | Tech Decision Writer  | Generates Technology Decision documents with alternatives analysis from the SDS technology stack |
+|                   | UI Spec Writer        | Generates UI screen specifications, user flow documents, and design system references from SRS   |
 | **Planning**      | Issue Generator       | Creates GitHub Issues from SDS components                                                        |
 |                   | SVP Writer            | Generates Software Verification Plan with test cases from SRS and issues                         |
 | **Execution**     | Controller            | Orchestrates work distribution and monitors progress                                             |
@@ -101,7 +104,8 @@ GitHub Issues → Issue Reader → Controller → Worker → PR Reviewer
 
 ## Features
 
-- **Automatic Document Generation**: PRD, SRS, SDS, DBS, and SVP documents from natural language requirements
+- **Automatic Document Generation**: PRD, SRS, SDS, DBS, SVP, and UI specification documents from natural language requirements
+- **UI Specification Generation**: Screen specifications, user flow documents, and design system references from SRS use cases; auto-skips for CLI/API/library projects
 - **Separate Database Schema Specification (DBS)**: SDS Writer emits a dedicated DBS document alongside the SDS, keeping the full database schema decoupled from architectural design
 - **Document Frontmatter Metadata**: YAML frontmatter with doc_id, version, status, and change history on all generated documents
 - **Enhancement Pipeline**: Incremental updates to existing projects without full rewrites

--- a/src/ad-sdlc-orchestrator/types.ts
+++ b/src/ad-sdlc-orchestrator/types.ts
@@ -25,6 +25,7 @@ export type GreenfieldStageName =
   | 'repo_detection'
   | 'github_repo_setup'
   | 'sds_generation'
+  | 'ui_spec_generation'
   | 'threat_modeling'
   | 'tech_decisions'
   | 'issue_generation'
@@ -390,6 +391,15 @@ export const GREENFIELD_STAGES: readonly PipelineStageDefinition[] = [
     dependsOn: ['github_repo_setup'],
   },
   {
+    name: 'ui_spec_generation',
+    agentType: 'ui-spec-writer',
+    description:
+      'Generate UI screen specifications and user flow documents from SRS (skipped for CLI/API/library)',
+    parallel: true,
+    approvalRequired: true,
+    dependsOn: ['sds_generation'],
+  },
+  {
     name: 'threat_modeling',
     agentType: 'threat-model-writer',
     description: 'Generate Threat Model (STRIDE + DREAD) from SDS',
@@ -411,7 +421,7 @@ export const GREENFIELD_STAGES: readonly PipelineStageDefinition[] = [
     description: 'Generate GitHub issues from SDS',
     parallel: false,
     approvalRequired: true,
-    dependsOn: ['threat_modeling', 'tech_decisions'],
+    dependsOn: ['ui_spec_generation', 'threat_modeling', 'tech_decisions'],
   },
   {
     name: 'svp_generation',

--- a/src/agents/AgentTypeMapping.ts
+++ b/src/agents/AgentTypeMapping.ts
@@ -149,6 +149,14 @@ export const AGENT_TYPE_MAP: Readonly<Record<string, AgentTypeEntry>> = {
     importPath: '../tech-decision-writer/index.js',
   },
 
+  'ui-spec-writer': {
+    agentId: 'ui-spec-writer-agent',
+    name: 'UI Specification Writer Agent',
+    lifecycle: 'singleton',
+    requiresWrapper: false,
+    importPath: '../ui-spec-writer/index.js',
+  },
+
   controller: {
     agentId: 'controller',
     name: 'Controller',

--- a/src/ui-spec-writer/DesignSystemGenerator.ts
+++ b/src/ui-spec-writer/DesignSystemGenerator.ts
@@ -1,0 +1,230 @@
+/**
+ * Design System Generator
+ *
+ * Generates a design token reference and component library specification
+ * based on the detected technology stack and screen specifications.
+ * Provides sensible defaults for web and mobile projects.
+ */
+
+import type {
+  DesignSystem,
+  DesignToken,
+  DesignComponent,
+  ScreenSpec,
+  ProjectType,
+} from './types.js';
+
+/**
+ * Default design tokens for web projects
+ */
+const WEB_TOKENS: readonly DesignToken[] = [
+  { category: 'color', name: 'primary', value: '#1976D2', description: 'Primary brand color' },
+  { category: 'color', name: 'secondary', value: '#424242', description: 'Secondary brand color' },
+  { category: 'color', name: 'error', value: '#D32F2F', description: 'Error state color' },
+  { category: 'color', name: 'success', value: '#388E3C', description: 'Success state color' },
+  { category: 'color', name: 'warning', value: '#F57C00', description: 'Warning state color' },
+  { category: 'color', name: 'background', value: '#FFFFFF', description: 'Default background' },
+  { category: 'color', name: 'surface', value: '#F5F5F5', description: 'Surface/card background' },
+  { category: 'color', name: 'text-primary', value: '#212121', description: 'Primary text color' },
+  {
+    category: 'color',
+    name: 'text-secondary',
+    value: '#757575',
+    description: 'Secondary text color',
+  },
+  { category: 'spacing', name: 'xs', value: '4px', description: 'Extra small spacing' },
+  { category: 'spacing', name: 'sm', value: '8px', description: 'Small spacing' },
+  { category: 'spacing', name: 'md', value: '16px', description: 'Medium spacing' },
+  { category: 'spacing', name: 'lg', value: '24px', description: 'Large spacing' },
+  { category: 'spacing', name: 'xl', value: '32px', description: 'Extra large spacing' },
+  {
+    category: 'typography',
+    name: 'font-family',
+    value: 'Inter, system-ui, sans-serif',
+    description: 'Default font family',
+  },
+  { category: 'typography', name: 'font-size-sm', value: '14px', description: 'Small text size' },
+  { category: 'typography', name: 'font-size-md', value: '16px', description: 'Body text size' },
+  { category: 'typography', name: 'font-size-lg', value: '20px', description: 'Large text size' },
+  { category: 'typography', name: 'font-size-xl', value: '24px', description: 'Heading text size' },
+  { category: 'border-radius', name: 'sm', value: '4px', description: 'Small border radius' },
+  { category: 'border-radius', name: 'md', value: '8px', description: 'Medium border radius' },
+  { category: 'border-radius', name: 'lg', value: '16px', description: 'Large border radius' },
+];
+
+/**
+ * Default design tokens for mobile projects
+ */
+const MOBILE_TOKENS: readonly DesignToken[] = [
+  {
+    category: 'color',
+    name: 'primary',
+    value: '#007AFF',
+    description: 'Primary brand color (iOS blue)',
+  },
+  { category: 'color', name: 'secondary', value: '#5856D6', description: 'Secondary brand color' },
+  { category: 'color', name: 'error', value: '#FF3B30', description: 'Error state color' },
+  { category: 'color', name: 'success', value: '#34C759', description: 'Success state color' },
+  { category: 'color', name: 'background', value: '#FFFFFF', description: 'Default background' },
+  { category: 'color', name: 'text-primary', value: '#000000', description: 'Primary text color' },
+  { category: 'spacing', name: 'xs', value: '4dp', description: 'Extra small spacing' },
+  { category: 'spacing', name: 'sm', value: '8dp', description: 'Small spacing' },
+  { category: 'spacing', name: 'md', value: '16dp', description: 'Medium spacing' },
+  { category: 'spacing', name: 'lg', value: '24dp', description: 'Large spacing' },
+  {
+    category: 'typography',
+    name: 'font-family',
+    value: 'SF Pro / Roboto',
+    description: 'Platform default font',
+  },
+  { category: 'typography', name: 'font-size-body', value: '16sp', description: 'Body text size' },
+  {
+    category: 'typography',
+    name: 'font-size-title',
+    value: '20sp',
+    description: 'Title text size',
+  },
+];
+
+/**
+ * Default design tokens for desktop projects
+ */
+const DESKTOP_TOKENS: readonly DesignToken[] = [
+  { category: 'color', name: 'primary', value: '#0078D4', description: 'Primary accent color' },
+  { category: 'color', name: 'background', value: '#F3F3F3', description: 'Window background' },
+  { category: 'color', name: 'text-primary', value: '#1A1A1A', description: 'Primary text color' },
+  { category: 'spacing', name: 'sm', value: '4px', description: 'Small spacing' },
+  { category: 'spacing', name: 'md', value: '8px', description: 'Medium spacing' },
+  { category: 'spacing', name: 'lg', value: '16px', description: 'Large spacing' },
+  {
+    category: 'typography',
+    name: 'font-family',
+    value: 'Segoe UI, system-ui',
+    description: 'Platform default font',
+  },
+  { category: 'typography', name: 'font-size-body', value: '14px', description: 'Body text size' },
+];
+
+/**
+ * Derive UI components from detected screen elements.
+ *
+ * Analyzes element types across all screens to determine which
+ * reusable components should be documented.
+ *
+ * @param screens - Detected screen specifications
+ */
+export function deriveComponents(screens: readonly ScreenSpec[]): readonly DesignComponent[] {
+  const elementTypes = new Map<string, number>();
+
+  for (const screen of screens) {
+    for (const element of screen.elements) {
+      const count = elementTypes.get(element.type) ?? 0;
+      elementTypes.set(element.type, count + 1);
+    }
+  }
+
+  const components: DesignComponent[] = [];
+
+  if (elementTypes.has('button')) {
+    components.push({
+      name: 'Button',
+      description: 'Interactive button component for user actions',
+      variants: ['primary', 'secondary', 'outlined', 'text', 'disabled'],
+    });
+  }
+
+  if (elementTypes.has('input')) {
+    components.push({
+      name: 'TextInput',
+      description: 'Text input field for user data entry',
+      variants: ['default', 'password', 'email', 'multiline', 'error', 'disabled'],
+    });
+  }
+
+  if (elementTypes.has('display')) {
+    components.push({
+      name: 'Card',
+      description: 'Content card for displaying grouped information',
+      variants: ['default', 'elevated', 'outlined'],
+    });
+  }
+
+  if (elementTypes.has('list')) {
+    components.push({
+      name: 'DataList',
+      description: 'List component for displaying collections of items',
+      variants: ['default', 'paginated', 'searchable'],
+    });
+  }
+
+  // Always include basic layout and navigation components
+  components.push({
+    name: 'AppBar',
+    description: 'Top navigation bar with title and actions',
+    variants: ['default', 'transparent', 'colored'],
+  });
+
+  components.push({
+    name: 'Navigation',
+    description: 'Navigation component for screen transitions',
+    variants: ['sidebar', 'bottom-tab', 'breadcrumb'],
+  });
+
+  return components;
+}
+
+/**
+ * Select appropriate design tokens based on project type.
+ *
+ * @param projectType - Detected project type
+ */
+function selectTokens(projectType: ProjectType): readonly DesignToken[] {
+  switch (projectType) {
+    case 'mobile':
+      return MOBILE_TOKENS;
+    case 'desktop':
+      return DESKTOP_TOKENS;
+    case 'web':
+    case 'unknown':
+    default:
+      return WEB_TOKENS;
+  }
+}
+
+/**
+ * Determine the technology stack reference string based on project type.
+ *
+ * @param projectType - Detected project type
+ */
+function technologyStackReference(projectType: ProjectType): string {
+  switch (projectType) {
+    case 'web':
+      return 'Web (HTML/CSS/JavaScript)';
+    case 'mobile':
+      return 'Mobile (iOS/Android)';
+    case 'desktop':
+      return 'Desktop Application';
+    default:
+      return 'Web (default)';
+  }
+}
+
+/**
+ * Generate a design system specification.
+ *
+ * Produces design tokens and component references appropriate for
+ * the project type, enriched with components derived from detected screens.
+ *
+ * @param projectType - Detected project type
+ * @param screens - Detected screen specifications
+ */
+export function generateDesignSystem(
+  projectType: ProjectType,
+  screens: readonly ScreenSpec[]
+): DesignSystem {
+  const tokens = selectTokens(projectType);
+  const components = deriveComponents(screens);
+  const technologyStack = technologyStackReference(projectType);
+
+  return { tokens, components, technologyStack };
+}

--- a/src/ui-spec-writer/FlowMapper.ts
+++ b/src/ui-spec-writer/FlowMapper.ts
@@ -1,0 +1,174 @@
+/**
+ * Flow Mapper
+ *
+ * Maps SRS use case flows to navigation flow documents.
+ * Each multi-step use case generates a flow specification that
+ * describes screen-to-screen transitions with actions and conditions.
+ */
+
+import type { ParsedUseCase, ScreenSpec, FlowSpec, FlowStep } from './types.js';
+
+/**
+ * Convert a flow title into a URL-safe slug.
+ *
+ * @param title - Human-readable flow title
+ * @returns URL-safe slug
+ */
+export function slugifyFlow(title: string): string {
+  const slug = title
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  return slug.length > 0 ? slug : 'flow';
+}
+
+/**
+ * Find the screen most relevant to a use case step.
+ *
+ * Looks for keyword overlap between the step text and screen titles/purposes.
+ * Falls back to the first screen related to the use case.
+ *
+ * @param step - Use case step text
+ * @param screens - Available screens
+ * @param useCaseId - Current use case ID
+ */
+function findScreenForStep(
+  step: string,
+  screens: readonly ScreenSpec[],
+  useCaseId: string
+): string {
+  const stepLower = step.toLowerCase();
+
+  // Try to find a screen whose title overlaps with the step
+  for (const screen of screens) {
+    const titleWords = screen.title.toLowerCase().split(/\s+/);
+    const matchCount = titleWords.filter((w) => w.length > 3 && stepLower.includes(w)).length;
+    if (matchCount > 0) {
+      return screen.id;
+    }
+  }
+
+  // Fall back to screens related to this use case
+  const relatedScreens = screens.filter((s) => s.relatedUseCases.includes(useCaseId));
+  if (relatedScreens.length > 0 && relatedScreens[0] !== undefined) {
+    return relatedScreens[0].id;
+  }
+
+  // Last resort: first screen
+  return screens[0]?.id ?? 'SCR-001';
+}
+
+/**
+ * Extract a condition from a step description.
+ *
+ * Looks for "if", "when", "upon" clauses.
+ *
+ * @param step - Step description
+ */
+function extractCondition(step: string): string {
+  const conditionMatch = step.match(/\b(?:if|when|upon|after)\s+(.+?)(?:[,.]|$)/i);
+  return conditionMatch?.[1]?.trim() ?? '';
+}
+
+/**
+ * Extract the action from a step description.
+ *
+ * Takes the main verb phrase from the step.
+ *
+ * @param step - Step description
+ */
+function extractAction(step: string): string {
+  // Remove leading step numbers
+  const cleaned = step.replace(/^(?:step\s*\d+[:.]?\s*|\d+[.)]\s*)/i, '').trim();
+  // Truncate to reasonable length
+  if (cleaned.length <= 80) {
+    return cleaned;
+  }
+  return cleaned.slice(0, 77) + '...';
+}
+
+/**
+ * Map use cases to flow specifications.
+ *
+ * Each use case with 2+ steps generates a flow that describes the
+ * navigation path across screens. Single-step use cases are skipped
+ * as they don't represent meaningful navigation flows.
+ *
+ * @param useCases - Parsed use cases from SRS
+ * @param screens - Detected screens
+ * @returns Array of flow specifications
+ */
+export function mapFlows(
+  useCases: readonly ParsedUseCase[],
+  screens: readonly ScreenSpec[]
+): readonly FlowSpec[] {
+  if (screens.length === 0) {
+    return [];
+  }
+
+  const flows: FlowSpec[] = [];
+  let flowIndex = 1;
+
+  for (const uc of useCases) {
+    // Skip use cases with fewer than 2 steps (no meaningful flow)
+    if (uc.steps.length < 2) {
+      continue;
+    }
+
+    const flowId = `FLW-${String(flowIndex).padStart(3, '0')}`;
+    const title = `${uc.title} Flow`;
+    const nameSlug = slugifyFlow(title);
+
+    const steps: FlowStep[] = [];
+
+    for (let i = 0; i < uc.steps.length - 1; i++) {
+      const currentStep = uc.steps[i];
+      const nextStep = uc.steps[i + 1];
+
+      if (currentStep === undefined || nextStep === undefined) {
+        continue;
+      }
+
+      const fromScreen = findScreenForStep(currentStep, screens, uc.id);
+      const toScreen = findScreenForStep(nextStep, screens, uc.id);
+
+      steps.push({
+        stepNumber: i + 1,
+        fromScreen,
+        toScreen,
+        action: extractAction(currentStep),
+        condition: extractCondition(currentStep),
+      });
+    }
+
+    // Add the last step if it has a clear terminal action
+    if (uc.steps.length > 0) {
+      const lastStep = uc.steps[uc.steps.length - 1];
+      if (lastStep !== undefined) {
+        const lastScreen = findScreenForStep(lastStep, screens, uc.id);
+        steps.push({
+          stepNumber: uc.steps.length,
+          fromScreen: lastScreen,
+          toScreen: lastScreen,
+          action: extractAction(lastStep),
+          condition: '',
+        });
+      }
+    }
+
+    flows.push({
+      id: flowId,
+      nameSlug,
+      title,
+      description: uc.description || `User flow for ${uc.title}`,
+      relatedUseCases: [uc.id],
+      steps,
+      preconditions: [...uc.preconditions],
+      outcomes: [...uc.postconditions],
+    });
+
+    flowIndex++;
+  }
+
+  return flows;
+}

--- a/src/ui-spec-writer/ScreenDetector.ts
+++ b/src/ui-spec-writer/ScreenDetector.ts
@@ -1,0 +1,309 @@
+/**
+ * Screen Detector
+ *
+ * Parses SRS use cases and features to identify distinct UI screens.
+ * Each use case that involves user interaction maps to one or more screens.
+ * Features that describe UI-facing functionality contribute additional
+ * screen candidates.
+ */
+
+import type { ParsedUseCase, ParsedFeature, ScreenSpec, UIElement } from './types.js';
+
+/**
+ * Convert a screen title into a URL-safe slug.
+ *
+ * @param title - Human-readable screen title
+ * @returns URL-safe slug
+ */
+export function slugifyScreen(title: string): string {
+  const slug = title
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  return slug.length > 0 ? slug : 'screen';
+}
+
+/**
+ * Extract UI elements from a use case's steps.
+ *
+ * Infers element types from step descriptions using keyword patterns.
+ *
+ * @param steps - Use case steps
+ * @param screenId - Parent screen ID for element ID generation
+ */
+export function extractElements(steps: readonly string[], screenId: string): readonly UIElement[] {
+  const elements: UIElement[] = [];
+  let elementIndex = 1;
+
+  for (const step of steps) {
+    const lower = step.toLowerCase();
+
+    if (lower.includes('enter') || lower.includes('input') || lower.includes('type')) {
+      elements.push({
+        id: `${screenId}-input-${String(elementIndex)}`,
+        type: 'input',
+        label: extractLabel(step),
+        dataSource: 'User input',
+        behavior: step,
+      });
+      elementIndex++;
+    }
+
+    if (
+      lower.includes('click') ||
+      lower.includes('press') ||
+      lower.includes('submit') ||
+      lower.includes('select')
+    ) {
+      elements.push({
+        id: `${screenId}-button-${String(elementIndex)}`,
+        type: 'button',
+        label: extractLabel(step),
+        dataSource: 'User action',
+        behavior: step,
+      });
+      elementIndex++;
+    }
+
+    if (lower.includes('display') || lower.includes('show') || lower.includes('view')) {
+      elements.push({
+        id: `${screenId}-display-${String(elementIndex)}`,
+        type: 'display',
+        label: extractLabel(step),
+        dataSource: inferDataSource(lower),
+        behavior: step,
+      });
+      elementIndex++;
+    }
+
+    if (lower.includes('list') || lower.includes('table')) {
+      elements.push({
+        id: `${screenId}-list-${String(elementIndex)}`,
+        type: 'list',
+        label: extractLabel(step),
+        dataSource: inferDataSource(lower),
+        behavior: step,
+      });
+      elementIndex++;
+    }
+  }
+
+  return elements;
+}
+
+/**
+ * Extract a short label from a step description.
+ *
+ * Takes the first meaningful clause (up to 50 chars) from the step.
+ *
+ * @param step - Full step description
+ */
+function extractLabel(step: string): string {
+  // Remove leading step numbers ("1. ", "Step 1: ")
+  const cleaned = step.replace(/^(?:step\s*\d+[:.]?\s*|\d+[.)]\s*)/i, '').trim();
+  if (cleaned.length <= 50) {
+    return cleaned;
+  }
+  return cleaned.slice(0, 47) + '...';
+}
+
+/**
+ * Infer the data source for a display or list element from its step text.
+ *
+ * Uses keyword patterns to classify as API response, system state, or
+ * database query.
+ *
+ * @param stepLower - Lowercased step description
+ */
+function inferDataSource(stepLower: string): string {
+  if (stepLower.includes('api') || stepLower.includes('fetch') || stepLower.includes('response')) {
+    return 'API response';
+  }
+  if (
+    stepLower.includes('database') ||
+    stepLower.includes('query') ||
+    stepLower.includes('record')
+  ) {
+    return 'Database query';
+  }
+  if (
+    stepLower.includes('system') ||
+    stepLower.includes('server') ||
+    stepLower.includes('generate')
+  ) {
+    return 'System state';
+  }
+  if (
+    stepLower.includes('user') ||
+    stepLower.includes('profile') ||
+    stepLower.includes('account')
+  ) {
+    return 'User data';
+  }
+  return 'System state';
+}
+
+/**
+ * Derive a screen title from a use case.
+ *
+ * Strips common prefixes like "User", "System" and action verbs
+ * to produce a noun-phrase screen name.
+ *
+ * @param useCase - Use case to derive screen from
+ */
+function deriveScreenTitle(useCase: ParsedUseCase): string {
+  let title = useCase.title;
+  // Remove common verb prefixes to get a noun-oriented screen name
+  title = title.replace(/^(?:User\s+)?(?:can\s+)?/i, '');
+  // Capitalize first character
+  if (title.length > 0) {
+    title = title.charAt(0).toUpperCase() + title.slice(1);
+  }
+  return title;
+}
+
+/**
+ * Detect screens from parsed SRS use cases and features.
+ *
+ * Each use case that references user interaction generates at least one
+ * screen. Features that map to UI surfaces may generate additional screens
+ * if they are not already covered by use-case-derived screens.
+ *
+ * @param useCases - Parsed use cases from SRS
+ * @param features - Parsed features from SRS
+ * @returns Array of screen specifications
+ */
+export function detectScreens(
+  useCases: readonly ParsedUseCase[],
+  features: readonly ParsedFeature[]
+): readonly ScreenSpec[] {
+  const screens: ScreenSpec[] = [];
+  const coveredFeatures = new Set<string>();
+  let screenIndex = 1;
+
+  // Generate screens from use cases
+  for (const uc of useCases) {
+    const screenId = `SCR-${String(screenIndex).padStart(3, '0')}`;
+    const title = deriveScreenTitle(uc);
+    const nameSlug = slugifyScreen(title);
+
+    // Find related features by keyword matching
+    const relatedFeatures: string[] = [];
+    for (const feature of features) {
+      const ucWords = uc.title.toLowerCase().split(/\s+/);
+      const featureWords = feature.title.toLowerCase().split(/\s+/);
+      const overlap = ucWords.filter((w) => featureWords.includes(w) && w.length > 3);
+      if (overlap.length > 0) {
+        relatedFeatures.push(feature.id);
+        coveredFeatures.add(feature.id);
+      }
+    }
+
+    const elements = extractElements(uc.steps, screenId);
+
+    screens.push({
+      id: screenId,
+      nameSlug,
+      title,
+      purpose: uc.description || `Screen for ${uc.title}`,
+      relatedUseCases: [uc.id],
+      relatedFeatures,
+      elements,
+      navigationTargets: [],
+    });
+
+    screenIndex++;
+  }
+
+  // Generate screens for features not covered by use cases
+  for (const feature of features) {
+    if (coveredFeatures.has(feature.id)) {
+      continue;
+    }
+
+    // Only create screens for UI-facing features
+    const lower = feature.description.toLowerCase();
+    const isUIFacing =
+      lower.includes('screen') ||
+      lower.includes('page') ||
+      lower.includes('form') ||
+      lower.includes('view') ||
+      lower.includes('display') ||
+      lower.includes('dashboard') ||
+      lower.includes('ui') ||
+      lower.includes('interface');
+
+    if (!isUIFacing) {
+      continue;
+    }
+
+    const screenId = `SCR-${String(screenIndex).padStart(3, '0')}`;
+    const title = feature.title;
+    const nameSlug = slugifyScreen(title);
+
+    screens.push({
+      id: screenId,
+      nameSlug,
+      title,
+      purpose: feature.description || `Screen for ${feature.title}`,
+      relatedUseCases: [],
+      relatedFeatures: [feature.id],
+      elements: [],
+      navigationTargets: [],
+    });
+
+    screenIndex++;
+  }
+
+  // Link navigation targets based on flow adjacency
+  return linkNavigationTargets(screens);
+}
+
+/**
+ * Link screens by setting navigationTargets based on related use cases.
+ *
+ * Screens that share related use cases or features are likely linked
+ * in the navigation graph.
+ *
+ * @param screens - Screens to link
+ */
+function linkNavigationTargets(screens: readonly ScreenSpec[]): readonly ScreenSpec[] {
+  return screens.map((screen, index) => {
+    const targets: string[] = [];
+
+    for (let i = 0; i < screens.length; i++) {
+      if (i === index) continue;
+      const other = screens[i];
+      if (other === undefined) continue;
+
+      // Link screens that share use cases
+      const sharedUCs = screen.relatedUseCases.filter((uc) => other.relatedUseCases.includes(uc));
+      if (sharedUCs.length > 0) {
+        targets.push(other.id);
+        continue;
+      }
+
+      // Link screens that share features
+      const sharedFeatures = screen.relatedFeatures.filter((f) =>
+        other.relatedFeatures.includes(f)
+      );
+      if (sharedFeatures.length > 0) {
+        targets.push(other.id);
+        continue;
+      }
+    }
+
+    // If no explicit links, connect to adjacent screens (sequential flow)
+    if (targets.length === 0 && screens.length > 1) {
+      const nextIndex = index + 1;
+      if (nextIndex < screens.length) {
+        const nextScreen = screens[nextIndex];
+        if (nextScreen !== undefined) {
+          targets.push(nextScreen.id);
+        }
+      }
+    }
+
+    return { ...screen, navigationTargets: targets };
+  });
+}

--- a/src/ui-spec-writer/UISpecWriterAgent.ts
+++ b/src/ui-spec-writer/UISpecWriterAgent.ts
@@ -1,0 +1,945 @@
+/**
+ * UI Specification Writer Agent
+ *
+ * Generates UI screen specifications, user flow documents, and a design
+ * system reference from SRS use cases. Produces structured wireframe
+ * descriptions and interaction flows for web/mobile projects.
+ *
+ * Auto-skips for CLI, API, and library projects that do not have UI surfaces.
+ *
+ * Implements IAgent interface for AgentFactory integration.
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { randomUUID } from 'node:crypto';
+import type { IAgent } from '../agents/types.js';
+
+import type {
+  UISpecWriterAgentConfig,
+  UISpecGenerationSession,
+  UISpecGenerationResult,
+  UISpecGenerationStats,
+  ParsedSRSForUI,
+  ParsedUseCase,
+  ParsedFeature,
+  ProjectType,
+  ScreenSpec,
+  FlowSpec,
+  DesignSystem,
+} from './types.js';
+import { SRSNotFoundError, GenerationError, FileWriteError, SessionStateError } from './errors.js';
+import { detectScreens } from './ScreenDetector.js';
+import { mapFlows } from './FlowMapper.js';
+import { generateDesignSystem } from './DesignSystemGenerator.js';
+
+/**
+ * Default configuration for the UI Spec Writer Agent
+ */
+const DEFAULT_CONFIG: Required<UISpecWriterAgentConfig> = {
+  scratchpadBasePath: '.ad-sdlc/scratchpad',
+  publicDocsPath: 'docs/ui',
+};
+
+/**
+ * Project types that should be auto-skipped (no UI surface)
+ */
+const SKIP_PROJECT_TYPES: ReadonlySet<ProjectType> = new Set(['cli', 'api', 'library']);
+
+/**
+ * Agent ID for UISpecWriterAgent used in AgentFactory
+ */
+export const UI_SPEC_WRITER_AGENT_ID = 'ui-spec-writer-agent';
+
+/**
+ * UI Specification Writer Agent class
+ *
+ * Orchestrates the generation of UI screen specs, flow docs, and design
+ * system references from SRS input. Implements IAgent for unified
+ * instantiation through AgentFactory.
+ */
+export class UISpecWriterAgent implements IAgent {
+  public readonly agentId = UI_SPEC_WRITER_AGENT_ID;
+  public readonly name = 'UI Specification Writer Agent';
+
+  private readonly config: Required<UISpecWriterAgentConfig>;
+  private session: UISpecGenerationSession | null = null;
+  private initialized = false;
+
+  constructor(config: UISpecWriterAgentConfig = {}) {
+    this.config = { ...DEFAULT_CONFIG, ...config };
+  }
+
+  /**
+   * Initialize the agent (IAgent interface)
+   */
+  public async initialize(): Promise<void> {
+    if (this.initialized) {
+      return;
+    }
+    await Promise.resolve();
+    this.initialized = true;
+  }
+
+  /**
+   * Dispose of the agent and release resources (IAgent interface)
+   */
+  public async dispose(): Promise<void> {
+    await Promise.resolve();
+    this.session = null;
+    this.initialized = false;
+  }
+
+  /**
+   * Get the current session
+   * @returns Current UI spec generation session or null if no session is active
+   */
+  public getSession(): UISpecGenerationSession | null {
+    return this.session;
+  }
+
+  /**
+   * Start a new UI spec generation session
+   * @param projectId - Project identifier
+   * @returns The new session
+   */
+  public async startSession(projectId: string): Promise<UISpecGenerationSession> {
+    await Promise.resolve();
+
+    const docsDir = path.join(this.config.scratchpadBasePath, 'documents', projectId);
+    const srsPath = path.join(docsDir, 'srs.md');
+
+    if (!fs.existsSync(srsPath)) {
+      throw new SRSNotFoundError(projectId, srsPath);
+    }
+
+    const srsContent = fs.readFileSync(srsPath, 'utf-8');
+    const parsedSRS = this.extractSRS(srsContent, projectId);
+
+    const warnings: string[] = [];
+    if (parsedSRS.useCases.length === 0 && parsedSRS.features.length === 0) {
+      warnings.push(
+        'No use cases or features detected in SRS — generated UI spec will be minimal.'
+      );
+    }
+
+    const shouldSkip = SKIP_PROJECT_TYPES.has(parsedSRS.projectType);
+    const skipReason = shouldSkip
+      ? `Project type "${parsedSRS.projectType}" does not have a UI surface — stage skipped.`
+      : undefined;
+
+    this.session = {
+      sessionId: randomUUID(),
+      projectId,
+      status: shouldSkip ? 'completed' : 'pending',
+      parsedSRS,
+      skipped: shouldSkip,
+      ...(skipReason !== undefined && { skipReason }),
+      startedAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      ...(warnings.length > 0 && { warnings }),
+    };
+
+    return this.session;
+  }
+
+  /**
+   * Generate UI specifications from a project
+   * @param projectId - Project identifier
+   * @returns Generation result
+   */
+  public async generateFromProject(projectId: string): Promise<UISpecGenerationResult> {
+    const startTime = Date.now();
+
+    if (!this.session || this.session.projectId !== projectId) {
+      await this.startSession(projectId);
+    }
+
+    if (!this.session) {
+      throw new GenerationError(projectId, 'initialization', 'Failed to create session');
+    }
+
+    // Handle auto-skip for non-UI projects
+    if (this.session.skipped) {
+      return {
+        success: true,
+        skipped: true,
+        ...(this.session.skipReason !== undefined && { skipReason: this.session.skipReason }),
+        projectId,
+        screenPaths: [],
+        flowPaths: [],
+        designSystemPath: '',
+        readmePath: '',
+        stats: {
+          useCasesProcessed: 0,
+          screensGenerated: 0,
+          flowsGenerated: 0,
+          designTokensGenerated: 0,
+          processingTimeMs: Date.now() - startTime,
+        },
+      };
+    }
+
+    try {
+      this.updateSession({ status: 'parsing' });
+
+      const { parsedSRS } = this.session;
+
+      this.updateSession({ status: 'generating' });
+
+      const warnings: string[] = this.session.warnings ? [...this.session.warnings] : [];
+
+      // Step 1: Detect screens from use cases and features
+      const screens = detectScreens(parsedSRS.useCases, parsedSRS.features);
+
+      // Step 2: Map flows from use cases
+      const flows = mapFlows(parsedSRS.useCases, screens);
+
+      // Step 3: Generate design system
+      const designSystem = generateDesignSystem(parsedSRS.projectType, screens);
+
+      if (screens.length === 0) {
+        warnings.push('No screens detected from SRS content — UI spec is empty.');
+      }
+
+      this.updateSession({
+        status: 'completed',
+        screens,
+        flows,
+        designSystem,
+        ...(warnings.length > 0 && { warnings }),
+      });
+
+      const paths = await this.writeOutputFiles(projectId, screens, flows, designSystem);
+
+      const stats: UISpecGenerationStats = {
+        useCasesProcessed: parsedSRS.useCases.length,
+        screensGenerated: screens.length,
+        flowsGenerated: flows.length,
+        designTokensGenerated: designSystem.tokens.length,
+        processingTimeMs: Date.now() - startTime,
+      };
+
+      return {
+        success: true,
+        skipped: false,
+        projectId,
+        screenPaths: paths.screenPaths,
+        flowPaths: paths.flowPaths,
+        designSystemPath: paths.designSystemPath,
+        readmePath: paths.readmePath,
+        stats,
+        ...(warnings.length > 0 && { warnings }),
+      };
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+      this.updateSession({
+        status: 'failed',
+        errorMessage,
+      });
+      throw error;
+    }
+  }
+
+  /**
+   * Finalize the current session and write output files
+   * @returns Generation result based on the cached session data
+   */
+  public async finalize(): Promise<UISpecGenerationResult> {
+    if (!this.session) {
+      throw new SessionStateError('null', 'active', 'finalize');
+    }
+
+    if (this.session.status !== 'completed') {
+      throw new SessionStateError(this.session.status, 'completed', 'finalize');
+    }
+
+    if (this.session.skipped) {
+      return {
+        success: true,
+        skipped: true,
+        ...(this.session.skipReason !== undefined && { skipReason: this.session.skipReason }),
+        projectId: this.session.projectId,
+        screenPaths: [],
+        flowPaths: [],
+        designSystemPath: '',
+        readmePath: '',
+        stats: {
+          useCasesProcessed: 0,
+          screensGenerated: 0,
+          flowsGenerated: 0,
+          designTokensGenerated: 0,
+          processingTimeMs: 0,
+        },
+      };
+    }
+
+    const screens = this.session.screens ?? [];
+    const flows = this.session.flows ?? [];
+    const designSystem = this.session.designSystem;
+
+    if (!designSystem) {
+      throw new GenerationError(this.session.projectId, 'finalization', 'No generated UI spec');
+    }
+
+    const paths = await this.writeOutputFiles(this.session.projectId, screens, flows, designSystem);
+
+    return {
+      success: true,
+      skipped: false,
+      projectId: this.session.projectId,
+      screenPaths: paths.screenPaths,
+      flowPaths: paths.flowPaths,
+      designSystemPath: paths.designSystemPath,
+      readmePath: paths.readmePath,
+      stats: {
+        useCasesProcessed: this.session.parsedSRS.useCases.length,
+        screensGenerated: screens.length,
+        flowsGenerated: flows.length,
+        designTokensGenerated: designSystem.tokens.length,
+        processingTimeMs: 0,
+      },
+    };
+  }
+
+  /**
+   * Update session with partial data
+   * @param updates - Partial session fields to merge
+   */
+  private updateSession(updates: Partial<UISpecGenerationSession>): void {
+    if (!this.session) return;
+
+    this.session = {
+      ...this.session,
+      ...updates,
+      updatedAt: new Date().toISOString(),
+    };
+  }
+
+  /**
+   * Extract SRS content for UI specification generation.
+   *
+   * Parses use cases, features, and detects the project type.
+   *
+   * @param content - Raw SRS markdown
+   * @param projectId - Project identifier
+   */
+  private extractSRS(content: string, projectId: string): ParsedSRSForUI {
+    const docIdMatch =
+      content.match(/^doc_id:\s*['"]?([^'"\n]+)['"]?/m) ??
+      content.match(/\|\s*\*\*Document ID\*\*\s*\|\s*([^|]+)\s*\|/);
+    const documentId = docIdMatch?.[1]?.trim() ?? `SRS-${projectId}`;
+
+    const titleMatch =
+      content.match(/^#\s+(?:Software Requirements Specification:\s*)?(.+)$/m) ??
+      content.match(/^title:\s*['"]?([^'"\n]+)['"]?/m);
+    const productName = titleMatch?.[1]?.trim() ?? projectId;
+
+    const useCases = this.extractUseCases(content);
+    const features = this.extractFeatures(content);
+    const projectType = this.detectProjectType(content);
+
+    return {
+      documentId,
+      productName,
+      useCases,
+      features,
+      projectType,
+    };
+  }
+
+  /**
+   * Extract use cases from SRS markdown content.
+   *
+   * Recognizes headings like `### UC-001: Login` and extracts
+   * description, actors, steps, preconditions, postconditions.
+   *
+   * @param content - Raw SRS markdown
+   */
+  private extractUseCases(content: string): readonly ParsedUseCase[] {
+    const useCases: ParsedUseCase[] = [];
+
+    // Match use case headings: ### UC-001: Title or #### UC-001: Title
+    const ucRegex = /^#{2,4}\s+(UC-\d+):\s*(.+)$/gm;
+    let match: RegExpExecArray | null;
+
+    while ((match = ucRegex.exec(content)) !== null) {
+      const id = match[1]?.trim() ?? '';
+      const title = match[2]?.trim() ?? '';
+
+      if (id.length === 0) continue;
+
+      // Extract the body between this heading and the next heading
+      const startIndex = match.index + match[0].length;
+      const nextHeading = content.slice(startIndex).search(/^#{2,4}\s/m);
+      const body =
+        nextHeading !== -1
+          ? content.slice(startIndex, startIndex + nextHeading)
+          : content.slice(startIndex);
+
+      const description = this.extractSection(body, /description|설명/i) || title;
+      const actors = this.extractListItems(body, /actors?|행위자/i);
+      const steps = this.extractListItems(body, /steps?|main\s+flow|주요\s*흐름/i);
+      const preconditions = this.extractListItems(body, /preconditions?|사전\s*조건/i);
+      const postconditions = this.extractListItems(body, /postconditions?|사후\s*조건/i);
+
+      useCases.push({
+        id,
+        title,
+        description,
+        actors: actors.length > 0 ? actors : ['User'],
+        steps,
+        preconditions,
+        postconditions,
+      });
+    }
+
+    return useCases;
+  }
+
+  /**
+   * Extract features from SRS markdown content.
+   *
+   * Recognizes headings like `### SF-001: User Authentication`
+   *
+   * @param content - Raw SRS markdown
+   */
+  private extractFeatures(content: string): readonly ParsedFeature[] {
+    const features: ParsedFeature[] = [];
+
+    const featureRegex = /^#{2,4}\s+(SF-\d+):\s*(.+)$/gm;
+    let match: RegExpExecArray | null;
+
+    while ((match = featureRegex.exec(content)) !== null) {
+      const id = match[1]?.trim() ?? '';
+      const title = match[2]?.trim() ?? '';
+
+      if (id.length === 0) continue;
+
+      const startIndex = match.index + match[0].length;
+      const nextHeading = content.slice(startIndex).search(/^#{2,4}\s/m);
+      const body =
+        nextHeading !== -1
+          ? content.slice(startIndex, startIndex + nextHeading)
+          : content.slice(startIndex);
+
+      // First non-empty line is treated as description
+      const descLine = body
+        .split('\n')
+        .find((l) => l.trim().length > 0 && !l.trim().startsWith('#'));
+      const description = descLine?.trim() ?? '';
+
+      features.push({ id, title, description });
+    }
+
+    return features;
+  }
+
+  /**
+   * Detect the project type from SRS content.
+   *
+   * Uses keyword analysis to classify the project as web, mobile,
+   * desktop, CLI, API, or library.
+   *
+   * @param content - Raw SRS markdown
+   */
+  private detectProjectType(content: string): ProjectType {
+    const lower = content.toLowerCase();
+
+    // CLI indicators
+    if (
+      lower.includes('command-line') ||
+      lower.includes('command line') ||
+      lower.includes('cli tool') ||
+      lower.includes('terminal')
+    ) {
+      return 'cli';
+    }
+
+    // API-only indicators
+    if (
+      (lower.includes('rest api') ||
+        lower.includes('api server') ||
+        lower.includes('api service')) &&
+      !lower.includes('web app') &&
+      !lower.includes('frontend') &&
+      !lower.includes('user interface')
+    ) {
+      return 'api';
+    }
+
+    // Library indicators
+    if (
+      lower.includes('library') ||
+      lower.includes('sdk') ||
+      lower.includes('npm package') ||
+      lower.includes('pip package')
+    ) {
+      return 'library';
+    }
+
+    // Mobile indicators
+    if (
+      lower.includes('mobile app') ||
+      lower.includes('ios') ||
+      lower.includes('android') ||
+      lower.includes('react native') ||
+      lower.includes('flutter')
+    ) {
+      return 'mobile';
+    }
+
+    // Desktop indicators
+    if (
+      lower.includes('desktop app') ||
+      lower.includes('electron') ||
+      lower.includes('native app')
+    ) {
+      return 'desktop';
+    }
+
+    // Web indicators (most common default)
+    if (
+      lower.includes('web') ||
+      lower.includes('browser') ||
+      lower.includes('frontend') ||
+      lower.includes('dashboard') ||
+      lower.includes('user interface') ||
+      lower.includes('html') ||
+      lower.includes('react') ||
+      lower.includes('vue') ||
+      lower.includes('angular')
+    ) {
+      return 'web';
+    }
+
+    return 'unknown';
+  }
+
+  /**
+   * Extract a section's text content from markdown body.
+   *
+   * @param body - Markdown body (after the heading)
+   * @param labelPattern - Pattern to match the section label
+   */
+  private extractSection(body: string, labelPattern: RegExp): string {
+    const lines = body.split('\n');
+
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
+      if (line === undefined) continue;
+
+      if (labelPattern.test(line)) {
+        // Return the next non-empty line as the section content
+        for (let j = i + 1; j < lines.length; j++) {
+          const nextLine = lines[j]?.trim();
+          if (nextLine !== undefined && nextLine.length > 0 && !nextLine.startsWith('#')) {
+            return nextLine.replace(/^[-*]\s*/, '');
+          }
+        }
+      }
+    }
+
+    return '';
+  }
+
+  /**
+   * Extract list items from a section in markdown body.
+   *
+   * @param body - Markdown body
+   * @param labelPattern - Pattern to match the section label
+   */
+  private extractListItems(body: string, labelPattern: RegExp): readonly string[] {
+    const items: string[] = [];
+    const lines = body.split('\n');
+
+    let inSection = false;
+
+    for (const line of lines) {
+      const trimmed = line.trim();
+
+      if (labelPattern.test(trimmed)) {
+        inSection = true;
+        continue;
+      }
+
+      if (inSection) {
+        // Stop at empty lines or new sections
+        if (trimmed.length === 0 || /^#+\s/.test(trimmed) || /^\*\*[^*]+\*\*/.test(trimmed)) {
+          if (items.length > 0) break;
+          continue;
+        }
+
+        // Match list items
+        const listMatch = trimmed.match(/^(?:\d+[.)]\s*|[-*]\s+)(.+)/);
+        if (listMatch?.[1] !== undefined) {
+          items.push(listMatch[1].trim());
+        }
+      }
+    }
+
+    return items;
+  }
+
+  /**
+   * Render a screen specification as markdown.
+   *
+   * @param screen - Screen specification
+   */
+  private renderScreenMarkdown(screen: ScreenSpec): string {
+    const lines: string[] = [];
+
+    lines.push('---');
+    lines.push(`doc_id: ${screen.id}-${screen.nameSlug}`);
+    lines.push(`title: "${screen.title}"`);
+    lines.push('version: 1.0.0');
+    lines.push('status: Draft');
+    lines.push('---');
+    lines.push('');
+    lines.push(`# ${screen.id}: ${screen.title}`);
+    lines.push('');
+    lines.push('## Purpose');
+    lines.push('');
+    lines.push(screen.purpose);
+    lines.push('');
+
+    if (screen.relatedUseCases.length > 0) {
+      lines.push('## Related Use Cases');
+      lines.push('');
+      for (const ucId of screen.relatedUseCases) {
+        lines.push(`- ${ucId}`);
+      }
+      lines.push('');
+    }
+
+    if (screen.relatedFeatures.length > 0) {
+      lines.push('## Related Features');
+      lines.push('');
+      for (const fId of screen.relatedFeatures) {
+        lines.push(`- ${fId}`);
+      }
+      lines.push('');
+    }
+
+    if (screen.elements.length > 0) {
+      lines.push('## UI Elements');
+      lines.push('');
+      lines.push('| ID | Type | Label | Data Source | Behavior |');
+      lines.push('|----|------|-------|------------|----------|');
+      for (const el of screen.elements) {
+        lines.push(`| ${el.id} | ${el.type} | ${el.label} | ${el.dataSource} | ${el.behavior} |`);
+      }
+      lines.push('');
+    }
+
+    if (screen.navigationTargets.length > 0) {
+      lines.push('## Navigation');
+      lines.push('');
+      lines.push('Navigates to:');
+      for (const target of screen.navigationTargets) {
+        lines.push(`- ${target}`);
+      }
+      lines.push('');
+    }
+
+    return lines.join('\n');
+  }
+
+  /**
+   * Render a flow specification as markdown.
+   *
+   * @param flow - Flow specification
+   */
+  private renderFlowMarkdown(flow: FlowSpec): string {
+    const lines: string[] = [];
+
+    lines.push('---');
+    lines.push(`doc_id: ${flow.id}-${flow.nameSlug}`);
+    lines.push(`title: "${flow.title}"`);
+    lines.push('version: 1.0.0');
+    lines.push('status: Draft');
+    lines.push('---');
+    lines.push('');
+    lines.push(`# ${flow.id}: ${flow.title}`);
+    lines.push('');
+    lines.push('## Description');
+    lines.push('');
+    lines.push(flow.description);
+    lines.push('');
+
+    if (flow.relatedUseCases.length > 0) {
+      lines.push('## Related Use Cases');
+      lines.push('');
+      for (const ucId of flow.relatedUseCases) {
+        lines.push(`- ${ucId}`);
+      }
+      lines.push('');
+    }
+
+    if (flow.preconditions.length > 0) {
+      lines.push('## Preconditions');
+      lines.push('');
+      for (const pre of flow.preconditions) {
+        lines.push(`- ${pre}`);
+      }
+      lines.push('');
+    }
+
+    if (flow.steps.length > 0) {
+      lines.push('## Flow Steps');
+      lines.push('');
+      lines.push('| Step | From | To | Action | Condition |');
+      lines.push('|------|------|----|--------|-----------|');
+      for (const step of flow.steps) {
+        lines.push(
+          `| ${String(step.stepNumber)} | ${step.fromScreen} | ${step.toScreen} | ${step.action} | ${step.condition || '-'} |`
+        );
+      }
+      lines.push('');
+
+      // Mermaid flow diagram
+      lines.push('## Flow Diagram');
+      lines.push('');
+      lines.push('```mermaid');
+      lines.push('graph LR');
+      const seenEdges = new Set<string>();
+      for (const step of flow.steps) {
+        if (step.fromScreen === step.toScreen) continue;
+        const edgeKey = `${step.fromScreen}-->${step.toScreen}`;
+        if (seenEdges.has(edgeKey)) continue;
+        seenEdges.add(edgeKey);
+        lines.push(`    ${step.fromScreen} --> ${step.toScreen}`);
+      }
+      lines.push('```');
+      lines.push('');
+    }
+
+    if (flow.outcomes.length > 0) {
+      lines.push('## Expected Outcomes');
+      lines.push('');
+      for (const outcome of flow.outcomes) {
+        lines.push(`- ${outcome}`);
+      }
+      lines.push('');
+    }
+
+    return lines.join('\n');
+  }
+
+  /**
+   * Render the design system document as markdown.
+   *
+   * @param designSystem - Design system specification
+   */
+  private renderDesignSystemMarkdown(designSystem: DesignSystem): string {
+    const lines: string[] = [];
+
+    lines.push('---');
+    lines.push('doc_id: design-system');
+    lines.push('title: "Design System"');
+    lines.push('version: 1.0.0');
+    lines.push('status: Draft');
+    lines.push('---');
+    lines.push('');
+    lines.push('# Design System');
+    lines.push('');
+    lines.push(`Technology Stack: ${designSystem.technologyStack}`);
+    lines.push('');
+
+    // Group tokens by category
+    const tokensByCategory = new Map<string, (typeof designSystem.tokens)[number][]>();
+    for (const token of designSystem.tokens) {
+      const existing = tokensByCategory.get(token.category) ?? [];
+      existing.push(token);
+      tokensByCategory.set(token.category, existing);
+    }
+
+    lines.push('## Design Tokens');
+    lines.push('');
+
+    for (const [category, tokens] of tokensByCategory) {
+      lines.push(`### ${category.charAt(0).toUpperCase() + category.slice(1)}`);
+      lines.push('');
+      lines.push('| Name | Value | Description |');
+      lines.push('|------|-------|-------------|');
+      for (const token of tokens) {
+        lines.push(`| ${token.name} | \`${token.value}\` | ${token.description} |`);
+      }
+      lines.push('');
+    }
+
+    if (designSystem.components.length > 0) {
+      lines.push('## Component Library');
+      lines.push('');
+      for (const component of designSystem.components) {
+        lines.push(`### ${component.name}`);
+        lines.push('');
+        lines.push(component.description);
+        lines.push('');
+        if (component.variants.length > 0) {
+          lines.push('**Variants:**');
+          for (const variant of component.variants) {
+            lines.push(`- ${variant}`);
+          }
+          lines.push('');
+        }
+      }
+    }
+
+    return lines.join('\n');
+  }
+
+  /**
+   * Render the UI README index as markdown.
+   *
+   * @param screens - Generated screens
+   * @param flows - Generated flows
+   * @param productName - Product name
+   */
+  private renderReadmeMarkdown(
+    screens: readonly ScreenSpec[],
+    flows: readonly FlowSpec[],
+    productName: string
+  ): string {
+    const lines: string[] = [];
+
+    lines.push('---');
+    lines.push('doc_id: ui-readme');
+    lines.push('title: "UI Specifications"');
+    lines.push('version: 1.0.0');
+    lines.push('status: Draft');
+    lines.push('---');
+    lines.push('');
+    lines.push(`# UI Specifications: ${productName}`);
+    lines.push('');
+    lines.push('## Overview');
+    lines.push('');
+    lines.push(
+      `This directory contains UI specifications for ${productName}, including screen definitions, user flows, and design system tokens.`
+    );
+    lines.push('');
+
+    if (screens.length > 0) {
+      lines.push('## Screens');
+      lines.push('');
+      lines.push('| ID | Screen | Related Use Cases |');
+      lines.push('|----|--------|-------------------|');
+      for (const screen of screens) {
+        const ucList = screen.relatedUseCases.join(', ') || '-';
+        lines.push(
+          `| [${screen.id}](screens/${screen.id}-${screen.nameSlug}.md) | ${screen.title} | ${ucList} |`
+        );
+      }
+      lines.push('');
+    }
+
+    if (flows.length > 0) {
+      lines.push('## User Flows');
+      lines.push('');
+      lines.push('| ID | Flow | Related Use Cases |');
+      lines.push('|----|------|-------------------|');
+      for (const flow of flows) {
+        const ucList = flow.relatedUseCases.join(', ') || '-';
+        lines.push(
+          `| [${flow.id}](flows/${flow.id}-${flow.nameSlug}.md) | ${flow.title} | ${ucList} |`
+        );
+      }
+      lines.push('');
+    }
+
+    lines.push('## Design System');
+    lines.push('');
+    lines.push(
+      '- [Design System](design-system.md) — Design tokens and component library reference'
+    );
+    lines.push('');
+
+    return lines.join('\n');
+  }
+
+  /**
+   * Write all output files for screens, flows, design system, and README.
+   *
+   * @param projectId - Project identifier
+   * @param screens - Screen specifications
+   * @param flows - Flow specifications
+   * @param designSystem - Design system specification
+   * @returns Paths to all written files
+   */
+  private async writeOutputFiles(
+    projectId: string,
+    screens: readonly ScreenSpec[],
+    flows: readonly FlowSpec[],
+    designSystem: DesignSystem
+  ): Promise<{
+    screenPaths: readonly string[];
+    flowPaths: readonly string[];
+    designSystemPath: string;
+    readmePath: string;
+  }> {
+    await Promise.resolve();
+
+    const publicDir = this.config.publicDocsPath;
+    const screensDir = path.join(publicDir, 'screens');
+    const flowsDir = path.join(publicDir, 'flows');
+
+    try {
+      fs.mkdirSync(screensDir, { recursive: true });
+      fs.mkdirSync(flowsDir, { recursive: true });
+
+      // Write screen files
+      const screenPaths: string[] = [];
+      for (const screen of screens) {
+        const filename = `${screen.id}-${screen.nameSlug}.md`;
+        const filePath = path.join(screensDir, filename);
+        fs.writeFileSync(filePath, this.renderScreenMarkdown(screen), 'utf-8');
+        screenPaths.push(filePath);
+      }
+
+      // Write flow files
+      const flowPaths: string[] = [];
+      for (const flow of flows) {
+        const filename = `${flow.id}-${flow.nameSlug}.md`;
+        const filePath = path.join(flowsDir, filename);
+        fs.writeFileSync(filePath, this.renderFlowMarkdown(flow), 'utf-8');
+        flowPaths.push(filePath);
+      }
+
+      // Write design system
+      const designSystemPath = path.join(publicDir, 'design-system.md');
+      fs.writeFileSync(designSystemPath, this.renderDesignSystemMarkdown(designSystem), 'utf-8');
+
+      // Write README
+      const productName = this.session?.parsedSRS.productName ?? projectId;
+      const readmePath = path.join(publicDir, 'README.md');
+      fs.writeFileSync(readmePath, this.renderReadmeMarkdown(screens, flows, productName), 'utf-8');
+
+      return { screenPaths, flowPaths, designSystemPath, readmePath };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      throw new FileWriteError(publicDir, message);
+    }
+  }
+}
+
+// Singleton pattern
+let instance: UISpecWriterAgent | null = null;
+
+/**
+ * Get the singleton instance of UISpecWriterAgent
+ * @param config - Optional configuration (used only for the first call)
+ * @returns The singleton instance
+ */
+export function getUISpecWriterAgent(config?: UISpecWriterAgentConfig): UISpecWriterAgent {
+  if (!instance) {
+    instance = new UISpecWriterAgent(config);
+  }
+  return instance;
+}
+
+/**
+ * Reset the singleton instance (mainly for testing)
+ */
+export function resetUISpecWriterAgent(): void {
+  instance = null;
+}

--- a/src/ui-spec-writer/errors.ts
+++ b/src/ui-spec-writer/errors.ts
@@ -1,0 +1,81 @@
+/**
+ * UI Specification Writer Agent module error definitions
+ *
+ * Custom error classes for UI spec generation and validation operations.
+ */
+
+/**
+ * Base error class for UI spec writer agent errors
+ */
+export class UISpecWriterError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'UISpecWriterError';
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
+
+/**
+ * Error thrown when the SRS document is not found
+ */
+export class SRSNotFoundError extends UISpecWriterError {
+  /** The project ID that was not found */
+  public readonly projectId: string;
+  /** The path that was searched */
+  public readonly searchedPath: string;
+
+  constructor(projectId: string, searchedPath: string) {
+    super(`SRS document not found for project "${projectId}" at path: ${searchedPath}`);
+    this.name = 'SRSNotFoundError';
+    this.projectId = projectId;
+    this.searchedPath = searchedPath;
+  }
+}
+
+/**
+ * Error thrown when a session is in an invalid state for an operation
+ */
+export class SessionStateError extends UISpecWriterError {
+  /** Current session state */
+  public readonly currentState: string;
+  /** Expected state */
+  public readonly expectedState: string;
+
+  constructor(currentState: string, expectedState: string, action: string) {
+    super(`Cannot ${action}: session is in "${currentState}" state, expected "${expectedState}"`);
+    this.name = 'SessionStateError';
+    this.currentState = currentState;
+    this.expectedState = expectedState;
+  }
+}
+
+/**
+ * Error thrown when UI spec generation fails
+ */
+export class GenerationError extends UISpecWriterError {
+  /** The phase where generation failed */
+  public readonly phase: string;
+  /** The project ID */
+  public readonly projectId: string;
+
+  constructor(projectId: string, phase: string, reason: string) {
+    super(`UI spec generation failed for project "${projectId}" at "${phase}": ${reason}`);
+    this.name = 'GenerationError';
+    this.projectId = projectId;
+    this.phase = phase;
+  }
+}
+
+/**
+ * Error thrown when a file write operation fails
+ */
+export class FileWriteError extends UISpecWriterError {
+  /** The file path that failed */
+  public readonly filePath: string;
+
+  constructor(filePath: string, reason: string) {
+    super(`Failed to write UI spec to "${filePath}": ${reason}`);
+    this.name = 'FileWriteError';
+    this.filePath = filePath;
+  }
+}

--- a/src/ui-spec-writer/index.ts
+++ b/src/ui-spec-writer/index.ts
@@ -1,0 +1,60 @@
+/**
+ * UI Specification Writer Agent module
+ *
+ * Generates UI screen specifications, user flow documents, and design
+ * system references from SRS use cases for web/mobile projects.
+ *
+ * @module ui-spec-writer
+ */
+
+// Main agent class (singleton + constructor)
+export {
+  UISpecWriterAgent,
+  getUISpecWriterAgent,
+  resetUISpecWriterAgent,
+  UI_SPEC_WRITER_AGENT_ID,
+} from './UISpecWriterAgent.js';
+
+// Helper modules
+export { detectScreens, slugifyScreen } from './ScreenDetector.js';
+export { mapFlows, slugifyFlow } from './FlowMapper.js';
+export { generateDesignSystem, deriveComponents } from './DesignSystemGenerator.js';
+
+// Error classes
+export {
+  UISpecWriterError,
+  SRSNotFoundError,
+  SessionStateError,
+  GenerationError,
+  FileWriteError,
+} from './errors.js';
+
+// Type exports
+export type {
+  // Status and config
+  UISpecGenerationStatus,
+  UISpecDocumentStatus,
+  UISpecWriterAgentConfig,
+  UISpecGenerationSession,
+  UISpecGenerationResult,
+  UISpecGenerationStats,
+  ProjectType,
+
+  // Parsed input types
+  ParsedSRSForUI,
+  ParsedUseCase,
+  ParsedFeature,
+
+  // Screen types
+  ScreenSpec,
+  UIElement,
+
+  // Flow types
+  FlowSpec,
+  FlowStep,
+
+  // Design system types
+  DesignSystem,
+  DesignToken,
+  DesignComponent,
+} from './types.js';

--- a/src/ui-spec-writer/types.ts
+++ b/src/ui-spec-writer/types.ts
@@ -1,0 +1,287 @@
+/**
+ * UI Specification Writer Agent module type definitions
+ *
+ * Defines types for UI screen specification and user flow document
+ * generation from SRS use cases.
+ */
+
+/**
+ * UI spec generation status
+ */
+export type UISpecGenerationStatus = 'pending' | 'parsing' | 'generating' | 'completed' | 'failed';
+
+/**
+ * Document status
+ */
+export type UISpecDocumentStatus = 'Draft' | 'Review' | 'Approved';
+
+/**
+ * Project type classification for auto-skip logic
+ */
+export type ProjectType = 'web' | 'mobile' | 'desktop' | 'cli' | 'api' | 'library' | 'unknown';
+
+// ============================================================================
+// Parsed Input Types (lightweight extracts from SRS markdown)
+// ============================================================================
+
+/**
+ * A single use case extracted from the SRS
+ */
+export interface ParsedUseCase {
+  /** Use case identifier, e.g., "UC-001" */
+  readonly id: string;
+  /** Use case title */
+  readonly title: string;
+  /** Use case description */
+  readonly description: string;
+  /** Actor(s) involved */
+  readonly actors: readonly string[];
+  /** Steps in the use case flow */
+  readonly steps: readonly string[];
+  /** Preconditions */
+  readonly preconditions: readonly string[];
+  /** Postconditions */
+  readonly postconditions: readonly string[];
+}
+
+/**
+ * A software feature extracted from the SRS
+ */
+export interface ParsedFeature {
+  /** Feature identifier, e.g., "SF-001" */
+  readonly id: string;
+  /** Feature title */
+  readonly title: string;
+  /** Feature description */
+  readonly description: string;
+}
+
+/**
+ * Lightweight SRS extract used by the UI Spec Writer
+ */
+export interface ParsedSRSForUI {
+  /** SRS document ID, e.g., "SRS-my-project" */
+  readonly documentId: string;
+  /** Product name */
+  readonly productName: string;
+  /** Use cases extracted from the SRS */
+  readonly useCases: readonly ParsedUseCase[];
+  /** Features extracted from the SRS */
+  readonly features: readonly ParsedFeature[];
+  /** Detected project type */
+  readonly projectType: ProjectType;
+}
+
+// ============================================================================
+// Screen Specification Types
+// ============================================================================
+
+/**
+ * A UI element within a screen
+ */
+export interface UIElement {
+  /** Element identifier within the screen */
+  readonly id: string;
+  /** Element type (button, input, label, list, table, etc.) */
+  readonly type: string;
+  /** Element label or display text */
+  readonly label: string;
+  /** Data source for this element (e.g., "User input", "API response", "System state") */
+  readonly dataSource: string;
+  /** Interaction behavior description */
+  readonly behavior: string;
+}
+
+/**
+ * A single screen specification
+ */
+export interface ScreenSpec {
+  /** Screen identifier, e.g., "SCR-001" */
+  readonly id: string;
+  /** Screen name slug, e.g., "login" */
+  readonly nameSlug: string;
+  /** Screen title */
+  readonly title: string;
+  /** Screen purpose description */
+  readonly purpose: string;
+  /** Related use case IDs */
+  readonly relatedUseCases: readonly string[];
+  /** Related feature IDs */
+  readonly relatedFeatures: readonly string[];
+  /** UI elements on the screen */
+  readonly elements: readonly UIElement[];
+  /** Navigation targets (screen IDs reachable from this screen) */
+  readonly navigationTargets: readonly string[];
+}
+
+// ============================================================================
+// Flow Specification Types
+// ============================================================================
+
+/**
+ * A single step in a user flow
+ */
+export interface FlowStep {
+  /** Step number (1-based) */
+  readonly stepNumber: number;
+  /** Source screen ID */
+  readonly fromScreen: string;
+  /** Target screen ID */
+  readonly toScreen: string;
+  /** Action that triggers the transition */
+  readonly action: string;
+  /** Condition for the transition (empty if unconditional) */
+  readonly condition: string;
+}
+
+/**
+ * A user flow specification
+ */
+export interface FlowSpec {
+  /** Flow identifier, e.g., "FLW-001" */
+  readonly id: string;
+  /** Flow name slug, e.g., "user-login" */
+  readonly nameSlug: string;
+  /** Flow title */
+  readonly title: string;
+  /** Flow description */
+  readonly description: string;
+  /** Related use case IDs */
+  readonly relatedUseCases: readonly string[];
+  /** Ordered steps in the flow */
+  readonly steps: readonly FlowStep[];
+  /** Preconditions for the flow */
+  readonly preconditions: readonly string[];
+  /** Expected outcomes */
+  readonly outcomes: readonly string[];
+}
+
+// ============================================================================
+// Design System Types
+// ============================================================================
+
+/**
+ * A design token entry
+ */
+export interface DesignToken {
+  /** Token category (color, spacing, typography, etc.) */
+  readonly category: string;
+  /** Token name */
+  readonly name: string;
+  /** Token value */
+  readonly value: string;
+  /** Token description */
+  readonly description: string;
+}
+
+/**
+ * A component in the design system
+ */
+export interface DesignComponent {
+  /** Component name */
+  readonly name: string;
+  /** Component description */
+  readonly description: string;
+  /** Component variants */
+  readonly variants: readonly string[];
+}
+
+/**
+ * Design system specification
+ */
+export interface DesignSystem {
+  /** Design tokens */
+  readonly tokens: readonly DesignToken[];
+  /** Reusable components */
+  readonly components: readonly DesignComponent[];
+  /** Technology stack reference */
+  readonly technologyStack: string;
+}
+
+// ============================================================================
+// Agent Configuration and Session Types
+// ============================================================================
+
+/**
+ * UI Spec Writer Agent configuration options
+ */
+export interface UISpecWriterAgentConfig {
+  /** Base path for scratchpad (defaults to .ad-sdlc/scratchpad) */
+  readonly scratchpadBasePath?: string;
+  /** Output directory for public UI docs (defaults to docs/ui) */
+  readonly publicDocsPath?: string;
+}
+
+/**
+ * UI spec generation session
+ */
+export interface UISpecGenerationSession {
+  /** Session identifier */
+  readonly sessionId: string;
+  /** Project identifier */
+  readonly projectId: string;
+  /** Current generation status */
+  readonly status: UISpecGenerationStatus;
+  /** Parsed SRS extract */
+  readonly parsedSRS: ParsedSRSForUI;
+  /** Whether this stage was auto-skipped */
+  readonly skipped: boolean;
+  /** Skip reason (when skipped is true) */
+  readonly skipReason?: string;
+  /** Generated screens (when completed) */
+  readonly screens?: readonly ScreenSpec[];
+  /** Generated flows (when completed) */
+  readonly flows?: readonly FlowSpec[];
+  /** Generated design system (when completed) */
+  readonly designSystem?: DesignSystem;
+  /** Session start time (ISO timestamp) */
+  readonly startedAt: string;
+  /** Session last update time (ISO timestamp) */
+  readonly updatedAt: string;
+  /** Error message if failed */
+  readonly errorMessage?: string;
+  /** Non-fatal warnings accumulated during generation */
+  readonly warnings?: readonly string[];
+}
+
+/**
+ * UI spec generation result
+ */
+export interface UISpecGenerationResult {
+  /** Whether generation was successful */
+  readonly success: boolean;
+  /** Whether the stage was skipped */
+  readonly skipped: boolean;
+  /** Skip reason (when skipped is true) */
+  readonly skipReason?: string;
+  /** Project identifier */
+  readonly projectId: string;
+  /** Paths to generated screen spec files */
+  readonly screenPaths: readonly string[];
+  /** Paths to generated flow spec files */
+  readonly flowPaths: readonly string[];
+  /** Path to the design system document */
+  readonly designSystemPath: string;
+  /** Path to the UI README index */
+  readonly readmePath: string;
+  /** Generation statistics */
+  readonly stats: UISpecGenerationStats;
+  /** Non-fatal warnings from generation */
+  readonly warnings?: readonly string[];
+}
+
+/**
+ * Statistics about the UI spec generation process
+ */
+export interface UISpecGenerationStats {
+  /** Number of use cases processed */
+  readonly useCasesProcessed: number;
+  /** Number of screens generated */
+  readonly screensGenerated: number;
+  /** Number of flows generated */
+  readonly flowsGenerated: number;
+  /** Number of design tokens generated */
+  readonly designTokensGenerated: number;
+  /** Total processing time in milliseconds */
+  readonly processingTimeMs: number;
+}

--- a/tests/ad-sdlc-orchestrator/AdsdlcOrchestratorAgent.test.ts
+++ b/tests/ad-sdlc-orchestrator/AdsdlcOrchestratorAgent.test.ts
@@ -1212,8 +1212,8 @@ describe('AdsdlcOrchestratorAgent', () => {
 });
 
 describe('GREENFIELD_STAGES', () => {
-  it('should define 18 stages', () => {
-    expect(GREENFIELD_STAGES).toHaveLength(18);
+  it('should define 19 stages', () => {
+    expect(GREENFIELD_STAGES).toHaveLength(19);
   });
 
   it('should start with initialization and end with doc_indexing', () => {

--- a/tests/e2e/fixtures/pipeline-fixtures.ts
+++ b/tests/e2e/fixtures/pipeline-fixtures.ts
@@ -467,6 +467,27 @@ export const techDecisionOutput = [
 ].join('\n');
 
 /**
+ * Output from the ui-spec-writer agent.
+ * Generates UI screen specifications and user flow documents from SRS.
+ */
+export const uiSpecWriterOutput = JSON.stringify({
+  success: true,
+  skipped: false,
+  projectId: 'smoke-test-project',
+  screenPaths: ['docs/ui/screens/SCR-001-login.md', 'docs/ui/screens/SCR-002-dashboard.md'],
+  flowPaths: ['docs/ui/flows/FLW-001-user-login.md'],
+  designSystemPath: 'docs/ui/design-system.md',
+  readmePath: 'docs/ui/README.md',
+  stats: {
+    useCasesProcessed: 2,
+    screensGenerated: 2,
+    flowsGenerated: 1,
+    designTokensGenerated: 12,
+    processingTimeMs: 80,
+  },
+});
+
+/**
  * Complete response map for all Greenfield pipeline agent types.
  * Keys match the agentType field in GREENFIELD_STAGES.
  */
@@ -500,6 +521,7 @@ export const GREENFIELD_RESPONSES: Record<string, string> = {
   'repo-detector': repoDetectorOutput,
   'github-repo-setup': githubRepoSetupOutput,
   'sds-writer': sdsOutput,
+  'ui-spec-writer': uiSpecWriterOutput,
   'threat-model-writer': threatModelOutput,
   'tech-decision-writer': techDecisionOutput,
   'issue-generator': issueGeneratorOutput,

--- a/tests/ui-spec-writer/UISpecWriterAgent.test.ts
+++ b/tests/ui-spec-writer/UISpecWriterAgent.test.ts
@@ -550,10 +550,16 @@ This is a web application with no defined features yet.
       const projectId = 'test-project';
       setupSRS(projectId);
 
+      // Create a regular file at the output path so mkdirSync fails
+      // when trying to create subdirectories under it (cross-platform).
+      const blockerFile = path.join(testDocsPath, 'blocker');
+      fs.mkdirSync(testDocsPath, { recursive: true });
+      fs.writeFileSync(blockerFile, 'not-a-directory', 'utf-8');
+
       const agent = new UISpecWriterAgent({
         scratchpadBasePath: testBasePath,
-        // Point to a read-only path to trigger write error
-        publicDocsPath: '/proc/nonexistent/ui',
+        // mkdirSync will fail: can't create dirs inside a regular file
+        publicDocsPath: path.join(blockerFile, 'ui'),
       });
       await agent.initialize();
 

--- a/tests/ui-spec-writer/UISpecWriterAgent.test.ts
+++ b/tests/ui-spec-writer/UISpecWriterAgent.test.ts
@@ -1,0 +1,875 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import {
+  UISpecWriterAgent,
+  getUISpecWriterAgent,
+  resetUISpecWriterAgent,
+  UI_SPEC_WRITER_AGENT_ID,
+} from '../../src/ui-spec-writer/UISpecWriterAgent.js';
+import { SRSNotFoundError, SessionStateError } from '../../src/ui-spec-writer/errors.js';
+import { detectScreens, slugifyScreen } from '../../src/ui-spec-writer/ScreenDetector.js';
+import { mapFlows, slugifyFlow } from '../../src/ui-spec-writer/FlowMapper.js';
+import {
+  generateDesignSystem,
+  deriveComponents,
+} from '../../src/ui-spec-writer/DesignSystemGenerator.js';
+
+describe('UISpecWriterAgent', () => {
+  const testBasePath = path.join(process.cwd(), 'tests', 'ui-spec-writer', 'test-scratchpad');
+  const testDocsPath = path.join(process.cwd(), 'tests', 'ui-spec-writer', 'test-docs');
+
+  const sampleSRS = `---
+doc_id: SRS-test-project
+title: Test Product
+version: 1.0.0
+status: Approved
+---
+
+# Software Requirements Specification: Test Product
+
+## 2. Software Features
+
+### SF-001: User Authentication
+
+User authentication with login and registration.
+
+### SF-002: Dashboard
+
+Dashboard screen displaying user data and analytics.
+
+### SF-003: Data Export
+
+Export data in CSV and JSON formats.
+
+## 3. Use Cases
+
+### UC-001: Login
+
+**Description**
+User logs into the application.
+
+**Actors**
+- User
+
+**Preconditions**
+- User has a registered account
+
+**Steps**
+1. User opens the login page
+2. User enters email and password
+3. User clicks the login button
+4. System validates credentials
+5. System displays the dashboard
+
+**Postconditions**
+- User is authenticated and sees the dashboard
+
+### UC-002: View Dashboard
+
+**Description**
+User views the dashboard with analytics data.
+
+**Actors**
+- User
+
+**Steps**
+1. User navigates to the dashboard
+2. System displays analytics summary
+3. User views charts and metrics
+
+**Postconditions**
+- User can see their data
+
+### UC-003: Export Data
+
+**Description**
+User exports data from the dashboard.
+
+**Actors**
+- User
+
+**Preconditions**
+- User is authenticated
+
+**Steps**
+1. User clicks the export button
+2. User selects export format
+3. System generates the export file
+4. System displays download link
+
+**Postconditions**
+- User receives the exported file
+`;
+
+  const cliSRS = `---
+doc_id: SRS-cli-project
+title: CLI Tool
+version: 1.0.0
+status: Approved
+---
+
+# Software Requirements Specification: CLI Tool
+
+This is a command-line tool for data processing.
+
+## 2. Software Features
+
+### SF-001: Data Processing
+
+Command-line data processing pipeline.
+`;
+
+  const apiSRS = `---
+doc_id: SRS-api-project
+title: API Server
+version: 1.0.0
+status: Approved
+---
+
+# Software Requirements Specification: API Server
+
+This is a REST API server for data management.
+
+## 2. Software Features
+
+### SF-001: API Endpoints
+
+REST API endpoints for CRUD operations.
+`;
+
+  const librarySRS = `---
+doc_id: SRS-lib-project
+title: Utils Library
+version: 1.0.0
+status: Approved
+---
+
+# Software Requirements Specification: Utils Library
+
+This is a utility library for string manipulation.
+
+## 2. Software Features
+
+### SF-001: String Utils
+
+SDK for string processing.
+`;
+
+  const mobileSRS = `---
+doc_id: SRS-mobile-project
+title: Mobile App
+version: 1.0.0
+status: Approved
+---
+
+# Software Requirements Specification: Mobile App
+
+This is a mobile app built with React Native for iOS and Android.
+
+## 3. Use Cases
+
+### UC-001: Login
+
+**Description**
+User logs into the mobile app.
+
+**Steps**
+1. User opens the app
+2. User enters credentials
+3. User taps login button
+`;
+
+  const setupSRS = (projectId: string, content: string = sampleSRS): void => {
+    const docsDir = path.join(testBasePath, 'documents', projectId);
+    fs.mkdirSync(docsDir, { recursive: true });
+    fs.writeFileSync(path.join(docsDir, 'srs.md'), content, 'utf-8');
+  };
+
+  beforeEach(() => {
+    if (fs.existsSync(testBasePath)) {
+      fs.rmSync(testBasePath, { recursive: true, force: true });
+    }
+    if (fs.existsSync(testDocsPath)) {
+      fs.rmSync(testDocsPath, { recursive: true, force: true });
+    }
+    resetUISpecWriterAgent();
+  });
+
+  afterEach(() => {
+    if (fs.existsSync(testBasePath)) {
+      fs.rmSync(testBasePath, { recursive: true, force: true });
+    }
+    if (fs.existsSync(testDocsPath)) {
+      fs.rmSync(testDocsPath, { recursive: true, force: true });
+    }
+    resetUISpecWriterAgent();
+  });
+
+  describe('constructor and IAgent interface', () => {
+    it('should construct with default config', () => {
+      const agent = new UISpecWriterAgent();
+      expect(agent.agentId).toBe(UI_SPEC_WRITER_AGENT_ID);
+      expect(agent.name).toBe('UI Specification Writer Agent');
+    });
+
+    it('should accept custom config overrides', () => {
+      const agent = new UISpecWriterAgent({
+        scratchpadBasePath: testBasePath,
+        publicDocsPath: testDocsPath,
+      });
+      expect(agent.agentId).toBe(UI_SPEC_WRITER_AGENT_ID);
+    });
+
+    it('should initialize and dispose without error', async () => {
+      const agent = new UISpecWriterAgent();
+      await agent.initialize();
+      await agent.initialize(); // idempotent
+      expect(agent.getSession()).toBeNull();
+      await agent.dispose();
+      expect(agent.getSession()).toBeNull();
+    });
+  });
+
+  describe('singleton', () => {
+    it('should return the same instance on repeated calls', () => {
+      const a = getUISpecWriterAgent();
+      const b = getUISpecWriterAgent();
+      expect(a).toBe(b);
+    });
+
+    it('should return a fresh instance after reset', () => {
+      const a = getUISpecWriterAgent();
+      resetUISpecWriterAgent();
+      const b = getUISpecWriterAgent();
+      expect(a).not.toBe(b);
+    });
+  });
+
+  describe('startSession', () => {
+    it('should create a session when SRS exists', async () => {
+      const projectId = 'test-project';
+      setupSRS(projectId);
+
+      const agent = new UISpecWriterAgent({
+        scratchpadBasePath: testBasePath,
+        publicDocsPath: testDocsPath,
+      });
+      await agent.initialize();
+
+      const session = await agent.startSession(projectId);
+
+      expect(session.projectId).toBe(projectId);
+      expect(session.status).toBe('pending');
+      expect(session.parsedSRS.documentId).toBe('SRS-test-project');
+      expect(session.parsedSRS.productName).toBe('Test Product');
+      expect(session.parsedSRS.useCases.length).toBe(3);
+      expect(session.parsedSRS.features.length).toBe(3);
+      expect(session.skipped).toBe(false);
+      expect(session.sessionId).toBeTruthy();
+    });
+
+    it('should throw SRSNotFoundError when SRS is missing', async () => {
+      const projectId = 'no-srs';
+      const docsDir = path.join(testBasePath, 'documents', projectId);
+      fs.mkdirSync(docsDir, { recursive: true });
+
+      const agent = new UISpecWriterAgent({
+        scratchpadBasePath: testBasePath,
+        publicDocsPath: testDocsPath,
+      });
+
+      await expect(agent.startSession(projectId)).rejects.toThrow(SRSNotFoundError);
+    });
+
+    it('should add a warning when SRS has no use cases or features', async () => {
+      const projectId = 'empty-srs';
+      const docsDir = path.join(testBasePath, 'documents', projectId);
+      fs.mkdirSync(docsDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(docsDir, 'srs.md'),
+        `---
+doc_id: SRS-empty
+title: Empty
+---
+# Software Requirements Specification: Empty
+
+This is a web application with no defined features yet.
+`,
+        'utf-8'
+      );
+
+      const agent = new UISpecWriterAgent({
+        scratchpadBasePath: testBasePath,
+        publicDocsPath: testDocsPath,
+      });
+
+      const session = await agent.startSession(projectId);
+      expect(session.parsedSRS.useCases.length).toBe(0);
+      expect(session.parsedSRS.features.length).toBe(0);
+      expect(session.warnings).toBeDefined();
+      expect(session.warnings?.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('auto-skip for non-UI projects', () => {
+    it('should auto-skip for CLI projects', async () => {
+      const projectId = 'cli-project';
+      setupSRS(projectId, cliSRS);
+
+      const agent = new UISpecWriterAgent({
+        scratchpadBasePath: testBasePath,
+        publicDocsPath: testDocsPath,
+      });
+
+      const session = await agent.startSession(projectId);
+      expect(session.skipped).toBe(true);
+      expect(session.skipReason).toContain('cli');
+      expect(session.status).toBe('completed');
+    });
+
+    it('should auto-skip for API-only projects', async () => {
+      const projectId = 'api-project';
+      setupSRS(projectId, apiSRS);
+
+      const agent = new UISpecWriterAgent({
+        scratchpadBasePath: testBasePath,
+        publicDocsPath: testDocsPath,
+      });
+
+      const session = await agent.startSession(projectId);
+      expect(session.skipped).toBe(true);
+      expect(session.skipReason).toContain('api');
+    });
+
+    it('should auto-skip for library projects', async () => {
+      const projectId = 'lib-project';
+      setupSRS(projectId, librarySRS);
+
+      const agent = new UISpecWriterAgent({
+        scratchpadBasePath: testBasePath,
+        publicDocsPath: testDocsPath,
+      });
+
+      const session = await agent.startSession(projectId);
+      expect(session.skipped).toBe(true);
+      expect(session.skipReason).toContain('library');
+    });
+
+    it('should not skip for web projects', async () => {
+      const projectId = 'web-project';
+      setupSRS(projectId, sampleSRS);
+
+      const agent = new UISpecWriterAgent({
+        scratchpadBasePath: testBasePath,
+        publicDocsPath: testDocsPath,
+      });
+
+      const session = await agent.startSession(projectId);
+      expect(session.skipped).toBe(false);
+    });
+
+    it('should not skip for mobile projects', async () => {
+      const projectId = 'mobile-project';
+      setupSRS(projectId, mobileSRS);
+
+      const agent = new UISpecWriterAgent({
+        scratchpadBasePath: testBasePath,
+        publicDocsPath: testDocsPath,
+      });
+
+      const session = await agent.startSession(projectId);
+      expect(session.skipped).toBe(false);
+      expect(session.parsedSRS.projectType).toBe('mobile');
+    });
+
+    it('should return skipped result from generateFromProject for CLI', async () => {
+      const projectId = 'cli-project';
+      setupSRS(projectId, cliSRS);
+
+      const agent = new UISpecWriterAgent({
+        scratchpadBasePath: testBasePath,
+        publicDocsPath: testDocsPath,
+      });
+
+      const result = await agent.generateFromProject(projectId);
+      expect(result.success).toBe(true);
+      expect(result.skipped).toBe(true);
+      expect(result.skipReason).toContain('cli');
+      expect(result.screenPaths.length).toBe(0);
+      expect(result.flowPaths.length).toBe(0);
+    });
+  });
+
+  describe('generateFromProject', () => {
+    it('should generate screens, flows, and design system', async () => {
+      const projectId = 'test-project';
+      setupSRS(projectId);
+
+      const agent = new UISpecWriterAgent({
+        scratchpadBasePath: testBasePath,
+        publicDocsPath: testDocsPath,
+      });
+      await agent.initialize();
+
+      const result = await agent.generateFromProject(projectId);
+
+      expect(result.success).toBe(true);
+      expect(result.skipped).toBe(false);
+      expect(result.stats.useCasesProcessed).toBe(3);
+      expect(result.stats.screensGenerated).toBeGreaterThan(0);
+      expect(result.stats.flowsGenerated).toBeGreaterThan(0);
+      expect(result.stats.designTokensGenerated).toBeGreaterThan(0);
+
+      // Check that output files were written
+      expect(result.screenPaths.length).toBeGreaterThan(0);
+      for (const p of result.screenPaths) {
+        expect(fs.existsSync(p)).toBe(true);
+      }
+
+      expect(result.flowPaths.length).toBeGreaterThan(0);
+      for (const p of result.flowPaths) {
+        expect(fs.existsSync(p)).toBe(true);
+      }
+
+      expect(fs.existsSync(result.designSystemPath)).toBe(true);
+      expect(fs.existsSync(result.readmePath)).toBe(true);
+
+      // Verify README content has frontmatter
+      const readmeContent = fs.readFileSync(result.readmePath, 'utf-8');
+      expect(readmeContent).toContain('---');
+      expect(readmeContent).toContain('doc_id: ui-readme');
+      expect(readmeContent).toContain('Test Product');
+      expect(readmeContent).toContain('SCR-');
+      expect(readmeContent).toContain('FLW-');
+
+      // Verify screen files have frontmatter
+      const screenContent = fs.readFileSync(result.screenPaths[0] as string, 'utf-8');
+      expect(screenContent).toContain('doc_id:');
+      expect(screenContent).toContain('version: 1.0.0');
+      expect(screenContent).toContain('status: Draft');
+      // Verify Data Source column in screen files
+      expect(screenContent).toContain('Data Source');
+
+      // Verify flow files have frontmatter
+      const flowContent = fs.readFileSync(result.flowPaths[0] as string, 'utf-8');
+      expect(flowContent).toContain('doc_id:');
+      expect(flowContent).toContain('version: 1.0.0');
+
+      // Verify design system has frontmatter
+      const dsContent = fs.readFileSync(result.designSystemPath, 'utf-8');
+      expect(dsContent).toContain('doc_id: design-system');
+    });
+
+    it('should update session status through lifecycle', async () => {
+      const projectId = 'test-project';
+      setupSRS(projectId);
+
+      const agent = new UISpecWriterAgent({
+        scratchpadBasePath: testBasePath,
+        publicDocsPath: testDocsPath,
+      });
+      await agent.initialize();
+
+      await agent.generateFromProject(projectId);
+
+      const session = agent.getSession();
+      expect(session).not.toBeNull();
+      expect(session?.status).toBe('completed');
+      expect(session?.screens).toBeDefined();
+      expect(session?.flows).toBeDefined();
+      expect(session?.designSystem).toBeDefined();
+    });
+  });
+
+  describe('finalize', () => {
+    it('should throw SessionStateError when no session', async () => {
+      const agent = new UISpecWriterAgent({
+        scratchpadBasePath: testBasePath,
+        publicDocsPath: testDocsPath,
+      });
+
+      await expect(agent.finalize()).rejects.toThrow(SessionStateError);
+    });
+
+    it('should throw SessionStateError when session not completed', async () => {
+      const projectId = 'test-project';
+      setupSRS(projectId);
+
+      const agent = new UISpecWriterAgent({
+        scratchpadBasePath: testBasePath,
+        publicDocsPath: testDocsPath,
+      });
+
+      await agent.startSession(projectId);
+      // Session is in 'pending' state, not 'completed'
+      await expect(agent.finalize()).rejects.toThrow(SessionStateError);
+    });
+
+    it('should finalize successfully after generation', async () => {
+      const projectId = 'test-project';
+      setupSRS(projectId);
+
+      const agent = new UISpecWriterAgent({
+        scratchpadBasePath: testBasePath,
+        publicDocsPath: testDocsPath,
+      });
+      await agent.initialize();
+
+      await agent.generateFromProject(projectId);
+
+      // Clean up output files to test that finalize rewrites them
+      if (fs.existsSync(testDocsPath)) {
+        fs.rmSync(testDocsPath, { recursive: true, force: true });
+      }
+
+      const result = await agent.finalize();
+      expect(result.success).toBe(true);
+      expect(result.skipped).toBe(false);
+      expect(result.screenPaths.length).toBeGreaterThan(0);
+    });
+
+    it('should return skipped result when session was skipped', async () => {
+      const projectId = 'cli-project';
+      setupSRS(projectId, cliSRS);
+
+      const agent = new UISpecWriterAgent({
+        scratchpadBasePath: testBasePath,
+        publicDocsPath: testDocsPath,
+      });
+
+      await agent.generateFromProject(projectId);
+      const result = await agent.finalize();
+      expect(result.success).toBe(true);
+      expect(result.skipped).toBe(true);
+    });
+  });
+
+  describe('error handling', () => {
+    it('should set session status to failed on generation error', async () => {
+      const projectId = 'test-project';
+      setupSRS(projectId);
+
+      const agent = new UISpecWriterAgent({
+        scratchpadBasePath: testBasePath,
+        // Point to a read-only path to trigger write error
+        publicDocsPath: '/proc/nonexistent/ui',
+      });
+      await agent.initialize();
+
+      await expect(agent.generateFromProject(projectId)).rejects.toThrow();
+
+      const session = agent.getSession();
+      expect(session?.status).toBe('failed');
+      expect(session?.errorMessage).toBeDefined();
+    });
+  });
+});
+
+describe('ScreenDetector', () => {
+  describe('slugifyScreen', () => {
+    it('should convert title to slug', () => {
+      expect(slugifyScreen('User Login')).toBe('user-login');
+      expect(slugifyScreen('Dashboard View')).toBe('dashboard-view');
+      expect(slugifyScreen('')).toBe('screen');
+      expect(slugifyScreen('  Special!@# Characters  ')).toBe('special-characters');
+    });
+  });
+
+  describe('detectScreens', () => {
+    it('should detect screens from use cases', () => {
+      const useCases = [
+        {
+          id: 'UC-001',
+          title: 'Login',
+          description: 'User logs in',
+          actors: ['User'],
+          steps: ['User enters email', 'User clicks login button', 'System displays dashboard'],
+          preconditions: [],
+          postconditions: [],
+        },
+        {
+          id: 'UC-002',
+          title: 'View Dashboard',
+          description: 'User views dashboard',
+          actors: ['User'],
+          steps: ['User navigates to dashboard', 'System displays data'],
+          preconditions: [],
+          postconditions: [],
+        },
+      ];
+
+      const screens = detectScreens(useCases, []);
+
+      expect(screens.length).toBe(2);
+      expect(screens[0]?.id).toBe('SCR-001');
+      expect(screens[0]?.relatedUseCases).toContain('UC-001');
+      expect(screens[1]?.id).toBe('SCR-002');
+    });
+
+    it('should extract UI elements from steps', () => {
+      const useCases = [
+        {
+          id: 'UC-001',
+          title: 'Login',
+          description: 'Login screen',
+          actors: ['User'],
+          steps: [
+            'User enters email',
+            'User enters password',
+            'User clicks login button',
+            'System displays welcome message',
+          ],
+          preconditions: [],
+          postconditions: [],
+        },
+      ];
+
+      const screens = detectScreens(useCases, []);
+      expect(screens[0]?.elements.length).toBeGreaterThan(0);
+
+      const elementTypes = screens[0]?.elements.map((e) => e.type) ?? [];
+      expect(elementTypes).toContain('input');
+      expect(elementTypes).toContain('button');
+      expect(elementTypes).toContain('display');
+    });
+
+    it('should detect screens from UI-facing features', () => {
+      const features = [
+        {
+          id: 'SF-001',
+          title: 'Dashboard',
+          description: 'A dashboard screen showing analytics data.',
+        },
+        {
+          id: 'SF-002',
+          title: 'Data Processing',
+          description: 'Backend processing pipeline.',
+        },
+      ];
+
+      const screens = detectScreens([], features);
+      // Only SF-001 should generate a screen (has "screen" keyword)
+      expect(screens.length).toBe(1);
+      expect(screens[0]?.relatedFeatures).toContain('SF-001');
+    });
+
+    it('should return empty array for no input', () => {
+      const screens = detectScreens([], []);
+      expect(screens.length).toBe(0);
+    });
+
+    it('should link navigation targets between screens', () => {
+      const useCases = [
+        {
+          id: 'UC-001',
+          title: 'Login',
+          description: 'Login',
+          actors: ['User'],
+          steps: ['Enter credentials', 'Click login'],
+          preconditions: [],
+          postconditions: [],
+        },
+        {
+          id: 'UC-002',
+          title: 'Register',
+          description: 'Register',
+          actors: ['User'],
+          steps: ['Enter details', 'Click register'],
+          preconditions: [],
+          postconditions: [],
+        },
+      ];
+
+      const screens = detectScreens(useCases, []);
+      expect(screens.length).toBe(2);
+      // Sequential flow: first screen navigates to second
+      expect(screens[0]?.navigationTargets.length).toBeGreaterThan(0);
+    });
+  });
+});
+
+describe('FlowMapper', () => {
+  describe('slugifyFlow', () => {
+    it('should convert title to slug', () => {
+      expect(slugifyFlow('User Login Flow')).toBe('user-login-flow');
+      expect(slugifyFlow('')).toBe('flow');
+    });
+  });
+
+  describe('mapFlows', () => {
+    it('should generate flows from multi-step use cases', () => {
+      const useCases = [
+        {
+          id: 'UC-001',
+          title: 'Login',
+          description: 'User login flow',
+          actors: ['User'],
+          steps: ['Enter email', 'Enter password', 'Click login', 'View dashboard'],
+          preconditions: ['User has account'],
+          postconditions: ['User is authenticated'],
+        },
+      ];
+
+      const screens = [
+        {
+          id: 'SCR-001',
+          nameSlug: 'login',
+          title: 'Login',
+          purpose: 'Login screen',
+          relatedUseCases: ['UC-001'],
+          relatedFeatures: [],
+          elements: [],
+          navigationTargets: [],
+        },
+      ];
+
+      const flows = mapFlows(useCases, screens);
+
+      expect(flows.length).toBe(1);
+      expect(flows[0]?.id).toBe('FLW-001');
+      expect(flows[0]?.relatedUseCases).toContain('UC-001');
+      expect(flows[0]?.steps.length).toBeGreaterThan(0);
+      expect(flows[0]?.preconditions).toContain('User has account');
+      expect(flows[0]?.outcomes).toContain('User is authenticated');
+    });
+
+    it('should skip single-step use cases', () => {
+      const useCases = [
+        {
+          id: 'UC-001',
+          title: 'Simple Action',
+          description: 'One-step action',
+          actors: ['User'],
+          steps: ['Do something'],
+          preconditions: [],
+          postconditions: [],
+        },
+      ];
+
+      const screens = [
+        {
+          id: 'SCR-001',
+          nameSlug: 'screen',
+          title: 'Screen',
+          purpose: 'Screen',
+          relatedUseCases: ['UC-001'],
+          relatedFeatures: [],
+          elements: [],
+          navigationTargets: [],
+        },
+      ];
+
+      const flows = mapFlows(useCases, screens);
+      expect(flows.length).toBe(0);
+    });
+
+    it('should return empty array when no screens', () => {
+      const useCases = [
+        {
+          id: 'UC-001',
+          title: 'Login',
+          description: 'Login',
+          actors: ['User'],
+          steps: ['Step 1', 'Step 2'],
+          preconditions: [],
+          postconditions: [],
+        },
+      ];
+
+      const flows = mapFlows(useCases, []);
+      expect(flows.length).toBe(0);
+    });
+  });
+});
+
+describe('DesignSystemGenerator', () => {
+  describe('generateDesignSystem', () => {
+    it('should generate web design system by default', () => {
+      const ds = generateDesignSystem('web', []);
+      expect(ds.tokens.length).toBeGreaterThan(0);
+      expect(ds.technologyStack).toContain('Web');
+      // Should have at least color, spacing, and typography tokens
+      const categories = new Set(ds.tokens.map((t) => t.category));
+      expect(categories.has('color')).toBe(true);
+      expect(categories.has('spacing')).toBe(true);
+      expect(categories.has('typography')).toBe(true);
+    });
+
+    it('should generate mobile design system', () => {
+      const ds = generateDesignSystem('mobile', []);
+      expect(ds.technologyStack).toContain('Mobile');
+      const values = ds.tokens.map((t) => t.value);
+      // Mobile tokens should use dp/sp units
+      expect(values.some((v) => v.includes('dp') || v.includes('sp'))).toBe(true);
+    });
+
+    it('should generate desktop design system', () => {
+      const ds = generateDesignSystem('desktop', []);
+      expect(ds.technologyStack).toContain('Desktop');
+    });
+
+    it('should always include navigation and appbar components', () => {
+      const ds = generateDesignSystem('web', []);
+      const names = ds.components.map((c) => c.name);
+      expect(names).toContain('AppBar');
+      expect(names).toContain('Navigation');
+    });
+  });
+
+  describe('deriveComponents', () => {
+    it('should derive button component from screen elements', () => {
+      const screens = [
+        {
+          id: 'SCR-001',
+          nameSlug: 'test',
+          title: 'Test',
+          purpose: 'Test',
+          relatedUseCases: [],
+          relatedFeatures: [],
+          elements: [
+            {
+              id: 'btn-1',
+              type: 'button',
+              label: 'Click',
+              dataSource: 'User action',
+              behavior: 'Click',
+            },
+          ],
+          navigationTargets: [],
+        },
+      ];
+
+      const components = deriveComponents(screens);
+      const names = components.map((c) => c.name);
+      expect(names).toContain('Button');
+    });
+
+    it('should derive input component from screen elements', () => {
+      const screens = [
+        {
+          id: 'SCR-001',
+          nameSlug: 'test',
+          title: 'Test',
+          purpose: 'Test',
+          relatedUseCases: [],
+          relatedFeatures: [],
+          elements: [
+            {
+              id: 'inp-1',
+              type: 'input',
+              label: 'Email',
+              dataSource: 'User input',
+              behavior: 'Enter email',
+            },
+          ],
+          navigationTargets: [],
+        },
+      ];
+
+      const components = deriveComponents(screens);
+      const names = components.map((c) => c.name);
+      expect(names).toContain('TextInput');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Release PR merging `develop` into `main`.

Includes the UI Specification Writer agent (#754), the last sub-issue of epic #747.

### Changes
- New `ui-spec-writer` agent module with screen detection, flow mapping, and design system generation
- Pipeline integration with auto-skip for CLI/API/library projects
- YAML frontmatter on all generated documents
- Unit tests and documentation updates

### Related Issues
- Closes #754
- Part of #747

See PR #770 for full implementation details and review summary.