### PR TITLE
fix(e2e-fixtures): rename validation -> validation-agent in GREENFIELD_RESPONSES (CI hot-fix)

### DIFF
--- a/tests/e2e/fixtures/pipeline-fixtures.ts
+++ b/tests/e2e/fixtures/pipeline-fixtures.ts
@@ -528,7 +528,7 @@ export const GREENFIELD_RESPONSES: Record<string, string> = {
   'svp-writer': svpOutput,
   controller: controllerOutput,
   worker: workerOutput,
-  validation: validationOutput,
+  'validation-agent': validationOutput,
   'pr-reviewer': prReviewerOutput,
   'doc-index-generator': docIndexGeneratorOutput,
 };


### PR DESCRIPTION
## What

PR #807 (AD-05)에서 agent type `'validation'` → `'validation-agent'` 리네임 시 `tests/e2e/fixtures/pipeline-fixtures.ts`의 `GREENFIELD_RESPONSES` 맵 키 1개를 누락했습니다. Mock invoker가 새 agent type에 대응하는 응답을 찾지 못해 e2e 스모크 8건이 실패했습니다.

## Why

- develop CI(`Test (ubuntu-latest)`/`Test (windows-latest)`)가 빨갛게 떠 있어 후속 PR 차단
- AD-06(ExecutionAdapter) 착수 전 develop 그린 회복 필수

## How

```diff
-  validation: validationOutput,
+  'validation-agent': validationOutput,
```

이 키는 agentType으로 lookup되며, `src/agents/AgentTypeMapping.ts`의 `'validation-agent':` 엔트리와 1:1 정합화하기 위한 변경입니다.

## 검증
- 로컬 vitest는 sandbox에 미설치 → CI에 위임
- 단일 라인 변경, 의미 그대로

## Linked
- Resolves: develop CI failure on `c8ae39c5` (run 25495224522, Test jobs)
- Follow-up of: #807 (AD-05)
- Unblocks: #790 (AD-06)
