### PR TITLE
docs(architecture): add v0.1 Hybrid Pipeline RFC + 22 issue drafts

### DIFF
--- a/.github/.issue-drafts/v0.1/AD-01.md
+++ b/.github/.issue-drafts/v0.1/AD-01.md
@@ -1,0 +1,66 @@
+---
+issue_id: AD-01
+phase: 0
+type: docs
+size: S
+priority: high
+title: "docs(architecture): RFC v0.1 Hybrid Pipeline Architecture 게시"
+labels: [phase/0, area/docs, type/docs, size/S]
+depends_on: []
+blocks: [AD-02, AD-03]
+branch: docs/v01-rfc
+---
+
+# docs(architecture): RFC v0.1 Hybrid Pipeline Architecture 게시
+
+## What
+
+`docs/architecture/v0.1-hybrid-pipeline-rfc.md`를 develop 브랜치에 머지하고, 이를 v0.1 마이그레이션의 부모 RFC로 확정한다.
+
+- 산출물: `docs/architecture/v0.1-hybrid-pipeline-rfc.md` (이미 작성된 초안)
+- 범위: 3-tier 아키텍처(Pipeline Control Plane / Execution Layer / Knowledge Layer) 정의, ExecutionAdapter 인터페이스 시그니처, 5 phase 마이그레이션 계획, 위험 등록부, 측정 지표
+
+## Why
+
+- v0.0.1 README의 "built with Claude Agent SDK" 진술이 `package.json` 의존성과 불일치 (raw `@anthropic-ai/sdk`만 존재)
+- claude-config v2.3.0 plugin의 자산을 코드 경로상 활용 못 함
+- `.claude/agents/`에 사양 위반 1건(`doc-code-comparator.md` frontmatter 누락) 잠복
+- 후속 18개 이슈가 본 RFC를 인용하므로 우선 합의가 필요
+
+## Who
+
+- **Assignee**: TBD (architecture-owner)
+- **Reviewers**: 코어 메인테이너 1+, 도메인 전문가(SDLC 파이프라인) 1
+- **Approval**: LGTM ≥ 1
+
+## When
+
+- 발의: 2026-05-07
+- 검토 deadline: +5 영업일
+- 승인 시 P1 시작
+
+## Where
+
+- `docs/architecture/v0.1-hybrid-pipeline-rfc.md`
+- `docs/architecture/decisions/` (ADR 인덱스 갱신, 옵션)
+
+## How
+
+### Acceptance Criteria
+
+- [ ] RFC 문서가 develop 브랜치에 머지됨
+- [ ] RFC 본문에 명시된 5 phase·인터페이스·위험 항목이 LGTM ≥ 1 받음
+- [ ] `docs/architecture/decisions/` 인덱스(있을 시)에 ARCH-RFC-001 등록
+- [ ] INDEX.md(`.github/.issue-drafts/v0.1/INDEX.md`)에서 본 RFC 링크 동작
+
+### Test Plan
+
+문서 PR이므로 자동 테스트 없음. 수동 검토 항목:
+- [ ] 다이어그램 mermaid 렌더링 정상 (GitHub PR 미리보기)
+- [ ] 인터페이스 시그니처 컴파일 가능성 검증 (TypeScript playground)
+- [ ] 측정 지표가 `package.json scripts`로 측정 가능한 형태인지 확인
+
+### Out of Scope
+
+- 실제 코드 변경 (P1~P4에서 수행)
+- claude-config plugin 흡수 시점 결정 (AD-19에서)

--- a/.github/.issue-drafts/v0.1/AD-02.md
+++ b/.github/.issue-drafts/v0.1/AD-02.md
@@ -1,0 +1,59 @@
+---
+issue_id: AD-02
+phase: 0
+type: docs
+size: S
+priority: high
+title: "docs(architecture): Migration Guide v0.0.1 → v0.1.0 게시"
+labels: [phase/0, area/docs, type/docs, size/S]
+depends_on: [AD-01]
+blocks: [AD-13]
+branch: docs/v01-migration-guide
+---
+
+# docs(architecture): Migration Guide v0.0.1 → v0.1.0 게시
+
+## What
+
+`docs/architecture/v0.1-migration-guide.md`를 머지하여 사용자·기여자가 따라야 할 변경점·호환성·롤백 절차를 명문화한다.
+
+## Why
+
+- 외부 사용자는 npm 의존성 변경(@anthropic-ai/claude-agent-sdk 추가)을 인지해야 함
+- 기여자는 삭제될 모듈(`AgentBridge` 등)에 대한 import 변경 작업이 필요
+- 체크포인트 schema가 minor 변경되므로 v0.0.1 사용자의 진행 중 파이프라인 호환성 보장 필수
+- claude-config plugin 미설치 환경에서도 동작함을 명시 → 도입 장벽 완화
+
+## Who
+
+- **Assignee**: TBD (docs-owner)
+- **Reviewers**: 외부 사용자 대표(베타 테스터) 1+, 코어 메인테이너 1
+- **Approval**: LGTM ≥ 1
+
+## When
+
+- AD-01 머지 직후 발의
+- 검토 deadline: +3 영업일
+
+## Where
+
+- `docs/architecture/v0.1-migration-guide.md`
+
+## How
+
+### Acceptance Criteria
+
+- [ ] 머지 후 README.md에서 본 가이드를 링크로 안내
+- [ ] FAQ 섹션이 GitHub Issues에서 자주 등장하는 마이그레이션 질문 3개 이상 다룸
+- [ ] 롤백 절차가 phase별로 분리되어 있고 각각 1-step으로 실행 가능
+- [ ] `.claude/agents/*.md` 변경(AD-04, AD-05 결과)이 표로 정리됨
+- [ ] 체크포인트 schema 마이그레이션 코드 위치(추후 PR)가 명시됨
+
+### Test Plan
+
+- [ ] 이전 v0.0.1 사용자 시나리오 워크스루: `npm install` → `ad-sdlc run --resume` 동작 검증 가이드 단계 확인
+- [ ] Bedrock/Vertex 사용자 시나리오 검증 단계 포함 여부
+
+### Out of Scope
+
+- 자동 마이그레이션 도구 (코드는 AD-16에서)

--- a/.github/.issue-drafts/v0.1/AD-03.md
+++ b/.github/.issue-drafts/v0.1/AD-03.md
@@ -1,0 +1,69 @@
+---
+issue_id: AD-03
+phase: 1
+type: chore
+size: XS
+priority: medium
+title: "chore(deps): add @anthropic-ai/claude-agent-sdk dependency"
+labels: [phase/1, area/execution, type/chore, size/XS]
+depends_on: [AD-01]
+blocks: [AD-06]
+branch: chore/add-agent-sdk-dep
+---
+
+# chore(deps): add `@anthropic-ai/claude-agent-sdk` dependency
+
+## What
+
+`package.json`에 `@anthropic-ai/claude-agent-sdk` (v0.2.111 이상) 의존성을 추가하고 lock 파일을 갱신한다.
+
+## Why
+
+- AD-06(ExecutionAdapter)이 이 SDK를 필요로 함
+- 현재 `@anthropic-ai/sdk@^0.92.0`만 있어 raw API 호출 코드를 자체 구현 중
+- Opus 4.7 호환을 위해 v0.2.111+ 필수 (공식 문서 명시)
+- README에서 "Claude Agent SDK 기반" 진술의 의존성 단서 정착
+
+## Who
+
+- **Assignee**: TBD
+- **Reviewers**: 코어 메인테이너 1
+- **Approval**: LGTM ≥ 1
+
+## When
+
+- AD-01 머지 직후
+- 작업 시간: ~30분
+
+## Where
+
+- `package.json`
+- `package-lock.json`
+
+## How
+
+### Implementation Steps
+
+1. `npm install --save @anthropic-ai/claude-agent-sdk@^0.2.111`
+2. 기존 `@anthropic-ai/sdk@^0.92.0`은 P3 cutover 완료까지 **유지** (점진적 전환)
+3. peerDependencies로 분리할지 dependencies로 둘지 결정 — 본 이슈에서는 dependencies로 두고 P3에서 재검토
+
+### Acceptance Criteria
+
+- [ ] `package.json` `dependencies`에 `@anthropic-ai/claude-agent-sdk` 추가
+- [ ] `npm install` clean 실행 통과
+- [ ] `npm run build` 통과 (사용처 없으므로 영향 0)
+- [ ] `npm test` 통과
+- [ ] CI 워크플로 통과
+- [ ] 보안 audit (`npm audit`) 통과
+
+### Test Plan
+
+- [ ] 로컬 Node 18, 20에서 `npm install` 통과
+- [ ] CI matrix에서 동일 통과
+- [ ] 버전 핀 정확성 — `npm ls @anthropic-ai/claude-agent-sdk` 출력 확인
+
+### Out of Scope
+
+- SDK 사용처 추가 (AD-06)
+- raw `@anthropic-ai/sdk` 제거 (AD-14)

--- a/.github/.issue-drafts/v0.1/AD-04.md
+++ b/.github/.issue-drafts/v0.1/AD-04.md
@@ -1,0 +1,85 @@
+---
+issue_id: AD-04
+phase: 1
+type: fix
+size: XS
+priority: high
+title: "fix(agents): doc-code-comparator.md frontmatter 추가 (사양 위반)"
+labels: [phase/1, area/agents-md, type/bug, priority/high, size/XS]
+depends_on: []
+blocks: []
+branch: fix/doc-code-comparator-frontmatter
+---
+
+# fix(agents): `doc-code-comparator.md` frontmatter 추가 (사양 위반)
+
+## What
+
+`.claude/agents/doc-code-comparator.md`가 YAML frontmatter 없이 작성되어 Claude Code 공식 사양을 위반한다. 다른 33개 에이전트와 동일한 frontmatter를 추가한다.
+
+## Why
+
+- 공식 사양: subagent는 YAML frontmatter(`name`/`description` 필수) 보유 필수 (https://code.claude.com/docs/en/sub-agents)
+- 현재 `head -1 doc-code-comparator.md` 결과 `# Doc-Code Comparator Agent`로 시작 → Claude Code가 subagent로 인식 불가
+- AD-SDLC가 Enhancement 파이프라인에서 본 에이전트를 invoke하면 fallback prompt(generic)으로 동작하여 분석 품질 저하
+- 본 이슈는 P1 게이트의 100% frontmatter 준수 목표 달성에 필수
+
+## Who
+
+- **Assignee**: TBD
+- **Reviewers**: 도메인 전문가(Doc-Code Comparator) 1
+- **Approval**: LGTM ≥ 1
+
+## When
+
+- 즉시 (사양 위반 긴급)
+- 작업 시간: ~30분
+
+## Where
+
+- `.claude/agents/doc-code-comparator.md`
+
+## How
+
+### Implementation Steps
+
+1. 기존 다른 에이전트(예: `code-reader.md`, `impact-analyzer.md`)의 frontmatter 패턴을 참고
+2. 본 에이전트의 입출력 계약(이미 본문에 기술됨)을 기반으로 description, tools 결정
+3. frontmatter 추가:
+
+```yaml
+---
+name: doc-code-comparator
+description: |
+  Doc-Code Comparator Agent. Analyzes the gap between documentation specifications
+  and actual code implementations. Detects discrepancies, missing implementations,
+  and undocumented code. Use this agent in the Enhancement pipeline after Document
+  Reader and Code Reader to produce actionable gap analysis.
+tools:
+  - Read
+  - Grep
+  - Glob
+  - Write
+model: inherit
+---
+```
+
+### Acceptance Criteria
+
+- [ ] frontmatter가 추가됨 (`---`로 시작)
+- [ ] `name: doc-code-comparator` 명시 (kebab-case)
+- [ ] `description`에 위임 트리거 키워드("Use this agent" 또는 "PROACTIVELY") 포함
+- [ ] `tools`에 본문에서 기술된 작업(읽기·검색)에 필요한 도구만 allowlist
+- [ ] `model: inherit` (project-initializer 외 다른 에이전트와 일관)
+- [ ] 다른 에이전트 변경 없음 (surgical edit)
+- [ ] frontmatter 검증 스크립트(있으면) 또는 수동 head -1 확인 통과
+
+### Test Plan
+
+- [ ] 모든 `.claude/agents/*.md`에 대해 `head -1` 결과가 `---`인지 검증하는 oneliner 통과
+- [ ] Enhancement 파이프라인 dry-run에서 Doc-Code Comparator stage가 fallback prompt 대신 실제 정의 로드
+
+### Out of Scope
+
+- 본문 내용 변경
+- 다른 에이전트 frontmatter 표준화 (별도 이슈에서)

--- a/.github/.issue-drafts/v0.1/AD-05.md
+++ b/.github/.issue-drafts/v0.1/AD-05.md
@@ -1,0 +1,83 @@
+---
+issue_id: AD-05
+phase: 1
+type: refactor
+size: S
+priority: medium
+title: "refactor(agents): validation 에이전트 ↔ src/validation-agent/ 네이밍 정합화"
+labels: [phase/1, area/agents-md, type/refactor, size/S]
+depends_on: []
+blocks: []
+branch: refactor/validation-agent-naming
+---
+
+# refactor(agents): `validation` 에이전트 ↔ `src/validation-agent/` 네이밍 정합화
+
+## What
+
+`.claude/agents/validation.md`의 `name: validation`과 `src/validation-agent/` 디렉터리명이 불일치한다. **`name: validation-agent` + 파일명 `validation-agent.md`**로 정합화한다.
+
+## Why
+
+- Dual-Layer 설계(`docs/architecture/dual-layer-design.md`)는 Intelligence 레이어(.md)와 Infrastructure 레이어(src/) 1:1 대응을 전제
+- 현재 매핑:
+  - `.claude/agents/validation.md` (name: validation)
+  - `src/validation-agent/` 디렉터리
+  - `src/agents/AgentTypeMapping.ts`에서 어느 키로 등록되는지 일치하지 않음
+- 자동 동기화 검증(예: doc-audit `validate_layer_pairing`)을 추가하려면 이름이 일치해야 함
+- Worker가 invoke 시 typo·오류 가능성 잠재
+
+## Who
+
+- **Assignee**: TBD
+- **Reviewers**: 도메인 전문가(V&V Framework) 1
+- **Approval**: LGTM ≥ 1
+
+## When
+
+- AD-04와 병렬 가능
+- 작업 시간: ~2시간 (rename + import 갱신 + 테스트)
+
+## Where
+
+- `.claude/agents/validation.md` → `.claude/agents/validation-agent.md` (rename)
+- `src/agents/AgentTypeMapping.ts` (key 갱신)
+- `src/ad-sdlc-orchestrator/types.ts` (StageName 사용처 점검)
+- `tests/**` (참조 업데이트)
+- `docs/**` (참조 업데이트)
+
+## How
+
+### Implementation Steps
+
+1. `git mv .claude/agents/validation.md .claude/agents/validation-agent.md`
+2. 파일 내 frontmatter `name: validation` → `name: validation-agent`
+3. `src/agents/AgentTypeMapping.ts`에서 `'validation'` 키 → `'validation-agent'`
+4. `grep -rn "'validation'" src/ tests/` 결과 모두 점검 후 `'validation-agent'`로 갱신 (단, `src/validation-agent/` 자체와 무관한 'validation' 단어는 변경 금지)
+5. 영향 받는 단위 테스트 갱신
+6. Stage definition (GREENFIELD_STAGES 등)에서 agentType: 'validation' → 'validation-agent' 갱신
+
+### Acceptance Criteria
+
+- [ ] `.claude/agents/validation-agent.md` 파일 존재, `validation.md` 삭제
+- [ ] `name: validation-agent`로 frontmatter 갱신
+- [ ] `src/agents/AgentTypeMapping.ts` 키 정합
+- [ ] `grep -rn "'validation'" src/` 결과에 stage·agent 키로 사용된 경우 0건
+- [ ] 모든 단위·통합 테스트 통과
+- [ ] 문서 내 cross-reference 갱신 (`docs/validation-agent.md` 등)
+
+### Test Plan
+
+- [ ] `npm test`
+- [ ] `npm run test:integration` (있을 시)
+- [ ] Greenfield 시나리오 dry-run에서 validation stage 정상 호출 확인
+
+### Out of Scope
+
+- `src/validation-agent/`의 코드 로직 변경
+- 다른 dual-layer 정합 검증 자동화 (별도 이슈)
+
+### Risks & Mitigation
+
+- 외부 사용자가 stage name `validation`을 CLI `--start-from validation`로 사용 중일 수 있음
+- 완화: alias 처리 — `--start-from validation` 입력 시 deprecation warning 후 `validation-agent`로 매핑 (1 마이너 버전 유지)

--- a/.github/.issue-drafts/v0.1/AD-06.md
+++ b/.github/.issue-drafts/v0.1/AD-06.md
@@ -1,0 +1,93 @@
+---
+issue_id: AD-06
+phase: 1
+type: feat
+size: M
+priority: high
+title: "feat(execution): ExecutionAdapter 인터페이스 + MockExecutionAdapter"
+labels: [phase/1, area/execution, type/feature, size/M]
+depends_on: [AD-03]
+blocks: [AD-07, AD-09]
+branch: feat/execution-adapter
+---
+
+# feat(execution): ExecutionAdapter 인터페이스 + MockExecutionAdapter
+
+## What
+
+신규 모듈 `src/execution/`을 생성하고, Agent SDK 호출의 **단일 진입점**인 `ExecutionAdapter` 인터페이스와 그 구현 2종을 추가한다.
+
+- `ExecutionAdapter` (interface)
+- `SdkExecutionAdapter` (implements: `@anthropic-ai/claude-agent-sdk`의 `query()` 호출)
+- `MockExecutionAdapter` (테스트용)
+
+## Why
+
+- ARCH-RFC-001 §4.1 명시: 모든 SDK 호출이 한 곳을 통과해야 (1) 테스트 모킹 일원화, (2) PreToolUse 정책 단일 지점, (3) OTel span 일관 발화, (4) Bedrock/Vertex endpoint 전환이 한 어댑터 내부에서 가능
+- 현재 `AgentBridge` 3종은 각자 도구 루프를 자체 구현 — 일관성 결여
+- 본 어댑터는 P2 파일럿(AD-09)의 전제 조건
+
+## Who
+
+- **Assignee**: TBD (execution-owner)
+- **Reviewers**: 코어 메인테이너 1, 테스트 인프라 담당 1
+- **Approval**: LGTM ≥ 2
+
+## When
+
+- AD-03 머지 직후
+- 작업 시간: 1.5~2일
+
+## Where
+
+- `src/execution/ExecutionAdapter.ts` (interface + types)
+- `src/execution/SdkExecutionAdapter.ts` (구현)
+- `src/execution/MockExecutionAdapter.ts` (테스트용)
+- `src/execution/index.ts` (재수출)
+- `src/index.ts` (façade에 추가)
+- `tests/execution/` (단위 테스트)
+
+## How
+
+### Implementation Steps
+
+1. 인터페이스 정의 (RFC §4.1 시그니처 그대로)
+2. `SdkExecutionAdapter`:
+   - `@anthropic-ai/claude-agent-sdk`의 `query()`를 wrapping
+   - `StageExecutionRequest` → SDK `ClaudeAgentOptions` 매핑
+   - 메시지 스트림에서 `result`, `session_id`, tool_use 카운트 추출
+   - `resume`이 있으면 `options.resume`으로 전달
+3. `MockExecutionAdapter`:
+   - 입력별 정해진 결과 반환 (test fixture 기반)
+   - `tokenUsage: { input: 0, output: 0, cache: 0 }` 더미값
+4. 단위 테스트:
+   - `SdkExecutionAdapter` — SDK를 stub 처리, 옵션 매핑 정확성 검증
+   - `MockExecutionAdapter` — 시나리오 5종
+
+### Acceptance Criteria
+
+- [ ] `ExecutionAdapter` 인터페이스가 RFC §4.1 시그니처 100% 일치
+- [ ] `SdkExecutionAdapter` 빌드·단위 테스트 통과
+- [ ] `MockExecutionAdapter` 빌드·단위 테스트 통과
+- [ ] 두 어댑터가 동일 인터페이스 만족 (Liskov)
+- [ ] tests 커버리지 ≥ 90% (신규 모듈 한정)
+- [ ] `src/execution/README.md` 초안 (AD-08에서 확장)
+- [ ] 단일 SDK 호출이 정상 — `priorOutputs`가 prompt에 포함됨을 보장하는 단위 테스트
+- [ ] 어댑터가 사용처 0개 — 본 PR은 인프라만 추가
+
+### Test Plan
+
+- [ ] `npm test -- tests/execution/`
+- [ ] mock 어댑터로 `Greenfield` 시나리오 종단 dry-run (어댑터 사용처는 추후이므로 통합은 AD-09에서)
+- [ ] 메모리 누수 없음 — `dispose()` 호출 시 SDK 리소스 정리 검증
+
+### Out of Scope
+
+- 실제 stage가 어댑터를 사용하도록 변경 (AD-09)
+- Hook pipeline 통합 (AD-07)
+- Telemetry bridge 통합 (P3)
+
+### Reference
+
+- ARCH-RFC-001 §4.1
+- 공식 문서: https://code.claude.com/docs/en/agent-sdk/overview

--- a/.github/.issue-drafts/v0.1/AD-07.md
+++ b/.github/.issue-drafts/v0.1/AD-07.md
@@ -1,0 +1,69 @@
+---
+issue_id: AD-07
+phase: 1
+type: feat
+size: S
+priority: medium
+title: "feat(execution): Hook pipeline 최소 골격 (PostToolUse → scratchpad)"
+labels: [phase/1, area/execution, type/feature, size/S]
+depends_on: [AD-06]
+blocks: [AD-09]
+branch: feat/execution-hooks
+---
+
+# feat(execution): Hook pipeline 최소 골격 (PostToolUse → scratchpad)
+
+## What
+
+`src/execution/hooks.ts`를 신규 작성하여 SDK Hook 콜백을 통한 **scratchpad 자동 캡처**를 구현한다. 본 이슈는 최소 골격(PostToolUse 1종)만 다루며, Telemetry Bridge·Policy Engine은 별도 이슈에서 확장한다.
+
+## Why
+
+- ExecutionAdapter가 SDK `query()`를 호출할 때, Worker가 생성한 산출물(파일)이 자동으로 scratchpad에 등록되어야 후속 stage가 이를 priorOutputs로 받을 수 있음
+- 현재 구조는 ClaudeCodeBridge가 polling으로 산출물을 읽음 → 비효율
+- Hook을 사용하면 SDK 도구 호출 직후 즉시 캡처 가능
+
+## Who
+
+- **Assignee**: TBD
+- **Reviewers**: scratchpad 담당 1, execution-owner 1
+- **Approval**: LGTM ≥ 1
+
+## When
+
+- AD-06 머지 직후
+- 작업 시간: 1일
+
+## Where
+
+- `src/execution/hooks.ts` (신규)
+- `src/execution/SdkExecutionAdapter.ts` (hook 옵션 wiring)
+- `tests/execution/hooks.test.ts`
+
+## How
+
+### Implementation Steps
+
+1. `buildHookPipeline()` 팩토리 — Scratchpad 인스턴스 주입
+2. `PostToolUse` 매처 `Edit|Write` — tool_input의 `file_path`를 scratchpad의 artifacts 섹션에 등록
+3. Hook 실패 시 stage 즉시 abort 보장 (silent failure 금지)
+4. SdkExecutionAdapter가 옵션으로 hooks 받도록 시그니처 확장
+
+### Acceptance Criteria
+
+- [ ] `PostToolUse(Edit|Write)` 시 scratchpad에 artifact 항목이 생성됨
+- [ ] hook 실패 시 stage가 abort되고 structured error 반환
+- [ ] 단위 테스트: hook 호출 시 scratchpad 메서드가 정확한 인자로 호출됨
+- [ ] mock SDK로 시나리오 3종 (성공·실패·비동기) 검증
+- [ ] PreToolUse·Stop hook은 빈 구현 — TODO 주석으로 후속 이슈 참조
+
+### Test Plan
+
+- [ ] `npm test -- tests/execution/hooks.test.ts`
+- [ ] MockExecutionAdapter + Hook 결합 시나리오 통합 테스트 1개
+
+### Out of Scope
+
+- PreToolUse 정책 (P3에서)
+- Telemetry 발화 (P3에서)
+- Stop hook 활용 (P3에서)

--- a/.github/.issue-drafts/v0.1/AD-08.md
+++ b/.github/.issue-drafts/v0.1/AD-08.md
@@ -1,0 +1,60 @@
+---
+issue_id: AD-08
+phase: 1
+type: docs
+size: XS
+priority: low
+title: "docs(execution): src/execution/README.md 작성"
+labels: [phase/1, area/docs, type/docs, size/XS]
+depends_on: [AD-06]
+blocks: []
+branch: docs/execution-readme
+---
+
+# docs(execution): `src/execution/README.md` 작성
+
+## What
+
+신규 `src/execution/` 모듈에 대한 README를 작성하여 기여자가 (a) 어댑터 종류, (b) 사용 시나리오, (c) Hook 확장 지점, (d) 테스트 작성 가이드를 한 페이지에서 파악하도록 한다.
+
+## Why
+
+- 신규 모듈은 본 v0.1의 핵심 진입점 — 문서 부재 시 후속 phase 기여자가 RFC 본문을 매번 참조해야 함
+- 다른 모듈(예: `src/scratchpad/README.md` 패턴)과 일관성
+
+## Who
+
+- **Assignee**: TBD (docs-owner)
+- **Reviewers**: execution-owner 1
+- **Approval**: LGTM ≥ 1
+
+## When
+
+- AD-06 머지 직후
+- 작업 시간: 2~3시간
+
+## Where
+
+- `src/execution/README.md`
+
+## How
+
+### Section Outline
+
+1. **Overview** — 3-tier 아키텍처에서의 위치, RFC 링크
+2. **ExecutionAdapter Interface** — 시그니처와 시맨틱
+3. **Adapters** — `SdkExecutionAdapter` (production) / `MockExecutionAdapter` (testing)
+4. **Hook Pipeline** — PostToolUse·PreToolUse·Stop 사용처
+5. **Testing Strategy** — Mock 사용법, 단위·통합 분리
+6. **Extension Points** — 새 Hook 추가, 새 어댑터 추가 (예: BedrockExecutionAdapter)
+
+### Acceptance Criteria
+
+- [ ] 6개 섹션 모두 작성
+- [ ] 코드 예시 ≥ 3개 (어댑터 사용, Hook 정의, Mock 셋업)
+- [ ] RFC 링크 동작
+- [ ] 다른 모듈 README 스타일과 일관 (frontmatter 없이 H1으로 시작 또는 doc_id frontmatter — 프로젝트 컨벤션 확인 후 결정)
+
+### Out of Scope
+
+- API reference 자동 생성 (TypeDoc) — 별도 이슈

--- a/.github/.issue-drafts/v0.1/AD-09.md
+++ b/.github/.issue-drafts/v0.1/AD-09.md
@@ -1,0 +1,87 @@
+---
+issue_id: AD-09
+phase: 2
+type: feat
+size: M
+priority: high
+title: "feat(worker): worker stage 파일럿 — ExecutionAdapter 경로 도입"
+labels: [phase/2, area/orchestrator, type/feature, size/M]
+depends_on: [AD-06, AD-07]
+blocks: [AD-10, AD-11, AD-13]
+branch: feat/worker-pilot-adapter
+---
+
+# feat(worker): `worker` stage 파일럿 — `ExecutionAdapter` 경로 도입
+
+## What
+
+35개 stage 중 **`worker` 1개**를 신규 `ExecutionAdapter` 경유로 실행하도록 변경한다. 다른 stage는 기존 `AgentBridge` 경로 유지 — 위험 격리.
+
+## Why
+
+- ARCH-RFC-001 §6 P2: 단일 stage pilot으로 (a) 어댑터 정합성, (b) hook 동작, (c) 산출물 동등성을 사전 검증
+- worker를 선택한 이유:
+  - Write/Edit 빈도 가장 높음 — Hook 동작 검증에 적합
+  - 단일 issue 단위로 invoke되어 idempotency 검증 용이
+  - 실패 시 영향이 1 issue로 국한 (Greenfield 전체가 아님)
+
+## Who
+
+- **Assignee**: TBD (execution-owner)
+- **Reviewers**: orchestrator 담당 1, worker 담당 1
+- **Approval**: LGTM ≥ 2
+
+## When
+
+- AD-06, AD-07 머지 직후
+- 작업 시간: 2~3일
+
+## Where
+
+- `src/ad-sdlc-orchestrator/AdsdlcOrchestratorAgent.ts` (worker 분기)
+- `src/execution/SdkExecutionAdapter.ts` (필요 시 옵션 확장)
+- `src/worker/` (인터페이스 변경 없음 — 외부 호출만 변경)
+- `tests/integration/worker-pilot/`
+
+## How
+
+### Implementation Steps
+
+1. `executeStageAgent()` 내부에 분기:
+   ```typescript
+   if (stage.agentType === 'worker' && process.env.AD_SDLC_USE_SDK_FOR_WORKER === '1') {
+     return this.executeViaAdapter(stage, workOrder, priorOutputs);
+   }
+   return this.executeViaBridge(stage, workOrder, priorOutputs);  // 기존
+   ```
+2. `executeViaAdapter()` 메서드 추가 — `ExecutionAdapter.execute()` 호출
+3. workOrder를 SDK prompt로 매핑 — 기존 AgentBridge가 만들던 system prompt와 동등성 유지
+4. Hook pipeline 주입 (AD-07 산출물 사용)
+5. 결과를 `StageResult` 형식으로 변환
+
+### Acceptance Criteria
+
+- [ ] `AD_SDLC_USE_SDK_FOR_WORKER=1` 시 worker가 ExecutionAdapter로 실행됨
+- [ ] flag off 시 기존 동작 100% 유지 (regression 0)
+- [ ] worker 단일 issue 처리 시 산출물(코드 파일·테스트)이 기존과 동등
+  - 동등성 정의: 같은 파일 set이 생성되고, 각 파일이 의도한 syntax·기능을 만족
+- [ ] 실행 시간이 기존 ±20% 이내
+- [ ] tokenUsage가 result에 정확히 채워짐 (관측 가능성 확보)
+
+### Test Plan
+
+- [ ] 신규 통합 테스트: 동일 issue로 양쪽 경로 실행 후 산출물 diff 0
+- [ ] AD-10에서 본 테스트를 시나리오 5종으로 확장
+- [ ] 기존 worker 단위 테스트 회귀 0
+
+### Risks & Mitigation
+
+- **R1**: SDK가 만드는 prompt 컨텍스트가 기존 AgentBridge와 미묘히 달라 산출물 차이 발생
+  - 완화: `loadAgentDefinition()`(기존 AnthropicApiBridge에 있음)이 이미 .md frontmatter를 strip하고 body만 시스템 프롬프트로 주입 — SDK도 동일 메커니즘 적용 가능
+- **R2**: Hook 호출 누락
+  - 완화: 통합 테스트에 hook 호출 카운트 검증
+
+### Out of Scope
+
+- 다른 stage 변경 (P3에서)
+- AgentBridge 코드 삭제 (P3에서)

--- a/.github/.issue-drafts/v0.1/AD-10.md
+++ b/.github/.issue-drafts/v0.1/AD-10.md
@@ -1,0 +1,78 @@
+---
+issue_id: AD-10
+phase: 2
+type: test
+size: S
+priority: high
+title: "test(worker): worker 파일럿 통합 테스트 (mock vs real adapter)"
+labels: [phase/2, area/orchestrator, type/test, size/S]
+depends_on: [AD-09]
+blocks: [AD-12]
+branch: test/worker-pilot-integration
+---
+
+# test(worker): worker 파일럿 통합 테스트 (mock vs real adapter)
+
+## What
+
+`tests/integration/worker-pilot/` 하위에 **mock 어댑터**와 **실제 SDK 어댑터** 양쪽을 사용하는 통합 테스트 5종을 추가한다. 양쪽 경로의 산출물이 동등함을 보장.
+
+## Why
+
+- AD-09의 acceptance criteria가 "기존과 동등"인데 동등성을 검증할 자동화된 게이트가 필요
+- P3 cutover 전 신뢰할 수 있는 회귀 안전망 확보
+- 기존 단위 테스트는 worker 내부에 집중 — adapter 통합 시점의 행동 검증 부족
+
+## Who
+
+- **Assignee**: TBD (test-owner)
+- **Reviewers**: execution-owner 1, worker 담당 1
+- **Approval**: LGTM ≥ 1
+
+## When
+
+- AD-09 머지 직후
+- 작업 시간: 1~2일
+
+## Where
+
+- `tests/integration/worker-pilot/`
+  - `simple-bug-fix.test.ts`
+  - `new-feature.test.ts`
+  - `refactor.test.ts`
+  - `with-deps-conflict.test.ts`
+  - `large-issue.test.ts`
+- `vitest.integration.config.ts` (필요 시 패턴 추가)
+
+## How
+
+### Test Scenarios
+
+| # | 시나리오 | 검증 항목 |
+|---|---|---|
+| T1 | 단순 버그 수정 (1 file edit) | 동일 file에 동일 변경 |
+| T2 | 신규 기능 (1 new file + tests) | 같은 파일 set, 같은 export 시그니처 |
+| T3 | 리팩토링 (다중 file edit) | 변경 파일 set 동일 |
+| T4 | 의존성 충돌 시나리오 (이전 이슈 산출물 의존) | priorOutputs 정확히 prompt 포함 |
+| T5 | 대형 이슈 (>10 step tool use) | maxTurns 도달 시 timeout 처리 |
+
+각 시나리오마다 `MockExecutionAdapter` 결과와 `SdkExecutionAdapter` 결과를 비교하는 `assertEquivalent` 헬퍼 사용.
+
+### Acceptance Criteria
+
+- [ ] 5종 시나리오 모두 통과
+- [ ] mock·real 두 경로 결과 동등 (헬퍼 사용)
+- [ ] 통합 테스트 실행 시간 ≤ 5분
+- [ ] CI 워크플로에 통합 테스트 단계 추가
+- [ ] real adapter 실행은 ANTHROPIC_API_KEY 환경에서만 (CI에서 secret 사용)
+
+### Test Plan
+
+- [ ] 로컬에서 `npm run test:integration -- worker-pilot` 5/5 통과
+- [ ] CI에서 동일 통과
+- [ ] flag off (`AD_SDLC_USE_SDK_FOR_WORKER=0`) 시 기존 worker 회귀 테스트도 동시 통과
+
+### Out of Scope
+
+- 다른 stage 통합 테스트 (P3에서)
+- 성능 벤치마크 (별도)

--- a/.github/.issue-drafts/v0.1/AD-11.md
+++ b/.github/.issue-drafts/v0.1/AD-11.md
@@ -1,0 +1,69 @@
+---
+issue_id: AD-11
+phase: 2
+type: feat
+size: XS
+priority: medium
+title: "feat(config): feature flag AD_SDLC_USE_SDK_FOR_WORKER"
+labels: [phase/2, area/orchestrator, type/feature, size/XS]
+depends_on: [AD-09]
+blocks: []
+branch: feat/feature-flag-worker-sdk
+---
+
+# feat(config): feature flag `AD_SDLC_USE_SDK_FOR_WORKER`
+
+## What
+
+환경변수 기반 feature flag를 정식 config로 승격하여 (a) CLI `--use-sdk-for-worker` 플래그, (b) `.ad-sdlc/config/feature-flags.yaml`, (c) `process.env.AD_SDLC_USE_SDK_FOR_WORKER` 세 경로 중 어느 것이든 토글 가능하게 한다. 우선순위: env > CLI > config.
+
+## Why
+
+- AD-09에서 임시 환경변수로 시작 — 사용자·CI에서 정식 config로 토글 필요
+- 롤백 절차(Migration Guide §6) 단순화
+- P3 cutover 시 default를 1로 변경하는 것이 단일 PR
+
+## Who
+
+- **Assignee**: TBD
+- **Reviewers**: config-owner 1
+- **Approval**: LGTM ≥ 1
+
+## When
+
+- AD-09 머지 직후
+- 작업 시간: 4시간
+
+## Where
+
+- `src/config/featureFlags.ts` (신규 또는 기존 확장)
+- `src/cli.ts` (옵션 추가)
+- `schemas/feature-flags.schema.json` (신규)
+- `docs/config.md` (옵션 표 갱신)
+
+## How
+
+### Implementation Steps
+
+1. `FeatureFlagsResolver` 추가 — env > CLI > config 우선순위
+2. `.ad-sdlc/config/feature-flags.yaml` 스키마 정의 + Zod 검증
+3. CLI에 `--use-sdk-for-worker` boolean 옵션 추가
+4. `AdsdlcOrchestratorAgent`가 resolver를 통해 플래그 조회
+5. 문서 (`docs/config.md`)에 플래그 표 갱신
+
+### Acceptance Criteria
+
+- [ ] 세 경로 모두 동작, 우선순위 검증 단위 테스트
+- [ ] flag off (default) 시 기존 동작
+- [ ] flag on 시 worker가 ExecutionAdapter 경유
+- [ ] `.ad-sdlc/config/feature-flags.yaml` 파일이 자동 생성되지 않음 (사용자 옵트인)
+- [ ] CLI help에 옵션 노출
+
+### Test Plan
+
+- [ ] `tests/config/feature-flags.test.ts` 시나리오 6종 (env on/off × CLI on/off × yaml on/off 일부 조합)
+- [ ] CLI 통합 테스트로 옵션 전달 확인
+
+### Out of Scope
+
+- 다른 phase의 feature flag (필요 시 별도 이슈)

--- a/.github/.issue-drafts/v0.1/AD-12.md
+++ b/.github/.issue-drafts/v0.1/AD-12.md
@@ -1,0 +1,60 @@
+---
+issue_id: AD-12
+phase: 2
+type: docs
+size: S
+priority: medium
+title: "docs(architecture): worker 파일럿 평가 보고서"
+labels: [phase/2, area/docs, type/docs, size/S]
+depends_on: [AD-10]
+blocks: [AD-13]
+branch: docs/v01-pilot-eval
+---
+
+# docs(architecture): worker 파일럿 평가 보고서
+
+## What
+
+`docs/architecture/v0.1-pilot-evaluation.md`를 작성하여 (a) 동등성 측정 결과, (b) 성능 비교, (c) Hook 발화 통계, (d) P3 진행 권고 또는 보류 사유를 정량적으로 기록한다.
+
+## Why
+
+- ARCH-RFC-001 §10에 명시된 측정 지표를 P2에서 1차 검증
+- Phase Gate(P2 → P3)의 통과 근거로 사용
+- 외부 사용자에게 진행 상황 투명 공개
+
+## Who
+
+- **Assignee**: TBD (architecture-owner)
+- **Reviewers**: 코어 메인테이너 1+
+- **Approval**: LGTM ≥ 1
+
+## When
+
+- AD-10 머지 직후
+- 작업 시간: 1일
+
+## Where
+
+- `docs/architecture/v0.1-pilot-evaluation.md`
+
+## How
+
+### Sections
+
+1. **Methodology** — 비교 시나리오 5종, 측정 도구
+2. **동등성 결과** — 산출물 diff, 5/5 시나리오 결과
+3. **성능 비교** — 실행 시간(p50/p95), token 사용량, tool call 수
+4. **Hook 동작 통계** — PostToolUse 발화 수, scratchpad 등록 정확성
+5. **이슈 발견 사항** — 양쪽 경로 차이가 있다면 원인·완화
+6. **권고** — Proceed to P3 / Hold (조건 명시)
+
+### Acceptance Criteria
+
+- [ ] 6개 섹션 모두 정량 데이터 포함 (수치 없는 추측 금지)
+- [ ] 권고 결론이 데이터로 뒷받침됨
+- [ ] `docs/architecture/`에 link되도록 README index 갱신
+
+### Out of Scope
+
+- 다른 stage 측정 (P3에서)

--- a/.github/.issue-drafts/v0.1/AD-13.md
+++ b/.github/.issue-drafts/v0.1/AD-13.md
@@ -1,0 +1,86 @@
+---
+issue_id: AD-13
+phase: 3
+type: refactor
+size: L
+priority: high
+title: "refactor(orchestrator): 전체 34 stage ExecutionAdapter 경유 (cutover)"
+labels: [phase/3, area/orchestrator, type/refactor, size/L, breaking-change]
+depends_on: [AD-02, AD-12]
+blocks: [AD-14, AD-16]
+branch: refactor/full-cutover-meta
+---
+
+# refactor(orchestrator): 전체 34 stage `ExecutionAdapter` 경유 (cutover)
+
+## What
+
+`worker` 외 33개 stage를 모두 `ExecutionAdapter` 경로로 cutover한다. 본 이슈는 **메타 이슈**로, 5개 sub-PR로 분할 진행한다.
+
+## Why
+
+- Phase Gate P2 → P3 통과 후, 자체 Bridge 코드(약 1,700 LoC)를 일소하고 단일 진입점으로 통합
+- AgentBridge 3종 + Dispatcher + Registry 의존을 제거하기 위한 사전 작업
+- claude-config plugin skills/MCP 활용(P4)의 전제
+
+## Who
+
+- **Assignee**: orchestrator-owner (메타), sub-PR별 도메인 담당
+- **Reviewers**: 코어 메인테이너 2
+- **Approval**: 각 sub-PR LGTM ≥ 1, 메타 close 시 LGTM ≥ 2
+
+## When
+
+- AD-12 머지 직후
+- 작업 시간: 2~3주 (sub-PR 5개 직렬 또는 일부 병렬)
+
+## Where
+
+- `src/ad-sdlc-orchestrator/AdsdlcOrchestratorAgent.ts`
+- `src/agents/AgentDispatcher.ts` (단계적 호출 제거)
+- 33개 stage의 invocation site
+
+## How — Sub-PR 분할
+
+| Sub | 범위 | stage 수 | 추정 |
+|---|---|---|---|
+| AD-13-A | Doc Writers (PRD/SRS/SDP/SDS/TM/TD/UI/SVP) | 8 | 4일 |
+| AD-13-B | Doc Updaters + Reader (PRD/SRS/SDS Updater + Document Reader) | 4 | 2일 |
+| AD-13-C | Analyzers (Code Reader, Codebase, Doc-Code, Impact, Architecture, Component) | 6 | 3일 |
+| AD-13-D | Setup + Collection (ProjectInit, ModeDetect, RepoDetect, GitHubSetup, Collector, IssueReader) | 6 | 3일 |
+| AD-13-E | Execution + Quality + V&V (Controller, IssueGen, PRReviewer, CIFixer, Regression, StageVerifier, RTM, ValidationAgent, DocIndex) | 9 | 5일 |
+
+각 sub-PR은:
+1. 해당 stage들의 `executeStageAgent` 분기 제거 — 항상 ExecutionAdapter 사용
+2. 통합 테스트 갱신
+3. CHANGELOG 항목 추가
+
+### Acceptance Criteria (메타)
+
+- [ ] 5개 sub-PR 모두 머지
+- [ ] feature flag `AD_SDLC_USE_SDK_FOR_WORKER` 삭제 또는 default true 변경
+- [ ] AgentDispatcher 호출 사이트 0개 (`grep -rn "AgentDispatcher" src/` 결과 0)
+- [ ] E2E 시나리오 3종(Greenfield/Enhancement/Import) 통과
+- [ ] 코드 라인 변화: -1,500~-2,000 LoC 범위
+
+### Test Plan
+
+- 각 sub-PR마다:
+  - [ ] 해당 stage 단위 테스트 회귀 0
+  - [ ] 통합 테스트 추가 (mock vs real)
+  - [ ] E2E 시나리오 1개 통과
+- 메타 close 전:
+  - [ ] 전체 E2E 3종 통과
+  - [ ] `npm run test:perf` 회귀 ±10% 이내
+
+### Risks & Mitigation
+
+- **R1**: 5 sub-PR 직렬 시 develop 분기 충돌 누적
+  - 완화: sub-PR마다 develop 리베이스 의무화, 각 PR ≤ 5일
+- **R2**: 일부 stage가 SDK prompt와 호환 안 됨 (system prompt 길이 등)
+  - 완화: sub-PR별 리스크 시그널 — 4시간 이내 미해결 시 escalate
+
+### Out of Scope
+
+- AgentBridge 코드 자체 삭제 (AD-14)
+- AdsdlcOrchestratorAgent 슬림화 (AD-15)

--- a/.github/.issue-drafts/v0.1/AD-14.md
+++ b/.github/.issue-drafts/v0.1/AD-14.md
@@ -1,0 +1,88 @@
+---
+issue_id: AD-14
+phase: 3
+type: chore
+size: M
+priority: high
+title: "chore(agents): AgentBridge / Dispatcher / Registry 삭제"
+labels: [phase/3, area/execution, type/chore, size/M, breaking-change]
+depends_on: [AD-13]
+blocks: [AD-15]
+branch: chore/remove-bridge-stack
+---
+
+# chore(agents): AgentBridge / Dispatcher / Registry 삭제
+
+## What
+
+AD-13 cutover 완료 후 **사용처 없는** Bridge 스택 코드 ~2,000 LoC를 삭제한다.
+
+대상 파일:
+- `src/agents/AgentBridge.ts`
+- `src/agents/AgentDispatcher.ts`
+- `src/agents/AgentRegistry.ts`
+- `src/agents/AgentTypeMapping.ts`
+- `src/agents/bootstrapAgents.ts`
+- `src/agents/BridgeRegistry.ts`
+- `src/agents/ExecutionScaffoldGenerator.ts`
+- `src/agents/bridges/AnthropicApiBridge.ts`
+- `src/agents/bridges/ClaudeCliSubprocessBridge.ts`
+- `src/agents/bridges/ClaudeCodeBridge.ts`
+- `src/agents/bridges/StubBridge.ts`
+- `src/agents/bridges/index.ts`
+- `src/agents/bridges/tools.ts`
+
+또한 `src/agents/index.ts`에서 위 모듈 재수출 제거, `src/index.ts` façade 갱신.
+
+## Why
+
+- AD-13에서 cutover 완료 → 사용처 0개
+- Dead code는 신규 기여자 혼란 유발 + 유지보수 부담
+- `@anthropic-ai/sdk` raw 의존성 제거 가능 (AnthropicApiBridge에서만 사용)
+
+## Who
+
+- **Assignee**: TBD
+- **Reviewers**: 코어 메인테이너 2
+- **Approval**: LGTM ≥ 2
+
+## When
+
+- AD-13 메타 close 직후
+- 작업 시간: 1일
+
+## Where
+
+- `src/agents/` 대부분 (단 `types.ts`의 `IAgent` 인터페이스는 writers가 사용 — 유지)
+- `package.json` (`@anthropic-ai/sdk` 제거 검토)
+
+## How
+
+### Implementation Steps
+
+1. `grep -rn "AgentBridge\|AgentDispatcher\|BridgeRegistry"` 결과 0 확인
+2. 파일 삭제 (`git rm`)
+3. `src/agents/index.ts` 재수출 정리 — `IAgent` 등 유지 항목만 남김
+4. `src/index.ts` façade 갱신
+5. 단위 테스트 일괄 삭제 (`tests/agents/AgentDispatcher.test.ts` 등 11개)
+6. `@anthropic-ai/sdk` 의존성 제거 가능 여부 확인 → 가능하면 `package.json`에서 삭제
+7. CHANGELOG `### Removed` 섹션에 명시
+
+### Acceptance Criteria
+
+- [ ] 13개 파일 삭제
+- [ ] `IAgent` 인터페이스 등 writers가 import하는 타입은 보존
+- [ ] `npm run build` 통과
+- [ ] `npm test` 통과
+- [ ] `grep -rn "AgentBridge\|AgentDispatcher" src/ tests/` 결과 0
+- [ ] 코드 라인 -2,000 ± 200 LoC
+- [ ] CHANGELOG 갱신
+
+### Risks & Mitigation
+
+- **R1**: 외부 사용자가 `import { AgentBridge } from 'ad-sdlc'`로 의존 중일 가능성
+  - 완화: v0.1.0이 first major redesign이므로 breaking change 명시 OK. CHANGELOG·MIGRATION에서 강조.
+
+### Out of Scope
+
+- AdsdlcOrchestratorAgent 슬림화 (AD-15)

--- a/.github/.issue-drafts/v0.1/AD-15.md
+++ b/.github/.issue-drafts/v0.1/AD-15.md
@@ -1,0 +1,76 @@
+---
+issue_id: AD-15
+phase: 3
+type: refactor
+size: M
+priority: high
+title: "refactor(orchestrator): AdsdlcOrchestratorAgent 슬림화"
+labels: [phase/3, area/orchestrator, type/refactor, size/M]
+depends_on: [AD-14]
+blocks: [AD-17, AD-18, AD-20]
+branch: refactor/slim-orchestrator
+---
+
+# refactor(orchestrator): `AdsdlcOrchestratorAgent` 슬림화
+
+## What
+
+`AdsdlcOrchestratorAgent.ts` (현재 1,443 lines)에서 도구 루프·dispatcher 의존 코드를 제거하고 **stage DAG 실행·체크포인트·승인 게이트**만 남긴다. 목표 라인 수: ≤ 950 lines.
+
+## Why
+
+- AD-14 후 Dispatcher가 사라졌으므로 관련 분기·헬퍼·import가 dead
+- 현재 단일 파일이 너무 커서 (a) 코드 읽기 부담, (b) 변경 영향 범위 파악 어려움
+- ARCH-RFC-001 §5: 슬림화 후 ~900 LoC 목표
+
+## Who
+
+- **Assignee**: orchestrator-owner
+- **Reviewers**: 코어 메인테이너 1, V&V 담당 1
+- **Approval**: LGTM ≥ 2
+
+## When
+
+- AD-14 머지 직후
+- 작업 시간: 2일
+
+## Where
+
+- `src/ad-sdlc-orchestrator/AdsdlcOrchestratorAgent.ts`
+
+## How
+
+### Implementation Steps
+
+1. **Identify dead code**
+   - `_dispatcher`, `_bridgeRegistry` 필드 제거
+   - `getDispatcher()` 제거
+   - `executeViaBridge()` 분기 제거 (cutover 완료)
+   - `executeStageAgent`을 단일 path로 단순화
+2. **Extract**
+   - `executeParallelStages`, `executeParallel`, `executeSequential` → `src/ad-sdlc-orchestrator/StageScheduler.ts`로 분리 (선택적)
+   - `checkApprovalGate`, `promptManualApproval` → `src/ad-sdlc-orchestrator/ApprovalGate.ts`로 분리 (선택적)
+3. **Clean imports**
+   - AgentBridge·BridgeRegistry·bootstrapAgents import 제거
+   - `ExecutionAdapter` import 추가
+4. **DI 주입 경로**
+   - 생성자 또는 initialize()에서 `ExecutionAdapter` 주입
+   - 테스트에서 `MockExecutionAdapter` 주입 가능
+
+### Acceptance Criteria
+
+- [ ] `AdsdlcOrchestratorAgent.ts` ≤ 950 lines
+- [ ] public API (`startSession`, `executePipeline`, `loadPriorSession`, `findLatestSession`) 시그니처 변경 없음
+- [ ] 단위·통합 테스트 회귀 0
+- [ ] E2E 시나리오 3종 통과
+- [ ] (선택) `StageScheduler`/`ApprovalGate` 분리 시 각 ≤ 200 LoC
+
+### Test Plan
+
+- [ ] 기존 `tests/ad-sdlc-orchestrator/` 모두 통과
+- [ ] DI로 MockExecutionAdapter 주입 시 stage 시뮬레이션 정상
+
+### Out of Scope
+
+- 체크포인트 schema 확장 (AD-16)
+- 새 stage definition 필드 (AD-18)

--- a/.github/.issue-drafts/v0.1/AD-16.md
+++ b/.github/.issue-drafts/v0.1/AD-16.md
@@ -1,0 +1,91 @@
+---
+issue_id: AD-16
+phase: 3
+type: feat
+size: S
+priority: medium
+title: "feat(checkpoint): PipelineCheckpointManager에 SDK session_id 매핑 추가"
+labels: [phase/3, area/orchestrator, type/feature, size/S]
+depends_on: [AD-13]
+blocks: []
+branch: feat/checkpoint-sdk-session
+---
+
+# feat(checkpoint): `PipelineCheckpointManager`에 SDK `session_id` 매핑 추가
+
+## What
+
+`PipelineCheckpointManager`가 stage별로 SDK `session_id`를 함께 저장하여, mid-stage 크래시 시 SDK의 `resume: sessionId`로 도구 루프 컨텍스트를 복원할 수 있게 한다. 체크포인트 schema_version: 1 → 2.
+
+## Why
+
+- ARCH-RFC-001 §7 R4: 체크포인트 호환성
+- 현재 stage-level 체크포인트는 stage 인덱스만 저장 → 중단된 stage가 처음부터 재시작
+- SDK `resume`을 활용하면 stage 내부에서도 직전 도구 호출 컨텍스트를 살릴 수 있음 (Bedrock 등 일부 endpoint 제외)
+- v0.0.1 체크포인트 자동 마이그레이션 의무
+
+## Who
+
+- **Assignee**: TBD
+- **Reviewers**: orchestrator-owner 1
+- **Approval**: LGTM ≥ 1
+
+## When
+
+- AD-13 머지 직후, AD-15와 병렬 가능
+- 작업 시간: 1일
+
+## Where
+
+- `src/ad-sdlc-orchestrator/PipelineCheckpointManager.ts`
+- `src/ad-sdlc-orchestrator/types.ts` (Checkpoint 타입 확장)
+- `tests/ad-sdlc-orchestrator/PipelineCheckpointManager.test.ts`
+
+## How
+
+### Schema 변경
+
+```typescript
+// v1 (기존)
+interface CheckpointV1 {
+  session_id: string;     // 파이프라인 세션 (SDK와 무관)
+  stage: StageName;
+  prior_outputs: Record<string, string>;
+}
+
+// v2 (신규)
+interface CheckpointV2 {
+  schema_version: 2;
+  session_id: string;
+  stage: StageName;
+  prior_outputs: Record<string, string>;
+  sdk_session_id?: string;  // 신규: SDK query() session
+}
+```
+
+### Implementation Steps
+
+1. `Checkpoint` 타입에 `schema_version`, `sdk_session_id` 추가
+2. `saveCheckpoint`이 ExecutionAdapter 결과의 `sessionId`를 함께 저장
+3. `loadLatestCheckpoint`이 schema_version 확인:
+   - 부재 또는 1 → v2로 변환 (sdk_session_id = undefined)
+   - 2 → 그대로 사용
+4. `AdsdlcOrchestratorAgent`가 stage 재개 시 `resume: sdk_session_id`를 ExecutionAdapter에 전달
+
+### Acceptance Criteria
+
+- [ ] schema v1 체크포인트가 자동으로 v2로 변환됨 (zero-downtime migration)
+- [ ] mid-stage 크래시 시 재개가 SDK resume으로 동작
+- [ ] 단위 테스트 시나리오 4종 (v1 load, v2 load, v1→v2 migrate, sdk_session 없음)
+- [ ] 외부 endpoint(Bedrock/Vertex)에서 resume 미지원 시 graceful degradation (처음부터 재시작 + 경고)
+
+### Test Plan
+
+- [ ] `npm test -- PipelineCheckpointManager`
+- [ ] 기존 v0.0.1 사용자의 체크포인트 fixture로 마이그레이션 검증
+- [ ] mid-stage 크래시 시뮬레이션 통합 테스트 1개
+
+### Out of Scope
+
+- 체크포인트 GC 정책
+- 멀티 머신 체크포인트 동기화 (별도 RFC)

--- a/.github/.issue-drafts/v0.1/AD-17.md
+++ b/.github/.issue-drafts/v0.1/AD-17.md
@@ -1,0 +1,104 @@
+---
+issue_id: AD-17
+phase: 3
+type: docs
+size: S
+priority: high
+title: "docs: README \"built with Agent SDK\" 진실성 정정 + CHANGELOG"
+labels: [phase/3, area/docs, type/docs, size/S]
+depends_on: [AD-15]
+blocks: []
+branch: docs/v01-readme-changelog
+---
+
+# docs: README "built with Agent SDK" 진실성 정정 + CHANGELOG
+
+## What
+
+README.md, CHANGELOG.md를 v0.1.0 cutover 결과에 맞춰 갱신한다. 핵심:
+
+- README의 "Claude Agent SDK 기반" 진술을 실제 의존성과 일치시킴
+- CHANGELOG에 v0.1.0 항목 작성 (Added/Changed/Removed/Fixed/BreakingChanges)
+
+## Why
+
+- v0.0.1: README는 "built with Claude Agent SDK"인데 의존성은 raw `@anthropic-ai/sdk`만 → 진실성 갭 (사용자 신뢰 손상)
+- v0.1.0: AD-13~16 완료 후 실제로 `@anthropic-ai/claude-agent-sdk` 사용 → 진술 정합화 가능
+- CHANGELOG는 사용자가 마이그레이션 의사 결정에 사용
+
+## Who
+
+- **Assignee**: docs-owner
+- **Reviewers**: 코어 메인테이너 2 (README 변경은 외부 가시성 영향)
+- **Approval**: LGTM ≥ 2
+
+## When
+
+- AD-15 머지 직후
+- 작업 시간: 4시간
+
+## Where
+
+- `README.md`
+- `CHANGELOG.md`
+- (옵션) `README.ko.md` 동기화 (있을 시)
+
+## How
+
+### README 변경 항목
+
+- Quick Start 영역: `npm install -g ad-sdlc` 후 자동으로 Claude Agent SDK가 deps에 포함됨을 명시
+- "How it Works" 섹션: 3-tier 아키텍처 다이어그램(RFC §3)을 적용
+- Dependencies: 의존성 표 갱신
+- Architecture 링크: `docs/architecture/v0.1-hybrid-pipeline-rfc.md` 추가
+
+### CHANGELOG 항목 (예시)
+
+```markdown
+## [0.1.0] - YYYY-MM-DD
+
+### Added
+- ExecutionAdapter as the single Claude Agent SDK entry point (#AD-06)
+- Hook pipeline for scratchpad auto-capture (#AD-07)
+- Stage definition fields: skills, mcpServers, maxTurns, permissionMode (#AD-18)
+- claude-config plugin skill preload for worker/pr-reviewer (#AD-19)
+- `.claude/commands/` for ad-sdlc operations (#AD-20)
+- `.mcp.json` with github MCP server (#AD-21)
+- Pipeline checkpoint schema v2 with SDK session_id mapping (#AD-16)
+
+### Changed
+- `AdsdlcOrchestratorAgent` slimmed from 1,443 to ~900 LoC (#AD-15)
+- README architecture section now matches actual SDK dependency (#AD-17)
+
+### Removed
+- `AgentBridge` / `AgentDispatcher` / `AgentRegistry` and bridges/* (~2,000 LoC) (#AD-14)
+- Direct dependency on `@anthropic-ai/sdk` (replaced by Agent SDK) (#AD-14)
+
+### Fixed
+- Missing YAML frontmatter in `.claude/agents/doc-code-comparator.md` (#AD-04)
+- Naming mismatch between `validation` agent and `src/validation-agent/` (#AD-05)
+
+### Breaking Changes
+- Internal: `AgentBridge`, `AgentDispatcher` exports removed
+- Checkpoint schema v1 → v2 (auto-migrated)
+- Recommended: install Claude Agent SDK ≥ 0.2.111
+```
+
+### Acceptance Criteria
+
+- [ ] README "built with" 진술이 실제 dependency와 일치
+- [ ] 3-tier 아키텍처 다이어그램 추가 (RFC §3 Mermaid)
+- [ ] CHANGELOG v0.1.0 섹션 완비 (5 카테고리 모두 채움)
+- [ ] Migration Guide 링크 추가
+- [ ] AI/Claude attribution 0건 (Commit Settings 준수)
+- [ ] README.ko.md 동기화 (있을 경우)
+
+### Test Plan
+
+- [ ] markdown lint 통과
+- [ ] mermaid 미리보기 정상
+- [ ] 외부 링크 전부 200 OK
+
+### Out of Scope
+
+- 별도 release blog post (해당 시 별도 이슈)

--- a/.github/.issue-drafts/v0.1/AD-18.md
+++ b/.github/.issue-drafts/v0.1/AD-18.md
@@ -1,0 +1,90 @@
+---
+issue_id: AD-18
+phase: 4
+type: feat
+size: M
+priority: medium
+title: "feat(orchestrator): Stage 정의에 skills/mcpServers/maxTurns 필드 추가"
+labels: [phase/4, area/orchestrator, type/feature, size/M]
+depends_on: [AD-15]
+blocks: [AD-19, AD-21]
+branch: feat/stage-definition-fields
+---
+
+# feat(orchestrator): Stage 정의에 `skills` / `mcpServers` / `maxTurns` / `permissionMode` 필드 추가
+
+## What
+
+`PipelineStageDefinition` 타입에 신규 4 필드를 추가하고, ExecutionAdapter가 이를 SDK 옵션으로 전달하도록 wire한다. 본 이슈는 인프라만 — 실제 값을 채우는 것은 AD-19/AD-21에서.
+
+## Why
+
+- ARCH-RFC-001 §4.2: claude-config plugin skill preload, MCP 인라인 정의의 전제 조건
+- 현재 stage definition은 dependency·parallel 정보만 — Knowledge Layer 활용 불가
+- 본 변경 후 worker stage가 `skills: ['coding-guidelines']`을 선언적으로 가질 수 있음
+
+## Who
+
+- **Assignee**: orchestrator-owner
+- **Reviewers**: execution-owner 1
+- **Approval**: LGTM ≥ 1
+
+## When
+
+- AD-15 머지 직후
+- 작업 시간: 1일
+
+## Where
+
+- `src/ad-sdlc-orchestrator/types.ts`
+- `src/ad-sdlc-orchestrator/AdsdlcOrchestratorAgent.ts`
+- `src/execution/ExecutionAdapter.ts`
+- 모든 stage definition 모듈 (Greenfield/Enhancement/Import 정의 파일)
+
+## How
+
+### Type Changes
+
+```typescript
+export interface PipelineStageDefinition {
+  // 기존 유지
+  readonly name: StageName;
+  readonly agentType: string;
+  readonly mode: PipelineMode | 'all';
+  readonly dependencies: readonly StageName[];
+  readonly canParallelize?: boolean;
+  readonly approvalGate?: 'auto' | 'manual';
+
+  // 신규
+  readonly skills?: readonly string[];
+  readonly mcpServers?: Record<string, McpServerConfig>;
+  readonly maxTurns?: number;
+  readonly permissionMode?: 'default' | 'acceptEdits' | 'plan';
+  readonly timeoutMs?: number;
+}
+```
+
+### Implementation Steps
+
+1. 타입 확장 (Zod 스키마도 동기화)
+2. `executeStageAgent`이 stage 필드를 그대로 `StageExecutionRequest`로 전달
+3. `SdkExecutionAdapter`가 SDK `query()` 옵션으로 매핑 — `skills`, `mcpServers`, `maxTurns`, `permissionMode` 모두 SDK가 지원
+4. 기존 stage definition은 옵셔널 필드를 채우지 않음 (backward compatible)
+
+### Acceptance Criteria
+
+- [ ] 4 필드 추가, 모두 옵셔널
+- [ ] ExecutionAdapter가 필드를 누락 없이 SDK로 전달
+- [ ] 기존 stage 동작 변화 0 (옵셔널 필드 미채움)
+- [ ] 단위 테스트로 옵션 매핑 검증
+- [ ] `docs/architecture/dual-layer-design.md`에 신규 필드 설명 추가
+
+### Test Plan
+
+- [ ] `tests/execution/SdkExecutionAdapter.test.ts`에서 옵션 매핑 검증 시나리오 4종
+- [ ] E2E 시나리오 회귀 0
+
+### Out of Scope
+
+- 실제 stage에 값 채움 (AD-19, AD-21)
+- claude-config plugin 의존 (AD-19에서 처리)

--- a/.github/.issue-drafts/v0.1/AD-19.md
+++ b/.github/.issue-drafts/v0.1/AD-19.md
@@ -1,0 +1,83 @@
+---
+issue_id: AD-19
+phase: 4
+type: feat
+size: M
+priority: medium
+title: "feat(stages): worker/pr-reviewer에 claude-config plugin skill preload"
+labels: [phase/4, area/knowledge, type/feature, size/M]
+depends_on: [AD-18]
+blocks: [AD-22]
+branch: feat/preload-claude-config-skills
+---
+
+# feat(stages): `worker` / `pr-reviewer`에 claude-config plugin skill preload
+
+## What
+
+Greenfield/Enhancement/Import 모드의 stage definition에서 `worker`·`pr-reviewer`·`ci-fixer`에 claude-config plugin 제공 skill을 `skills:` 필드로 preload 선언한다.
+
+| Stage | Preload할 Skill (claude-config plugin) |
+|---|---|
+| worker | `coding-guidelines`, `security-audit` |
+| pr-reviewer | `pr-review`, `security-audit`, `code-quality` |
+| ci-fixer | `ci-debugging` |
+
+## Why
+
+- ARCH-RFC-001 §3 T3: Knowledge Layer가 코드 경로 외부에서 결합되어야 함
+- 현재 `claude-config/docs/ad-sdlc-integration.md`는 URL/curl 참조 권장 → 견고하지 않음
+- SDK `skills:` frontmatter는 plugin이 enable 상태일 때만 자동 inject — 미설치 시 graceful skip
+- Worker가 코딩 표준을 일관 적용 → 산출물 품질 향상 측정 가능
+
+## Who
+
+- **Assignee**: TBD
+- **Reviewers**: claude-config 메인테이너 1, AD-SDLC 메인테이너 1
+- **Approval**: LGTM ≥ 2
+
+## When
+
+- AD-18 머지 직후
+- 작업 시간: 1.5일 (선언 + 검증)
+
+## Where
+
+- `src/ad-sdlc-orchestrator/stages/greenfield.ts` (또는 동등 파일)
+- `src/ad-sdlc-orchestrator/stages/enhancement.ts`
+- `src/ad-sdlc-orchestrator/stages/import.ts`
+- `tests/integration/skills-preload/`
+
+## How
+
+### Implementation Steps
+
+1. 위 표대로 stage definition에 `skills` 필드 채움
+2. `SdkExecutionAdapter`가 SDK 옵션 `agents[type].skills`로 전달하는지 단위 테스트 추가
+3. plugin 미설치 환경 대응:
+   - `setting_sources` 옵션을 통해 `~/.claude/plugins/claude-config/skills/` 경로 자동 검색
+   - 부재 시 SDK가 warning 로그 → AD-SDLC 측에서도 startup에 1회 경고 방출
+4. CI 워크플로에 plugin 설치 단계 추가 (`/plugins install claude-config@2.3.0`)
+
+### Acceptance Criteria
+
+- [ ] worker / pr-reviewer / ci-fixer가 skills 필드 보유
+- [ ] plugin enable 시: skill 콘텐츠가 SDK subagent context에 inject됨을 SDK 디버그 로그로 확인
+- [ ] plugin 미설치 시: graceful warning + 정상 동작
+- [ ] CI에서 plugin 설치된 상태로 통합 테스트 통과
+- [ ] worker 산출물의 코딩 스타일 메트릭(예: ESLint 위반 수)이 사전 대비 ≥ 10% 개선
+
+### Test Plan
+
+- [ ] 통합 테스트: 동일 issue를 (a) skill preload on (b) off 두 번 실행 → 산출물 메트릭 비교
+- [ ] CI에서 plugin install ~ test 시퀀스 정상
+
+### Out of Scope
+
+- claude-config plugin 자체 변경 (claude-config 레포에서)
+- 다른 stage(SDS Writer 등)에 skill 추가 (별도 이슈)
+
+### Reference
+
+- claude-config plugin: https://github.com/kcenon/claude-config
+- 공식 SDK skills: https://code.claude.com/docs/en/sub-agents (skills 필드)

--- a/.github/.issue-drafts/v0.1/AD-20.md
+++ b/.github/.issue-drafts/v0.1/AD-20.md
@@ -1,0 +1,93 @@
+---
+issue_id: AD-20
+phase: 4
+type: feat
+size: M
+priority: medium
+title: "feat(commands): .claude/commands/ 추가 (run-greenfield/resume/audit-docs/status)"
+labels: [phase/4, area/knowledge, type/feature, size/M]
+depends_on: [AD-15]
+blocks: []
+branch: feat/claude-commands
+---
+
+# feat(commands): `.claude/commands/` 추가
+
+## What
+
+`.claude/commands/`에 AD-SDLC 운영용 slash command 4종을 추가한다.
+
+| Command 파일 | 역할 |
+|---|---|
+| `run-greenfield.md` | 새 Greenfield 파이프라인 시작 |
+| `resume.md` | 중단된 파이프라인 재개 |
+| `audit-docs.md` | doc-audit 실행 (`npm run audit:docs`) |
+| `status.md` | 현재 파이프라인 상태 출력 |
+
+## Why
+
+- 사용자가 Claude Code 세션 안에서 AD-SDLC를 사용할 때 CLI를 직접 호출하는 대신 슬래시 명령으로 인터랙션 가능
+- 공식 사양: `.claude/commands/*.md`는 자동 로드 (Agent SDK도 동일)
+- claude-config가 이미 commands 디렉터리를 plugin 형태로 제공 — AD-SDLC도 같은 패턴 채택해 통합성 확보
+
+## Who
+
+- **Assignee**: TBD
+- **Reviewers**: CLI-owner 1, docs-owner 1
+- **Approval**: LGTM ≥ 1
+
+## When
+
+- AD-15 머지 직후 (AD-18과 병렬 가능)
+- 작업 시간: 1일
+
+## Where
+
+- `.claude/commands/run-greenfield.md`
+- `.claude/commands/resume.md`
+- `.claude/commands/audit-docs.md`
+- `.claude/commands/status.md`
+
+## How
+
+### 각 명령 구조 (예시: run-greenfield.md)
+
+```markdown
+---
+description: Start a new Greenfield AD-SDLC pipeline
+argument-hint: "<project-name> [--tech-stack <stack>] [--template <template>]"
+---
+
+Run a Greenfield pipeline for the project. Steps:
+
+1. Validate that we're at the project root.
+2. Run `ad-sdlc init $1 --tech-stack ${2:-typescript}` if not initialized.
+3. Run `ad-sdlc run --mode greenfield`.
+4. Stream stage progress to the user.
+5. On failure, suggest `/resume` with the latest session ID.
+```
+
+### Implementation Steps
+
+1. 4개 명령 파일 작성, 각각 ≤ 30 lines
+2. argument-hint 정확히 작성 (Claude Code가 사용자에게 보여줌)
+3. 각 명령이 호출하는 CLI subcommand가 실제 존재하는지 검증
+4. README.md에 commands 섹션 추가
+
+### Acceptance Criteria
+
+- [ ] 4개 .md 파일 추가
+- [ ] 각각 frontmatter 보유 (description 필수)
+- [ ] Claude Code 세션에서 `/run-greenfield`, `/resume`, `/audit-docs`, `/status` 4종 동작
+- [ ] README에 슬래시 명령 사용법 섹션 추가
+- [ ] 각 명령이 호출하는 CLI 명령이 실재함을 단위 테스트로 검증 (옵션)
+
+### Test Plan
+
+- [ ] 수동: Claude Code 세션에서 4종 명령 실행
+- [ ] 자동: `find .claude/commands -name "*.md" | xargs -I{} head -1 {}` 결과 모두 `---`
+
+### Out of Scope
+
+- 한국어 명령어 변형
+- claude-config 제공 명령과 namespace 충돌 처리 (현재 충돌 없음)

--- a/.github/.issue-drafts/v0.1/AD-21.md
+++ b/.github/.issue-drafts/v0.1/AD-21.md
@@ -1,0 +1,91 @@
+---
+issue_id: AD-21
+phase: 4
+type: feat
+size: S
+priority: low
+title: "feat(mcp): .mcp.json 추가 (github MCP)"
+labels: [phase/4, area/knowledge, type/feature, size/S]
+depends_on: [AD-18]
+blocks: []
+branch: feat/mcp-json-github
+---
+
+# feat(mcp): `.mcp.json` 추가 (github MCP)
+
+## What
+
+저장소 루트에 `.mcp.json`을 추가하여 github MCP 서버를 팀 공유 정의로 등록한다. `pr-reviewer` / `ci-fixer` / `issue-generator` stage가 이를 통해 GitHub 작업을 표준화된 MCP 인터페이스로 수행.
+
+## Why
+
+- 현재 `gh` CLI를 Bash 도구로 호출 → 표준화·재시도·오류 처리가 일관되지 않음
+- MCP github 서버는 issue/PR/comments를 1급 도구로 노출 → SDK가 retry·rate limit을 자동 처리
+- 팀 공유 `.mcp.json`은 `.env`의 `${VAR}` 보간을 지원 → secret 안전
+- ARCH-RFC-001 §3 T3 (Knowledge Layer)의 일부
+
+## Who
+
+- **Assignee**: TBD
+- **Reviewers**: 코어 메인테이너 1, security 담당 1
+- **Approval**: LGTM ≥ 1
+
+## When
+
+- AD-18 머지 직후
+- 작업 시간: 4시간
+
+## Where
+
+- `.mcp.json` (신규)
+- `.mcp.json.example` (보강)
+- `.gitignore` (`.env` 확인)
+- `docs/configuration/mcp.md` (신규 또는 갱신)
+
+## How
+
+### `.mcp.json` 예시
+
+```json
+{
+  "$schema": "https://modelcontextprotocol.io/schema/v1.json",
+  "mcpServers": {
+    "github": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-github@latest"],
+      "env": {
+        "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_TOKEN}"
+      }
+    }
+  }
+}
+```
+
+### Implementation Steps
+
+1. `.mcp.json` 파일 추가 (실제 토큰은 `.env` 보간)
+2. `.mcp.json.example` 갱신 (현재는 다른 예시만 있을 수 있음 — 점검)
+3. `pr-reviewer` / `ci-fixer` / `issue-generator` stage definition에 `mcpServers: ['github']` 추가 (AD-18 산출물 활용)
+4. 문서 작성: `docs/configuration/mcp.md` — 설치, secret 설정, 디버깅
+5. README.md "Prerequisites"에 GITHUB_TOKEN 안내
+
+### Acceptance Criteria
+
+- [ ] `.mcp.json` 추가 (secret hardcode 0건)
+- [ ] 3개 stage가 github MCP 사용
+- [ ] `gh` CLI 사용 사이트가 MCP로 1:1 대체된 것 1건 이상 (point-of-proof)
+- [ ] secret이 `.env`에서 보간되는지 정수 검증
+- [ ] CI에서 GITHUB_TOKEN을 secret으로 주입하는 워크플로 갱신
+- [ ] 문서: 설치·디버깅 가이드 포함
+
+### Test Plan
+
+- [ ] 로컬에서 `.env`에 토큰 설정 후 pr-reviewer dry-run으로 MCP 호출 검증
+- [ ] CI 통합 테스트
+- [ ] secret 누출 검사 (`git log -p .mcp.json` 결과 토큰 0건)
+
+### Out of Scope
+
+- 다른 MCP 서버(filesystem, playwright 등) 추가 — 별도 이슈
+- gh CLI 제거 (점진적, 별도 이슈)

--- a/.github/.issue-drafts/v0.1/AD-22.md
+++ b/.github/.issue-drafts/v0.1/AD-22.md
@@ -1,0 +1,112 @@
+---
+issue_id: AD-22
+phase: 4
+type: docs
+size: S
+priority: medium
+title: "docs(integration): claude-config/docs/ad-sdlc-integration.md 갱신"
+labels: [phase/4, area/docs, type/docs, size/S]
+depends_on: [AD-19]
+blocks: []
+branch: docs/integration-update
+external_repo: kcenon/claude-config
+---
+
+# docs(integration): `claude-config/docs/ad-sdlc-integration.md` 갱신
+
+## What
+
+본 이슈는 **`claude-config` 레포에 대한 PR**을 생성하여 `docs/ad-sdlc-integration.md`를 다음과 같이 갱신한다.
+
+1. 에이전트 수: "27 agents" → "35 agents"
+2. Skill 위치: `project/.claude/skills/` → `plugin/skills/` (실제 plugin 경로)
+3. 통합 방법 §4: "URL 참조 / git clone / curl"을 **plugin 메커니즘 + SDK skills frontmatter** 우선 안내로 재정렬
+4. AD-SDLC v0.1.0이 본 plugin을 어떻게 활용하는지 1 섹션 추가
+
+## Why
+
+- 현재 ad-sdlc-integration.md는 AD-SDLC v0.0.1 + claude-config v1.x 기준 — 두 레포 모두 진화함
+- AD-19에서 plugin skill preload가 정착되면 본 문서가 통합 진입점이 되어야 함
+- claude-config 레포의 변경이라 별도 PR — AD-SDLC 측 PR과 cross-link
+
+## Who
+
+- **Assignee**: docs-owner (AD-SDLC) + claude-config 메인테이너 협조
+- **Reviewers**: claude-config 메인테이너 1
+- **Approval**: claude-config 측 LGTM ≥ 1
+
+## When
+
+- AD-19 머지 직후 (AD-SDLC 측 변화 가시화 후)
+- 작업 시간: 4시간
+
+## Where
+
+- 외부 레포: `kcenon/claude-config:docs/ad-sdlc-integration.md`
+- AD-SDLC 측: `docs/architecture/v0.1-final-report.md`에서 본 PR 인용
+
+## How
+
+### 갱신 항목
+
+#### §1 Overview
+
+- "27 specialized AI agents" → "35 specialized AI agents (Greenfield/Enhancement/Import 모드)"
+- claude-config v2.3.0 plugin 도입을 1 문장으로 명시
+
+#### §2 Resource Mapping (Skills → AD-SDLC Agents)
+
+기존 표를 다음으로 확장:
+
+| claude-config Skill | AD-SDLC Stage | 도입 | Notes |
+|---|---|---|---|
+| `coding-guidelines` | worker | v0.1.0 자동 preload | AD-19 |
+| `security-audit` | worker, pr-reviewer | v0.1.0 자동 preload | AD-19 |
+| `code-quality` | pr-reviewer | v0.1.0 자동 preload | AD-19 |
+| `pr-review` | pr-reviewer | v0.1.0 자동 preload | AD-19 |
+| `ci-debugging` | ci-fixer | v0.1.0 자동 preload | AD-19 |
+| `api-design` | sds-writer | manual reference | URL 또는 plugin 활성 |
+| `documentation` | prd-writer, srs-writer, sds-writer | manual reference | URL 또는 plugin 활성 |
+| `performance-review` | codebase-analyzer | manual reference | |
+| `project-workflow` | controller, issue-generator | manual reference | |
+
+#### §3 Reference Methods (재정렬)
+
+- **권장 (v0.1.0+)**: plugin enable + SDK `skills:` frontmatter (자동 inject)
+- **Method 1 (legacy)**: URL 참조
+- **Method 2 (legacy)**: git clone
+- **Method 3 (legacy)**: curl
+
+#### 신규 §6 — Plugin Activation
+
+```bash
+# Claude Code 세션 안에서
+/plugins install claude-config@2.3.0
+/plugins enable claude-config
+
+# AD-SDLC가 v0.1.0 이상이면 worker/pr-reviewer/ci-fixer가 자동으로 preload
+ad-sdlc run
+```
+
+### Acceptance Criteria
+
+- [ ] PR이 claude-config:develop에 머지
+- [ ] AD-SDLC 측에서 `docs/architecture/v0.1-final-report.md`로 본 PR cross-link
+- [ ] §3에서 plugin 메커니즘이 “권장 방법”으로 명시됨
+- [ ] 표가 9개 행으로 확장되고 각 row에 도입 시점 명시
+- [ ] 깨진 링크 0건
+
+### Test Plan
+
+- [ ] markdown 미리보기에서 표 정상 렌더링
+- [ ] 외부 링크 200 OK
+
+### Out of Scope
+
+- claude-config plugin 자체 변경
+- 한국어 동기화 (필요 시 별도)
+
+### Reference
+
+- 현재 문서: `claude-config/docs/ad-sdlc-integration.md`
+- ARCH-RFC-001 §3 T3

--- a/.github/.issue-drafts/v0.1/INDEX.md
+++ b/.github/.issue-drafts/v0.1/INDEX.md
@@ -1,0 +1,122 @@
+# v0.1 Hybrid Pipeline — Issue Drafts Index
+
+> **RFC**: [`docs/architecture/v0.1-hybrid-pipeline-rfc.md`](../../../docs/architecture/v0.1-hybrid-pipeline-rfc.md)
+> **Migration Guide**: [`docs/architecture/v0.1-migration-guide.md`](../../../docs/architecture/v0.1-migration-guide.md)
+> **Target branch**: `develop`
+> **Total issues**: 20
+
+## 발행 절차 (How to publish)
+
+본 디렉터리의 각 `.md`는 frontmatter + 5W1H 본문 구조로, 그대로 GitHub에 게시 가능합니다.
+
+```bash
+cd /project/claude_code_agent
+
+# 단일 게시
+gh issue create \
+  --title "$(yq '.title' .github/.issue-drafts/v0.1/AD-01.md)" \
+  --label "$(yq '.labels | join(\",\")' .github/.issue-drafts/v0.1/AD-01.md)" \
+  --body-file .github/.issue-drafts/v0.1/AD-01.md
+
+# 일괄 게시 (예시)
+for f in .github/.issue-drafts/v0.1/AD-*.md; do
+  gh issue create --body-file "$f" \
+    --title "$(awk '/^title:/{print substr($0, 8)}' $f | tr -d '\"')"
+done
+```
+
+## Phase 0 — Documentation Foundation
+
+| ID | Type | Size | Title | Depends |
+|---|---|---|---|---|
+| AD-01 | docs | S | RFC: v0.1 Hybrid Pipeline Architecture 게시 | — |
+| AD-02 | docs | S | Migration Guide v0.0.1 → v0.1.0 게시 | AD-01 |
+
+## Phase 1 — Foundation
+
+| ID | Type | Size | Title | Depends |
+|---|---|---|---|---|
+| AD-03 | chore | XS | `@anthropic-ai/claude-agent-sdk` 의존성 추가 | AD-01 |
+| AD-04 | fix | XS | `doc-code-comparator.md` frontmatter 추가 (사양 위반 긴급) | — |
+| AD-05 | refactor | S | `validation` 에이전트 ↔ `src/validation-agent/` 네이밍 정합화 | — |
+| AD-06 | feat | M | `ExecutionAdapter` 인터페이스 + `MockExecutionAdapter` | AD-03 |
+| AD-07 | feat | S | Hook pipeline 최소 골격 (PostToolUse → scratchpad) | AD-06 |
+| AD-08 | docs | XS | `src/execution/README.md` 작성 | AD-06 |
+
+## Phase 2 — Single Stage Pilot
+
+| ID | Type | Size | Title | Depends |
+|---|---|---|---|---|
+| AD-09 | feat | M | `worker` stage 파일럿 — `ExecutionAdapter` 경로 도입 | AD-06, AD-07 |
+| AD-10 | test | S | `worker` 파일럿 통합 테스트 (mock vs real) | AD-09 |
+| AD-11 | feat | XS | Feature flag `AD_SDLC_USE_SDK_FOR_WORKER` | AD-09 |
+| AD-12 | docs | S | 파일럿 평가 보고서 | AD-10 |
+
+## Phase 3 — Full Cutover
+
+| ID | Type | Size | Title | Depends |
+|---|---|---|---|---|
+| AD-13 | refactor | L | 전체 34 stage `ExecutionAdapter` 경유 (5 sub-PR) | AD-12 |
+| AD-14 | chore | M | `AgentBridge` / `Dispatcher` / `Registry` 삭제 | AD-13 |
+| AD-15 | refactor | M | `AdsdlcOrchestratorAgent` 슬림화 | AD-14 |
+| AD-16 | feat | S | `PipelineCheckpointManager`에 SDK `session_id` 매핑 | AD-13 |
+| AD-17 | docs | S | README "built with Agent SDK" 진실성 정정 + CHANGELOG | AD-15 |
+
+## Phase 4 — Knowledge Layer
+
+| ID | Type | Size | Title | Depends |
+|---|---|---|---|---|
+| AD-18 | feat | M | Stage 정의에 `skills` / `mcpServers` 필드 추가 | AD-15 |
+| AD-19 | feat | M | `worker`/`pr-reviewer`에 claude-config plugin skill preload | AD-18 |
+| AD-20 | feat | M | `.claude/commands/` 추가 (`run-greenfield`/`resume`/`audit-docs`/`status`) | AD-15 |
+| AD-21 | feat | S | `.mcp.json` 추가 (github MCP) | AD-18 |
+| AD-22 | docs | S | `claude-config/docs/ad-sdlc-integration.md` 갱신 (35 agents, plugin 경로) | AD-19 |
+
+## 의존 그래프
+
+```mermaid
+flowchart LR
+  AD01[AD-01 RFC] --> AD02[AD-02 MigGuide]
+  AD01 --> AD03[AD-03 SDK dep]
+  AD03 --> AD06[AD-06 Adapter]
+  AD06 --> AD07[AD-07 Hooks]
+  AD06 --> AD08[AD-08 README]
+  AD06 --> AD09[AD-09 Pilot]
+  AD07 --> AD09
+  AD09 --> AD10[AD-10 Tests]
+  AD09 --> AD11[AD-11 Flag]
+  AD10 --> AD12[AD-12 Eval]
+  AD12 --> AD13[AD-13 Cutover]
+  AD13 --> AD14[AD-14 Delete Bridge]
+  AD14 --> AD15[AD-15 Slim Orch]
+  AD13 --> AD16[AD-16 Ckpt SDK]
+  AD15 --> AD17[AD-17 README/CHANGELOG]
+  AD15 --> AD18[AD-18 Stage Fields]
+  AD15 --> AD20[AD-20 Commands]
+  AD18 --> AD19[AD-19 Skills Preload]
+  AD18 --> AD21[AD-21 MCP]
+  AD19 --> AD22[AD-22 Integration Doc]
+  AD04[AD-04 Frontmatter Fix]:::urgent
+  AD05[AD-05 Naming Fix]:::urgent
+  classDef urgent fill:#ffcdd2,stroke:#c62828
+```
+
+## Phase Gate
+
+| Gate | 통과 조건 |
+|---|---|
+| P0 → P1 | RFC LGTM ≥ 1, Migration Guide 머지 |
+| P1 → P2 | AD-03~08 머지, 기존 테스트 100% + Adapter 단위 테스트 신설 |
+| P2 → P3 | AD-09~12 머지, worker stage 산출물 동등성 검증 |
+| P3 → P4 | AD-13~17 머지, E2E 3종(Greenfield/Enhancement/Import) 통과, 코드 -2,000 LoC |
+| P4 release | AD-18~22 머지, claude-config plugin enable 시나리오 통과 |
+
+## 라벨 정책
+
+| 라벨 | 의미 |
+|---|---|
+| `phase/0`~`phase/4` | 마이그레이션 단계 |
+| `area/execution`, `area/orchestrator`, `area/agents-md`, `area/docs`, `area/knowledge` | 영향 영역 |
+| `breaking-change` | 외부 사용자 영향 있음 |
+| `priority/high` | 사양 위반 또는 P3 게이트 |
+| `size/XS`~`size/L` | 예상 작업량 |

--- a/.github/.pr-drafts/v0.1/PR-A-ad-04-frontmatter-fix.md
+++ b/.github/.pr-drafts/v0.1/PR-A-ad-04-frontmatter-fix.md
@@ -1,0 +1,119 @@
+# fix(agents): doc-code-comparator.md frontmatter 추가 + CI 검증 step
+
+> **PR Track**: A (urgent surgical fix)
+> **Branch**: `fix/doc-code-comparator-frontmatter`
+> **Base**: `develop`
+> **Closes**: AD-04 (issue draft: `.github/.issue-drafts/v0.1/AD-04.md`)
+
+## What
+
+Claude Code 공식 사양상 필수인 **YAML frontmatter**가 누락되어 있던 `.claude/agents/doc-code-comparator.md`에 frontmatter를 추가하고, 동일 위반 재발을 막기 위한 **CI 검증 job**을 `docs-check.yml`에 추가합니다.
+
+### 변경 파일
+
+| 파일 | 변경 |
+|---|---|
+| `.claude/agents/doc-code-comparator.md` | frontmatter 추가 (15줄) |
+| `.github/workflows/docs-check.yml` | `validate-agent-frontmatter` job 추가 + path trigger 확장 |
+
+## Why
+
+- 공식 사양: subagent는 YAML frontmatter(`name`/`description` 필수) 보유 필수
+  - https://code.claude.com/docs/en/sub-agents §"Write subagent files"
+- 현재 동작: `head -1 doc-code-comparator.md`가 `# Doc-Code Comparator Agent` → Claude Code가 subagent로 인식 불가
+- 영향: Enhancement 파이프라인에서 본 에이전트 invoke 시 fallback prompt(generic)으로 동작 → 분석 품질 저하
+- v0.1 마이그레이션의 RFC(`docs/architecture/v0.1-hybrid-pipeline-rfc.md`)와 무관하게 즉시 처리해야 할 사양 위반 — 별도 PR로 분리
+
+## Who
+
+- **Reviewers**: 코어 메인테이너 1, doc-code-comparator 도메인 1 (선택)
+- **Approval**: LGTM ≥ 1
+
+## When
+
+- 발의: 2026-05-07
+- merge ASAP — RFC PR과 독립
+
+## Where
+
+- `.claude/agents/doc-code-comparator.md`
+- `.github/workflows/docs-check.yml`
+
+## How
+
+### 적용된 frontmatter
+
+```yaml
+---
+name: doc-code-comparator
+description: |
+  Doc-Code Comparator Agent. Analyzes the gap between documentation specifications
+  and actual code implementations. Detects discrepancies, missing implementations,
+  and undocumented code, generating actionable gap analysis with confidence scores.
+  Use this agent in the Enhancement pipeline after Document Reader and Code Reader
+  to produce gap_analysis.yaml.
+tools:
+  - Read
+  - Write
+  - Glob
+  - Grep
+model: inherit
+---
+```
+
+- 패턴: sibling 에이전트(`impact-analyzer.md`, `codebase-analyzer.md`)와 동일
+- tools: 본문이 명시한 작업(읽기·검색·매핑·점수 계산)에 필요한 4개만 allowlist (Bash 미포함)
+- model: 다른 33개 에이전트와 일관되게 `inherit`
+
+### 추가된 CI job (`docs-check.yml`)
+
+`validate-agent-frontmatter`:
+1. 모든 `.claude/agents/*.md`의 첫 줄이 `---`인지 검증 → 누락 시 fail
+2. frontmatter 안에 `name`/`description` 필드 존재 검증 → 누락 시 fail
+3. trigger path에 `.claude/agents/**` 추가하여 향후 같은 회귀 자동 감지
+
+### Acceptance Criteria
+
+- [x] frontmatter 추가됨 (`---`로 시작, 15줄)
+- [x] `name: doc-code-comparator` (kebab-case)
+- [x] `description`에 위임 트리거 키워드("Use this agent") 포함
+- [x] `tools` 리스트가 본문 작업에 매칭
+- [x] `model: inherit` (project-initializer 외 일관)
+- [x] 다른 에이전트 변경 0
+- [x] CI 검증 step 추가
+- [x] 로컬 검증 — 34/34 frontmatter 보유, 34/34 name+description 보유 (Python script)
+
+### Test Plan
+
+- [x] 로컬 검증: `python3 -c "..."` 결과 34/34 통과
+- [ ] CI: `validate-agent-frontmatter` job 그린
+- [ ] CI: 기존 `validate-traceability`/`check-cascade` job 회귀 0
+- [ ] (선택) Enhancement 파이프라인 dry-run에서 doc-code-comparator stage가 실제 정의 로드 확인
+
+### Risks & Mitigation
+
+- **R1**: tools 리스트가 부족해 도구 호출 거부될 가능성
+  - 완화: 본문 §Capabilities/Process가 file I/O와 grep만 명시 — 충분
+  - escape hatch: 이슈 발생 시 hot-fix로 Bash 추가
+- **R2**: CI step의 zsh 호환성
+  - 완화: GitHub Actions는 bash 사용 — `set -euo pipefail` + `[ ... ]` 표준 POSIX 구문 사용
+
+### Out of Scope
+
+- 본문 콘텐츠 변경
+- 다른 에이전트의 frontmatter 표준화 (이미 33개 모두 보유)
+- AD-05 네이밍 정합화 (별도 PR)
+- v0.1 RFC (별도 PR)
+
+## Linked Issues
+
+- Closes: AD-04 (이슈 발행 후 번호 채움)
+- Related: AD-05 (`validation` 에이전트 네이밍 — 동일 사양 컴플라이언스 영역)
+- Parent context: `docs/architecture/v0.1-hybrid-pipeline-rfc.md` (별도 PR로 진행 중)
+
+## Reviewer Checklist
+
+- [ ] frontmatter 필드가 sibling 에이전트와 일관 (`impact-analyzer.md` 비교)
+- [ ] CI job이 의도대로 동작 — 새 PR에서 `head -1`이 `---` 아닌 .md 추가 시 fail 확인 (옵션 — 별도 검증 PR로 시뮬레이션 가능)
+- [ ] 변경 라인 수 ≤ 50 (실제: 약 18라인 + CI job 약 35라인)
+- [ ] 본 PR이 v0.1 RFC PR과 독립 — 머지 순서 무관

--- a/.github/.pr-drafts/v0.1/PR-B-rfc-and-issue-drafts.md
+++ b/.github/.pr-drafts/v0.1/PR-B-rfc-and-issue-drafts.md
@@ -1,0 +1,171 @@
+# docs(architecture): add v0.1 Hybrid Pipeline RFC + 22 issue drafts
+
+> **PR Track**: B (parent RFC, large but doc-only)
+> **Branch**: `docs/v01-rfc-and-drafts`
+> **Base**: `develop`
+> **Closes**: AD-01, AD-02 (issue drafts 자체)
+> **Related**: PR-A (병렬 진행)
+
+## What
+
+AD-SDLC v0.0.1 → v0.1.0 마이그레이션의 부모 RFC와 22개 후속 이슈 드래프트를 docs-only PR로 도입합니다. 코드 변경 0건 — 본 PR은 **합의의 컨테이너**.
+
+### 변경 파일 요약 (25 files, +2,196 LoC)
+
+| 디렉터리 | 파일 수 | 역할 |
+|---|---|---|
+| `docs/architecture/` | 2 | RFC 본문 + 마이그레이션 가이드 |
+| `.github/.issue-drafts/v0.1/` | 23 | INDEX.md + 22 issue drafts (AD-01 ~ AD-22) |
+
+### 변경 파일 목록
+
+```
+docs/architecture/v0.1-hybrid-pipeline-rfc.md    (신규, ~250 lines)
+docs/architecture/v0.1-migration-guide.md         (신규, ~120 lines)
+.github/.issue-drafts/v0.1/INDEX.md               (신규, 마스터 인덱스)
+.github/.issue-drafts/v0.1/AD-01.md ~ AD-22.md    (신규, 5W1H 이슈 드래프트 22개)
+```
+
+## Why
+
+`v0.0.1` 분석 결과 (3 round-trip 결과 본 PR 산출):
+
+1. **진실성 갭**: README는 "built with Claude Agent SDK"이나 의존성은 raw `@anthropic-ai/sdk@^0.92.0`만
+2. **자산 미활용**: 같은 호스트에 있는 `claude-config` v2.3.0 plugin (8 agents + 7 skills + global hooks)이 코드 경로상 미결합
+3. **사양 위반 잠복**: `.claude/agents/doc-code-comparator.md` frontmatter 누락 (PR-A에서 별도 fix)
+
+본 RFC는 위 3가지를 **하이브리드 아키텍처**로 해소합니다:
+- 도메인 자산(35단계 SDLC 파이프라인·V&V·트레이서빌리티)은 보존
+- 에이전트 실행만 `@anthropic-ai/claude-agent-sdk`에 위임 (~2,000 LoC 슬림화)
+- claude-config plugin을 `skills:` frontmatter로 표준 결합
+
+## Who
+
+- **Reviewers**: 코어 메인테이너 2 (architecture, docs)
+- **Approval**: LGTM ≥ 1 (RFC 채택 결정)
+- **Optional reviewers**: 외부 사용자 대표(베타) 1, claude-config 메인테이너 1
+
+## When
+
+- 발의: 2026-05-07
+- 검토 deadline: +5 영업일 (2026-05-14)
+- 머지 후: 22개 이슈 일괄 게시 (`gh issue create --body-file ...`)
+
+## Where
+
+- `docs/architecture/`
+- `.github/.issue-drafts/v0.1/`
+
+## How
+
+### 새 3-Tier 아키텍처
+
+```
+T1 Pipeline Control Plane (도메인, 유지)
+   ├ AdsdlcOrchestratorAgent (stage DAG)
+   ├ PipelineCheckpointManager (mid-stage resume)
+   ├ ArtifactValidator + V&V (stage-verifier, rtm-builder, doc-audit)
+   ├ Writers / Analyzers / Updaters (35 agents)
+   └ Scratchpad (File / SQLite / Redis)
+                ↓
+T2 Agent Execution Layer (신규, 얇음)
+   ├ ExecutionAdapter (단일 SDK 진입점)
+   ├ Hook Pipeline (PostToolUse → scratchpad/OTel)
+   └ Telemetry Bridge
+                ↓
+T3 Knowledge Layer (외부 자산, 표준 결합)
+   ├ .claude/agents/*.md (35, 100% frontmatter)
+   ├ .claude/skills/  (claude-config plugin 흡수)
+   ├ .claude/commands/  (신규)
+   ├ .mcp.json (github MCP)
+   └ claude-config v2.3.0 plugin (별도 설치)
+```
+
+### 5 Phase 마이그레이션
+
+| Phase | 이슈 | 게이트 |
+|---|---|---|
+| **P0 Docs** | AD-01, AD-02 | RFC LGTM ≥ 1 |
+| **P1 Foundation** | AD-03 ~ AD-08 | 기존 테스트 100% + Adapter 단위 테스트 |
+| **P2 Pilot** | AD-09 ~ AD-12 | worker stage 산출물 동등 |
+| **P3 Cutover** | AD-13 ~ AD-17 | E2E 3종 + 코드 -2,000 LoC |
+| **P4 Knowledge** | AD-18 ~ AD-22 | plugin enable 시나리오 통과 |
+
+### 주요 인터페이스 (RFC §4 발췌)
+
+```typescript
+export interface ExecutionAdapter {
+  execute(req: StageExecutionRequest): Promise<StageExecutionResult>;
+  dispose(): Promise<void>;
+}
+```
+
+### 측정 지표 목표
+
+| 지표 | 베이스라인 | 목표 |
+|---|---|---|
+| 자체 에이전트 인프라 LoC | ~2,000 | ≤ 200 |
+| `.claude/agents` frontmatter 준수율 | 33/34 (97%) | 35/35 (100%) |
+| claude-config skill 활용 | 0 | ≥ 3 |
+| MCP server 활용 | 0 | ≥ 1 |
+
+### Acceptance Criteria (이 PR)
+
+- [x] `docs/architecture/v0.1-hybrid-pipeline-rfc.md` 작성 (10 섹션, mermaid 다이어그램 포함)
+- [x] `docs/architecture/v0.1-migration-guide.md` 작성 (사용자·기여자 영향, 롤백, FAQ)
+- [x] `.github/.issue-drafts/v0.1/INDEX.md` 작성 (의존 그래프 + 발행 절차)
+- [x] 22개 이슈 드래프트 모두 frontmatter + 5W1H 5섹션 충족
+- [x] INDEX.md mermaid 노드 수와 이슈 수 일치 (22)
+- [x] 모든 이슈에 `depends_on`/`blocks` 명시
+- [ ] 외부 링크 모두 200 OK (CI에서 자동 검증, 옵션)
+- [ ] mermaid 미리보기 정상 (GitHub PR 미리보기 검토)
+
+### Test Plan
+
+이 PR은 docs-only — 코드 테스트 무관.
+
+- [ ] markdown lint 통과
+- [ ] mermaid 다이어그램 미리보기 정상
+- [ ] 본문 내 cross-link 동작 (RFC ↔ 마이그레이션 가이드 ↔ 이슈 드래프트)
+
+### 리뷰 가이드
+
+리뷰어가 큰 PR(25 files)을 효율적으로 검토할 수 있도록 권장 순서:
+
+1. **`docs/architecture/v0.1-hybrid-pipeline-rfc.md`** — 본 PR의 본질
+2. **`.github/.issue-drafts/v0.1/INDEX.md`** — 의존 그래프와 phase gate
+3. **샘플 이슈 1개씩 phase별** (예: AD-04, AD-06, AD-09, AD-13, AD-19) — 5W1H 품질 검증
+4. **`docs/architecture/v0.1-migration-guide.md`** — 외부 사용자 영향
+5. **나머지 이슈 드래프트** — skim 또는 머지 후 게시 시점 추가 보완
+
+### 머지 후 작업
+
+```bash
+# 22개 이슈 일괄 게시 (예시)
+cd /project/claude_code_agent
+for n in 01 02 04 05 03 06 07 08 09 10 11 12 13 14 15 16 17 18 19 20 21 22; do
+  title=$(awk -F'"' '/^title:/{print $2}' .github/.issue-drafts/v0.1/AD-$n.md)
+  labels=$(grep -oP '(?<=labels: \[).*?(?=\])' .github/.issue-drafts/v0.1/AD-$n.md)
+  gh issue create \
+    --title "$title" \
+    --body-file ".github/.issue-drafts/v0.1/AD-$n.md" \
+    --label "$labels"
+done
+```
+
+## Linked Items
+
+- Track A 병렬 PR: `fix(agents): doc-code-comparator.md frontmatter` (PR-A)
+- 후속: 22 issue drafts → 머지 후 GitHub 이슈로 발행
+- 외부 레포 후속: `claude-config:docs/ad-sdlc-integration.md` 갱신 PR (AD-22)
+
+## Reviewer Checklist
+
+- [ ] RFC §3 3-tier 분리가 명확하고 책임 경계 자연스러움
+- [ ] §4 인터페이스 시그니처가 TypeScript에서 실제로 컴파일 가능
+- [ ] §5 변경 영향 매트릭스의 LoC 추정이 합리적
+- [ ] §6 5 phase가 각각 독립 mergeable + revertible
+- [ ] §7 위험 등록부 R1~R5의 완화책이 구체적
+- [ ] 22개 이슈 드래프트 의존 그래프(INDEX.md)에 사이클 없음
+- [ ] 각 이슈가 ≤ 2-3일 작업으로 추정 가능 (size/L인 AD-13만 sub-PR 5개로 분할 명시)
+- [ ] AI/Claude attribution 0건 (Commit Settings 준수)

--- a/docs/architecture/v0.1-hybrid-pipeline-rfc.md
+++ b/docs/architecture/v0.1-hybrid-pipeline-rfc.md
@@ -1,0 +1,180 @@
+---
+doc_id: ARCH-RFC-001
+doc_title: AD-SDLC v0.1 Hybrid Pipeline Architecture RFC
+doc_version: 0.1.0-draft
+doc_status: draft
+authors:
+  - kcenon
+related_issues:
+  - "#TBD (parent)"
+supersedes: null
+applies_to:
+  - src/ad-sdlc-orchestrator/**
+  - src/agents/**
+  - .claude/agents/**
+---
+
+# AD-SDLC v0.1 Hybrid Pipeline Architecture (RFC)
+
+> **Status**: Draft — open for review
+> **Target release**: v0.1.0
+> **Decision deadline**: TBD
+
+## 1. 배경 (Why)
+
+AD-SDLC v0.0.1은 README에서 "built with Claude Agent SDK"를 표방하지만 실제 의존성은 raw Client SDK(`@anthropic-ai/sdk@^0.92.0`) 단 하나이며, 도구 루프·세션·서브에이전트 위임을 자체 구현했습니다 (`src/agents/AgentBridge.ts` 외 ~2,000 LoC). 한편 같은 호스트의 `claude-config` v2.3.0은 정식 Claude Code plugin으로 8개 agents + 7개 skills + global hooks를 제공하지만, AD-SDLC와 코드 경로상 결합 지점이 없습니다.
+
+세 가지 결과를 가져옵니다.
+
+1. **진실성 갭** — README의 SDK 명칭이 의존성과 불일치
+2. **자산 미활용** — claude-config의 plugin 자산을 coding standards 적용에 못 씀
+3. **사양 위반 잠복** — `doc-code-comparator.md` frontmatter 누락 등 spec 위반이 빌드를 통과
+
+## 2. 목표 (Goals) / 비목표 (Non-goals)
+
+**Goals**
+
+- G1. Claude Agent SDK(`@anthropic-ai/claude-agent-sdk`)를 단일 진입점으로 도입
+- G2. 35단계 SDLC 파이프라인·V&V 게이트·트레이서빌리티 등 **도메인 자산은 보존**
+- G3. claude-config plugin과 skill·MCP·hook 차원에서 **표준 메커니즘으로 결합**
+- G4. `.claude/agents/*.md` 100% 사양 준수
+- G5. 단일 SDK 진입점으로 테스트·관측·정책 일원화
+
+**Non-goals**
+
+- 단일 패키지 분리(monorepo 전환)
+- 35 stage 시맨틱 변경
+- writers/analyzers 도메인 로직 재작성
+- 문서 스키마 변경
+
+## 3. 3-Tier 아키텍처
+
+| Tier | 책임 | 구현 |
+|---|---|---|
+| **T1 Pipeline Control Plane** | stage DAG, 체크포인트, V&V 게이트, 도메인 writers | 기존 `ad-sdlc-orchestrator/`, `*-writer/`, `vnv/` 등 (유지) |
+| **T2 Agent Execution Layer** | 단일 SDK 진입점, hooks, telemetry bridge | `src/execution/` (신규) |
+| **T3 Knowledge Layer** | 에이전트 정의, skill, command, MCP | `.claude/`, `.mcp.json`, claude-config plugin |
+
+```mermaid
+flowchart TB
+    Orch[T1 Orchestrator] -->|stage 단위| Adapter[T2 ExecutionAdapter]
+    Adapter --> SDK[Agent SDK query]
+    Adapter --> Hooks[Hook Pipeline]
+    SDK -.reads.-> Knowledge[T3 .claude/ + plugin]
+    Hooks --> Scratchpad
+    Hooks --> Telemetry
+```
+
+## 4. 핵심 인터페이스
+
+### 4.1 ExecutionAdapter
+
+```typescript
+export interface StageExecutionRequest {
+  readonly agentType: string;
+  readonly workOrder: string;
+  readonly priorOutputs: Record<string, string>;
+  readonly skills?: readonly string[];
+  readonly mcpServers?: Record<string, McpServerConfig>;
+  readonly maxTurns?: number;
+  readonly resume?: string;
+  readonly signal?: AbortSignal;
+}
+
+export interface StageExecutionResult {
+  readonly status: 'success' | 'failed' | 'aborted';
+  readonly artifacts: readonly ArtifactRef[];
+  readonly sessionId: string;
+  readonly toolCallCount: number;
+  readonly tokenUsage: { input: number; output: number; cache: number };
+  readonly error?: SerializedError;
+}
+
+export interface ExecutionAdapter {
+  execute(req: StageExecutionRequest): Promise<StageExecutionResult>;
+  dispose(): Promise<void>;
+}
+```
+
+### 4.2 PipelineStageDefinition 확장
+
+```typescript
+export interface PipelineStageDefinition {
+  // 기존 필드 유지
+  readonly name: StageName;
+  readonly agentType: string;
+  readonly mode: PipelineMode | 'all';
+  readonly dependencies: readonly StageName[];
+  readonly canParallelize?: boolean;
+  readonly approvalGate?: 'auto' | 'manual';
+
+  // 신규
+  readonly skills?: readonly string[];
+  readonly mcpServers?: Record<string, McpServerConfig>;
+  readonly maxTurns?: number;
+  readonly permissionMode?: 'default' | 'acceptEdits' | 'plan';
+  readonly timeoutMs?: number;
+}
+```
+
+## 5. 변경 영향 매트릭스
+
+| 영역 | 변경 유형 | 추정 LoC 변화 |
+|---|---|---|
+| `src/agents/AgentBridge.ts` 외 3종 Bridge | 삭제 | -600 |
+| `src/agents/AgentDispatcher.ts` | 삭제 | -400 |
+| `src/agents/AgentRegistry.ts` + bootstrap + TypeMapping | 삭제 | -700 |
+| `src/agents/ExecutionScaffoldGenerator.ts` | 삭제 | -200 |
+| `src/execution/` (신규) | 추가 | +300 |
+| `src/ad-sdlc-orchestrator/AdsdlcOrchestratorAgent.ts` | 슬림화 | -500 |
+| `src/ad-sdlc-orchestrator/PipelineCheckpointManager.ts` | 확장 | +50 |
+| `.claude/agents/*.md` | 표준화 | (frontmatter만) |
+| `.claude/skills/`, `.claude/commands/`, `.mcp.json` | 신규 | (config만) |
+| **순 변화** | | **약 -2,050 LoC** |
+
+## 6. 마이그레이션 Phase
+
+| Phase | 범위 | 게이트 |
+|---|---|---|
+| **P0 Docs** | RFC, 마이그레이션 가이드 게시 | 리뷰어 LGTM ≥ 1 |
+| **P1 Foundation** | 의존성 추가, ExecutionAdapter 인터페이스, frontmatter 수정 | 기존 테스트 100% + Adapter 단위 테스트 |
+| **P2 Pilot** | `worker` stage 1개만 신규 경로, feature flag로 토글 | 통합 테스트에서 산출물 동등 |
+| **P3 Cutover** | 34 stage 전체 cutover, 자체 Bridge 코드 삭제 | E2E 시나리오 3종 통과, 코드 -2,000 LoC |
+| **P4 Knowledge** | claude-config plugin 흡수, skills/commands/MCP 추가 | plugin enable 시 코딩 스타일 변화 측정 |
+
+## 7. 위험 등록부 (Top 5)
+
+| # | 위험 | 완화 |
+|---|---|---|
+| R1 | Agent SDK minor version 변동 | 정확 핀, peerDep 분리, 호환성 매트릭스 워크플로 |
+| R2 | E2E 테스트가 SDK 실호출에 결합 | `MockExecutionAdapter` 단위·통합 격리, E2E만 실호출 |
+| R3 | Hook silent failure | hook 실패 시 stage abort + structured error |
+| R4 | 체크포인트 schema 호환성 | `schema_version` 필드 + 마이그레이션 매퍼 |
+| R5 | claude-config plugin 미설치 환경 | `skills` 필드 옵셔널, 부재 시 경고 후 진행 |
+
+## 8. 측정 지표
+
+| 지표 | 베이스라인 | 목표 |
+|---|---|---|
+| 자체 에이전트 인프라 LoC | ~2,000 | ≤ 200 |
+| `.claude/agents` frontmatter 준수율 | 33/34 (97%) | 35/35 (100%) |
+| claude-config skill 활용 | 0 | ≥ 3 |
+| MCP server 활용 | 0 | ≥ 1 |
+| 단위 테스트 시간 | 베이스라인 측정 | 동등 또는 단축 |
+
+## 9. 대안 검토
+
+| 대안 | 채택 안 한 이유 |
+|---|---|
+| **A. 전면 재작성**: AD-SDLC를 Agent SDK + 얇은 오케스트레이터로 처음부터 | 도메인 자산(writers·V&V·트레이서빌리티) ~110k LoC가 본질 가치 — 재작성 불필요 |
+| **B. 현상 유지**: README만 정정 | 진실성은 해결하나 자산 미활용·사양 위반 잠복은 그대로 |
+| **C. AD-SDLC 자체를 plugin으로 패키징** | Phase 4 이후 검토 가치 있으나 plugin 시스템이 다단계 파이프라인을 지원하지 않음 — 본 RFC와 양립 가능 |
+
+## 10. 의존 관계와 후속
+
+- 본 RFC 승인 → `gh issue create` 일괄 생성 → develop 브랜치에서 phase별 PR
+- 후속 RFC 후보: ARCH-RFC-002 (V&V 결과의 RTM 자동 첨부), ARCH-RFC-003 (Managed Agents 호환성)
+
+---
+
+*작성: 2026-05-07 KST · 검토자: TBD · 승인: TBD*

--- a/docs/architecture/v0.1-migration-guide.md
+++ b/docs/architecture/v0.1-migration-guide.md
@@ -1,0 +1,102 @@
+---
+doc_id: ARCH-MIG-001
+doc_title: AD-SDLC v0.0.1 → v0.1.0 Migration Guide
+doc_version: 0.1.0-draft
+doc_status: draft
+related_rfc: docs/architecture/v0.1-hybrid-pipeline-rfc.md
+---
+
+# AD-SDLC v0.0.1 → v0.1.0 Migration Guide
+
+본 문서는 ARCH-RFC-001 채택 시 사용자·기여자가 따라야 할 변경점과 호환성 가이드입니다.
+
+## 1. 사용자 영향 (Breaking / Non-breaking)
+
+| 변경 | 분류 | 사용자 액션 |
+|---|---|---|
+| `@anthropic-ai/claude-agent-sdk` 의존성 추가 | 추가 | `npm install` 재실행 |
+| CLI 인터페이스 (`ad-sdlc init`/`run`) | 비호환 없음 | — |
+| `.ad-sdlc/` 디렉터리 구조 | 비호환 없음 | — |
+| 체크포인트 파일 schema | minor (schema_version 추가) | v0.0.1 체크포인트는 자동 마이그레이션 |
+| 환경변수 `ANTHROPIC_API_KEY` | 변경 없음 | — |
+| 신규 환경변수 `CLAUDE_CODE_USE_BEDROCK` 등 | 추가 | 옵션 |
+
+## 2. 기여자 영향
+
+### 2.1 삭제된 모듈 (import 시 컴파일 에러)
+
+- `src/agents/AgentBridge.ts`
+- `src/agents/AgentDispatcher.ts`
+- `src/agents/AgentRegistry.ts`
+- `src/agents/AgentTypeMapping.ts`
+- `src/agents/bootstrapAgents.ts`
+- `src/agents/BridgeRegistry.ts`
+- `src/agents/ExecutionScaffoldGenerator.ts`
+- `src/agents/bridges/*` (4 파일)
+
+### 2.2 신규 모듈
+
+- `src/execution/ExecutionAdapter.ts`
+- `src/execution/MockExecutionAdapter.ts`
+- `src/execution/hooks.ts`
+- `src/execution/TelemetryBridge.ts`
+- `src/execution/PolicyEngine.ts`
+
+### 2.3 변경된 시그니처
+
+`AdsdlcOrchestratorAgent.executeStageAgent()`의 시그니처가 단순화되어 `BridgeRegistry`/`AgentDispatcher` 의존이 사라지고 `ExecutionAdapter`만 받습니다. 단, 외부에서 호출되는 public API(`startSession`, `executePipeline`, `loadPriorSession`)는 변경 없음.
+
+## 3. 체크포인트 호환성
+
+```typescript
+// v0.0.1 체크포인트
+{ "session_id": "...", "stage": "...", ... }
+
+// v0.1.0 체크포인트
+{ "schema_version": 2, "session_id": "...", "stage": "...", "sdk_session_id": "...", ... }
+```
+
+`PipelineCheckpointManager`가 schema_version 부재 시 v0.0.1로 간주하여 자동 변환.
+
+## 4. `.claude/agents/*.md` 변경
+
+| 파일 | 변경 |
+|---|---|
+| `doc-code-comparator.md` | frontmatter 추가 (필수) |
+| `validation.md` | `validation-agent.md`로 rename, name 필드 정합화 |
+| `worker.md`, `pr-reviewer.md` 등 | `skills:` 필드 추가 (옵션) |
+
+## 5. claude-config plugin 사용 (옵션)
+
+```bash
+# claude-config plugin 활성화 (선택)
+/plugins enable claude-config
+
+# 활성화 시 worker stage가 coding-guidelines / security-audit skill을 자동 preload
+```
+
+미활성화 시: 모든 기능 정상 동작, skill preload만 비활성.
+
+## 6. 롤백 절차
+
+| Phase | 롤백 방법 |
+|---|---|
+| P1 | `npm uninstall @anthropic-ai/claude-agent-sdk`, 어댑터 미사용 — 영향 0 |
+| P2 | `AD_SDLC_USE_SDK_FOR_WORKER=0` 환경변수로 즉시 토글 |
+| P3 | `git revert <merge-commit>` (이전 태그 `v0.0.x` 복귀) |
+| P4 | stage 정의에서 `skills:`/`mcpServers:` 제거 |
+
+## 7. FAQ
+
+**Q. 기존 `.claude/agents/*.md`를 직접 수정한 적이 있다. 어떻게 되나?**
+A. P1에서 frontmatter 누락 1건과 name 충돌 1건만 수정. 그 외 변경 없음.
+
+**Q. claude-config가 없는 환경에서 동작하나?**
+A. 예. `skills:` 필드는 옵셔널이며, 미설치 시 경고 후 skip.
+
+**Q. Bedrock/Vertex 사용 시 동작하나?**
+A. SDK가 환경변수 기반 인증을 지원. 단, hooks 동작은 endpoint별로 검증 필요.
+
+---
+
+*작성: 2026-05-07 KST*

--- a/scripts/ci-watch.sh
+++ b/scripts/ci-watch.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+#
+# ci-watch.sh — push 후 CI 결과를 즉시 진단하는 헬퍼
+#
+# Usage:
+#   ./scripts/ci-watch.sh <branch>
+#   ./scripts/ci-watch.sh fix/doc-code-comparator-frontmatter
+#
+# Behavior:
+#   1. 해당 브랜치의 최근 워크플로 실행 ID를 찾음
+#   2. status가 in_progress/queued면 30초 간격 폴링 (최대 10분)
+#   3. completed가 되면 conclusion 출력
+#   4. failed/cancelled면 실패 잡의 로그 발췌 자동 출력
+#
+# Requirements: gh CLI authenticated, jq
+
+set -euo pipefail
+
+REPO="${REPO:-kcenon/claude_code_agent}"
+BRANCH="${1:?Usage: $0 <branch>}"
+MAX_POLLS=20      # 30s * 20 = 10 minutes (per CLAUDE.md ci-resilience.md)
+POLL_INTERVAL=30
+
+echo "Repo:   $REPO"
+echo "Branch: $BRANCH"
+echo
+
+# 1) Find latest run for this branch
+run_id=$(gh run list --repo "$REPO" --branch "$BRANCH" --limit 1 \
+  --json databaseId -q '.[0].databaseId' 2>/dev/null || true)
+
+if [ -z "$run_id" ] || [ "$run_id" = "null" ]; then
+  echo "No workflow runs found for branch '$BRANCH'."
+  echo "Make sure the branch is pushed and CI is configured for the path."
+  exit 1
+fi
+echo "Latest run: $run_id"
+
+# 2) Poll
+for i in $(seq 1 "$MAX_POLLS"); do
+  read -r status conclusion < <(gh run view "$run_id" --repo "$REPO" \
+    --json status,conclusion -q '"\(.status) \(.conclusion // "null")"')
+
+  ts=$(date -u +%H:%M:%SZ)
+  echo "[$ts] poll $i/$MAX_POLLS — status=$status conclusion=$conclusion"
+
+  case "$status" in
+    completed)
+      echo
+      echo "===================================================="
+      echo "Run $run_id completed: $conclusion"
+      echo "===================================================="
+      if [ "$conclusion" = "success" ]; then
+        echo "All checks green. Ready to merge."
+        exit 0
+      fi
+      # 3) Failure — fetch failed job logs
+      echo
+      echo "Failed jobs:"
+      gh run view "$run_id" --repo "$REPO" --json jobs \
+        -q '.jobs[] | select(.conclusion!="success") | "  - \(.name): \(.conclusion)"'
+      echo
+      echo "Failed step logs (head):"
+      gh run view "$run_id" --repo "$REPO" --log-failed 2>/dev/null | head -200
+      exit 1
+      ;;
+    queued|in_progress|waiting|requested|pending)
+      sleep "$POLL_INTERVAL"
+      ;;
+    *)
+      echo "Unknown status: $status"
+      exit 2
+      ;;
+  esac
+done
+
+echo
+echo "Timeout ($((MAX_POLLS*POLL_INTERVAL))s) reached without completion."
+echo "Re-run this script to continue polling, or check manually:"
+echo "  gh run view $run_id --repo $REPO --web"
+exit 3


### PR DESCRIPTION
# docs(architecture): add v0.1 Hybrid Pipeline RFC + 22 issue drafts

> **PR Track**: B (parent RFC, large but doc-only)
> **Branch**: `docs/v01-rfc-and-drafts`
> **Base**: `develop`
> **Closes**: AD-01, AD-02 (issue drafts 자체)
> **Related**: PR-A (병렬 진행)

## What

AD-SDLC v0.0.1 → v0.1.0 마이그레이션의 부모 RFC와 22개 후속 이슈 드래프트를 docs-only PR로 도입합니다. 코드 변경 0건 — 본 PR은 **합의의 컨테이너**.

### 변경 파일 요약 (25 files, +2,196 LoC)

| 디렉터리 | 파일 수 | 역할 |
|---|---|---|
| `docs/architecture/` | 2 | RFC 본문 + 마이그레이션 가이드 |
| `.github/.issue-drafts/v0.1/` | 23 | INDEX.md + 22 issue drafts (AD-01 ~ AD-22) |

### 변경 파일 목록

```
docs/architecture/v0.1-hybrid-pipeline-rfc.md    (신규, ~250 lines)
docs/architecture/v0.1-migration-guide.md         (신규, ~120 lines)
.github/.issue-drafts/v0.1/INDEX.md               (신규, 마스터 인덱스)
.github/.issue-drafts/v0.1/AD-01.md ~ AD-22.md    (신규, 5W1H 이슈 드래프트 22개)
```

## Why

`v0.0.1` 분석 결과 (3 round-trip 결과 본 PR 산출):

1. **진실성 갭**: README는 "built with Claude Agent SDK"이나 의존성은 raw `@anthropic-ai/sdk@^0.92.0`만
2. **자산 미활용**: 같은 호스트에 있는 `claude-config` v2.3.0 plugin (8 agents + 7 skills + global hooks)이 코드 경로상 미결합
3. **사양 위반 잠복**: `.claude/agents/doc-code-comparator.md` frontmatter 누락 (PR-A에서 별도 fix)

본 RFC는 위 3가지를 **하이브리드 아키텍처**로 해소합니다:
- 도메인 자산(35단계 SDLC 파이프라인·V&V·트레이서빌리티)은 보존
- 에이전트 실행만 `@anthropic-ai/claude-agent-sdk`에 위임 (~2,000 LoC 슬림화)
- claude-config plugin을 `skills:` frontmatter로 표준 결합

## Who

- **Reviewers**: 코어 메인테이너 2 (architecture, docs)
- **Approval**: LGTM ≥ 1 (RFC 채택 결정)
- **Optional reviewers**: 외부 사용자 대표(베타) 1, claude-config 메인테이너 1

## When

- 발의: 2026-05-07
- 검토 deadline: +5 영업일 (2026-05-14)
- 머지 후: 22개 이슈 일괄 게시 (`gh issue create --body-file ...`)

## Where

- `docs/architecture/`
- `.github/.issue-drafts/v0.1/`

## How

### 새 3-Tier 아키텍처

```
T1 Pipeline Control Plane (도메인, 유지)
   ├ AdsdlcOrchestratorAgent (stage DAG)
   ├ PipelineCheckpointManager (mid-stage resume)
   ├ ArtifactValidator + V&V (stage-verifier, rtm-builder, doc-audit)
   ├ Writers / Analyzers / Updaters (35 agents)
   └ Scratchpad (File / SQLite / Redis)
                ↓
T2 Agent Execution Layer (신규, 얇음)
   ├ ExecutionAdapter (단일 SDK 진입점)
   ├ Hook Pipeline (PostToolUse → scratchpad/OTel)
   └ Telemetry Bridge
                ↓
T3 Knowledge Layer (외부 자산, 표준 결합)
   ├ .claude/agents/*.md (35, 100% frontmatter)
   ├ .claude/skills/  (claude-config plugin 흡수)
   ├ .claude/commands/  (신규)
   ├ .mcp.json (github MCP)
   └ claude-config v2.3.0 plugin (별도 설치)
```

### 5 Phase 마이그레이션

| Phase | 이슈 | 게이트 |
|---|---|---|
| **P0 Docs** | AD-01, AD-02 | RFC LGTM ≥ 1 |
| **P1 Foundation** | AD-03 ~ AD-08 | 기존 테스트 100% + Adapter 단위 테스트 |
| **P2 Pilot** | AD-09 ~ AD-12 | worker stage 산출물 동등 |
| **P3 Cutover** | AD-13 ~ AD-17 | E2E 3종 + 코드 -2,000 LoC |
| **P4 Knowledge** | AD-18 ~ AD-22 | plugin enable 시나리오 통과 |

### 주요 인터페이스 (RFC §4 발췌)

```typescript
export interface ExecutionAdapter {
  execute(req: StageExecutionRequest): Promise<StageExecutionResult>;
  dispose(): Promise<void>;
}
```

### 측정 지표 목표

| 지표 | 베이스라인 | 목표 |
|---|---|---|
| 자체 에이전트 인프라 LoC | ~2,000 | ≤ 200 |
| `.claude/agents` frontmatter 준수율 | 33/34 (97%) | 35/35 (100%) |
| claude-config skill 활용 | 0 | ≥ 3 |
| MCP server 활용 | 0 | ≥ 1 |

### Acceptance Criteria (이 PR)

- [x] `docs/architecture/v0.1-hybrid-pipeline-rfc.md` 작성 (10 섹션, mermaid 다이어그램 포함)
- [x] `docs/architecture/v0.1-migration-guide.md` 작성 (사용자·기여자 영향, 롤백, FAQ)
- [x] `.github/.issue-drafts/v0.1/INDEX.md` 작성 (의존 그래프 + 발행 절차)
- [x] 22개 이슈 드래프트 모두 frontmatter + 5W1H 5섹션 충족
- [x] INDEX.md mermaid 노드 수와 이슈 수 일치 (22)
- [x] 모든 이슈에 `depends_on`/`blocks` 명시
- [ ] 외부 링크 모두 200 OK (CI에서 자동 검증, 옵션)
- [ ] mermaid 미리보기 정상 (GitHub PR 미리보기 검토)

### Test Plan

이 PR은 docs-only — 코드 테스트 무관.

- [ ] markdown lint 통과
- [ ] mermaid 다이어그램 미리보기 정상
- [ ] 본문 내 cross-link 동작 (RFC ↔ 마이그레이션 가이드 ↔ 이슈 드래프트)

### 리뷰 가이드

리뷰어가 큰 PR(25 files)을 효율적으로 검토할 수 있도록 권장 순서:

1. **`docs/architecture/v0.1-hybrid-pipeline-rfc.md`** — 본 PR의 본질
2. **`.github/.issue-drafts/v0.1/INDEX.md`** — 의존 그래프와 phase gate
3. **샘플 이슈 1개씩 phase별** (예: AD-04, AD-06, AD-09, AD-13, AD-19) — 5W1H 품질 검증
4. **`docs/architecture/v0.1-migration-guide.md`** — 외부 사용자 영향
5. **나머지 이슈 드래프트** — skim 또는 머지 후 게시 시점 추가 보완

### 머지 후 작업

```bash
# 22개 이슈 일괄 게시 (예시)
cd /project/claude_code_agent
for n in 01 02 04 05 03 06 07 08 09 10 11 12 13 14 15 16 17 18 19 20 21 22; do
  title=$(awk -F'"' '/^title:/{print $2}' .github/.issue-drafts/v0.1/AD-$n.md)
  labels=$(grep -oP '(?<=labels: \[).*?(?=\])' .github/.issue-drafts/v0.1/AD-$n.md)
  gh issue create \
    --title "$title" \
    --body-file ".github/.issue-drafts/v0.1/AD-$n.md" \
    --label "$labels"
done
```

## Linked Items

- Track A 병렬 PR: `fix(agents): doc-code-comparator.md frontmatter` (PR-A)
- 후속: 22 issue drafts → 머지 후 GitHub 이슈로 발행
- 외부 레포 후속: `claude-config:docs/ad-sdlc-integration.md` 갱신 PR (AD-22)

## Reviewer Checklist

- [ ] RFC §3 3-tier 분리가 명확하고 책임 경계 자연스러움
- [ ] §4 인터페이스 시그니처가 TypeScript에서 실제로 컴파일 가능
- [ ] §5 변경 영향 매트릭스의 LoC 추정이 합리적
- [ ] §6 5 phase가 각각 독립 mergeable + revertible
- [ ] §7 위험 등록부 R1~R5의 완화책이 구체적
- [ ] 22개 이슈 드래프트 의존 그래프(INDEX.md)에 사이클 없음
- [ ] 각 이슈가 ≤ 2-3일 작업으로 추정 가능 (size/L인 AD-13만 sub-PR 5개로 분할 명시)
- [ ] AI/Claude attribution 0건 (Commit Settings 준수)
