### PR TITLE
fix(agents): prettier format for AgentDispatcher callAdapters (CI hot-fix)

### DIFF
--- a/src/agents/AgentDispatcher.ts
+++ b/src/agents/AgentDispatcher.ts
@@ -669,7 +669,10 @@ export class AgentDispatcher {
     // otherwise fall through to the standard executeAdapter.
     this.callAdapters.set('controller', this.createScaffoldAdapter('controller', executeAdapter));
     this.callAdapters.set('worker', this.createScaffoldAdapter('worker', executeAdapter));
-    this.callAdapters.set('validation-agent', this.createScaffoldAdapter('validation', executeAdapter));
+    this.callAdapters.set(
+      'validation-agent',
+      this.createScaffoldAdapter('validation', executeAdapter)
+    );
     this.callAdapters.set('pr-reviewer', this.createScaffoldAdapter('review', executeAdapter));
   }
 


### PR DESCRIPTION
## What

PR #807 머지 직후 develop의 CI(`Lint > Check formatting`)가 실패했습니다 — `validation-agent` 리네임으로 길어진 `this.callAdapters.set(...)` 호출이 prettier `printWidth`를 초과한 것이 원인입니다.

본 hot-fix는 prettier가 제안하는 line break만 적용합니다 (의미 변화 0).

## Why

- develop CI workflow가 빨갛게 떠 있어 후속 PR 모두 차단
- AD-06(ExecutionAdapter) 착수 전 develop을 그린으로 회복해야 다음 작업이 안전

## How

```diff
-    this.callAdapters.set('validation-agent', this.createScaffoldAdapter('validation', executeAdapter));
+    this.callAdapters.set(
+      'validation-agent',
+      this.createScaffoldAdapter('validation', executeAdapter)
+    );
```

### 검증
- 로컬 `npx prettier --check 'src/**/*.ts'` exit=0 (전체 sources clean)
- AgentDispatcher.ts 단독으로 `npx prettier --write` 적용

## Linked

- Resolves: develop CI failure on `16de84c9` (run 25494118706, Lint job)
- Follow-up of: #807 (AD-05)
- Unblocks: #790 (AD-06 ExecutionAdapter) 후속 작업
