### PR TITLE
fix(tests): update e2e fixtures and cross-platform test for ui-spec-writer

### DIFF
--- a/tests/e2e/fixtures/pipeline-fixtures.ts
+++ b/tests/e2e/fixtures/pipeline-fixtures.ts
@@ -467,6 +467,27 @@ export const techDecisionOutput = [
 ].join('\n');
 
 /**
+ * Output from the ui-spec-writer agent.
+ * Generates UI screen specifications and user flow documents from SRS.
+ */
+export const uiSpecWriterOutput = JSON.stringify({
+  success: true,
+  skipped: false,
+  projectId: 'smoke-test-project',
+  screenPaths: ['docs/ui/screens/SCR-001-login.md', 'docs/ui/screens/SCR-002-dashboard.md'],
+  flowPaths: ['docs/ui/flows/FLW-001-user-login.md'],
+  designSystemPath: 'docs/ui/design-system.md',
+  readmePath: 'docs/ui/README.md',
+  stats: {
+    useCasesProcessed: 2,
+    screensGenerated: 2,
+    flowsGenerated: 1,
+    designTokensGenerated: 12,
+    processingTimeMs: 80,
+  },
+});
+
+/**
  * Complete response map for all Greenfield pipeline agent types.
  * Keys match the agentType field in GREENFIELD_STAGES.
  */
@@ -500,6 +521,7 @@ export const GREENFIELD_RESPONSES: Record<string, string> = {
   'repo-detector': repoDetectorOutput,
   'github-repo-setup': githubRepoSetupOutput,
   'sds-writer': sdsOutput,
+  'ui-spec-writer': uiSpecWriterOutput,
   'threat-model-writer': threatModelOutput,
   'tech-decision-writer': techDecisionOutput,
   'issue-generator': issueGeneratorOutput,

--- a/tests/ui-spec-writer/UISpecWriterAgent.test.ts
+++ b/tests/ui-spec-writer/UISpecWriterAgent.test.ts
@@ -550,10 +550,16 @@ This is a web application with no defined features yet.
       const projectId = 'test-project';
       setupSRS(projectId);
 
+      // Create a regular file at the output path so mkdirSync fails
+      // when trying to create subdirectories under it (cross-platform).
+      const blockerFile = path.join(testDocsPath, 'blocker');
+      fs.mkdirSync(testDocsPath, { recursive: true });
+      fs.writeFileSync(blockerFile, 'not-a-directory', 'utf-8');
+
       const agent = new UISpecWriterAgent({
         scratchpadBasePath: testBasePath,
-        // Point to a read-only path to trigger write error
-        publicDocsPath: '/proc/nonexistent/ui',
+        // mkdirSync will fail: can't create dirs inside a regular file
+        publicDocsPath: path.join(blockerFile, 'ui'),
       });
       await agent.initialize();
 


### PR DESCRIPTION
## Summary

Fix CI test failures from #754 (UI Specification Writer agent).

### Fixes
1. **E2E pipeline stage count**: Added `ui-spec-writer` mock response to `GREENFIELD_RESPONSES` fixture map
2. **Windows path test**: Replaced Linux-specific `/proc/nonexistent` with cross-platform ENOTDIR approach

Relates to #754