### PR TITLE
feat(execution): ExecutionAdapter + SDK adapter + Mock + SDK dep (AD-03 + AD-06)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.1",
       "license": "BSD-3-Clause",
       "dependencies": {
+        "@anthropic-ai/claude-agent-sdk": "^0.2.132",
         "@anthropic-ai/sdk": "^0.92.0",
         "chalk": "^5.6.2",
         "commander": "^14.0.3",
@@ -108,6 +109,156 @@
           "optional": true
         },
         "pdf-parse": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk": {
+      "version": "0.2.132",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.2.132.tgz",
+      "integrity": "sha512-3hCkfbHi6d73QcNqgrjU9zXGdNs3BrwWnxV90p+DDFARtnwbszkkEm4nz9c80af3nzGBRVvKNZPVCqVaBrkO0g==",
+      "license": "SEE LICENSE IN README.md",
+      "dependencies": {
+        "@anthropic-ai/sdk": "^0.81.0",
+        "@modelcontextprotocol/sdk": "^1.29.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.2.132",
+        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.2.132",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.2.132",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.2.132",
+        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.2.132",
+        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.2.132",
+        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.2.132",
+        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.2.132"
+      },
+      "peerDependencies": {
+        "zod": "^4.0.0"
+      }
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64": {
+      "version": "0.2.132",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.2.132.tgz",
+      "integrity": "sha512-wrGxeqsnhw3JSU25v78FSw85guN0FGqLA7LuAzLe+KVZqJElJvhtae1ceCvgF8e8Bc/RUrniNxRrTur+8vIZYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-darwin-x64": {
+      "version": "0.2.132",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.2.132.tgz",
+      "integrity": "sha512-qiutRtM+cz6FPA2AX2fKaINkLpMO9W48d3s4CTcWPT014uJTRxZZRb5TBxnjdxRLIt6njsqvvvh0XzQLGpblBA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64": {
+      "version": "0.2.132",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.2.132.tgz",
+      "integrity": "sha512-fWyjKRg+qfThhY9iI5GJRNtBW7qBoV20yn8kJ9RoKG4c6yn3Q+QJX+ybkfgXM45RyrO4SPmdhDeTCTG9LJSN3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64-musl": {
+      "version": "0.2.132",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.2.132.tgz",
+      "integrity": "sha512-Gu4JCAkXA/XChcrTixtnurSn445O/1EHt2TAlX/rq2gP/wCijKU3eQyZ+YWx2UMud0f9e+E4W/CHhwtCVzgqgw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64": {
+      "version": "0.2.132",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.2.132.tgz",
+      "integrity": "sha512-AAThetjWjCRWQ7IcDTjXLltUB9DJS4S4HpPmTpCOM8muOFWOwpgTmOHe1DJc9uVXbAgFO/WEASDbD4qrsdn0rw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64-musl": {
+      "version": "0.2.132",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.2.132.tgz",
+      "integrity": "sha512-Ri7RQkbjOVox0TXTN4g04oiO5bU8WLCH9SdChxaZtS/K76Yu1vV6fYyB/wRoYWuvRLHjOANWUFIGs6O/wK5s0w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-win32-arm64": {
+      "version": "0.2.132",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.2.132.tgz",
+      "integrity": "sha512-8m5L6MlMqIzvx2V/J1gJwhXt9iMfXFvLOmtm1nhzyslc7czJWZQtHUQ8Tr/1rW32t2oEpXqrDhbjrlHgGp9xBQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-win32-x64": {
+      "version": "0.2.132",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.2.132.tgz",
+      "integrity": "sha512-NNbAHtl/Bew6HUvOW8R27r/pwwctZbScGAKAxt/p4GiYa0oLKvxq/CGLv+wscRVlebeI0hA6DwC0DtnB0KnA1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk/node_modules/@anthropic-ai/sdk": {
+      "version": "0.81.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.81.0.tgz",
+      "integrity": "sha512-D4K5PvEV6wPiRtVlVsJHIUhHAmOZ6IT/I9rKlTf84gR7GyyAurPJK7z9BOf/AZqC5d1DhYQGJNKRmV+q8dGhgw==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
           "optional": true
         }
       }
@@ -1618,6 +1769,18 @@
         "node": ">=6"
       }
     },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -2043,6 +2206,68 @@
         "type": "opencollective",
         "url": "https://opencollective.com/js-sdsl"
       }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
     },
     "node_modules/@napi-rs/canvas": {
       "version": "0.1.80",
@@ -4485,6 +4710,19 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -4534,6 +4772,45 @@
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
       }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv-formats/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
     },
     "node_modules/ansi-escapes": {
       "version": "7.3.0",
@@ -4752,6 +5029,30 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/bowser": {
       "version": "2.14.1",
       "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
@@ -4794,6 +5095,44 @@
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/chai": {
@@ -5128,12 +5467,52 @@
         "node": ">= 12.0.0"
       }
     },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
     },
     "node_modules/core-util-is": {
       "version": "1.0.3",
@@ -5142,11 +5521,27 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -5161,7 +5556,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -5218,6 +5612,15 @@
         "node": ">=0.10"
       }
     },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -5257,12 +5660,41 @@
         "underscore": "^1.13.1"
       }
     },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/end-of-stream": {
       "version": "1.4.5",
@@ -5300,12 +5732,42 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/es-module-lexer": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
       "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.27.7",
@@ -5358,6 +5820,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -5615,12 +6083,42 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/eventemitter3": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
       "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.8.tgz",
+      "integrity": "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
     },
     "node_modules/expand-template": {
       "version": "2.0.3",
@@ -5642,11 +6140,71 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.1.tgz",
+      "integrity": "sha512-5O6KYmyJEpuPJV5hNTXKbAHWRqrzyu+OI3vUnSd2kXFubIVpG7ezpgxQy76Zo5GQZtrQBg86hF+CM/NX+cioiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-json-stable-stringify": {
@@ -5677,6 +6235,22 @@
       "dependencies": {
         "fast-string-truncated-width": "^3.0.2"
       }
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fast-wrap-ansi": {
       "version": "0.2.0",
@@ -5762,6 +6336,27 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/find-replace": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-5.0.2.tgz",
@@ -5825,6 +6420,24 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/fs-constants": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
@@ -5845,6 +6458,15 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/get-caller-file": {
@@ -5868,6 +6490,43 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/get-tsconfig": {
@@ -5903,6 +6562,18 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -5911,6 +6582,39 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.18",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
+      "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
       }
     },
     "node_modules/hpagent": {
@@ -5946,6 +6650,26 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/husky": {
       "version": "9.1.7",
@@ -6047,7 +6771,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/ini": {
@@ -6108,6 +6831,24 @@
         "url": "https://opencollective.com/ioredis"
       }
     },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -6147,6 +6888,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
     "node_modules/isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -6158,7 +6905,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/istanbul-lib-coverage": {
@@ -6198,6 +6944,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/js-tokens": {
@@ -6264,6 +7019,12 @@
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -6823,12 +7584,67 @@
         "markdown-it": "bin/markdown-it.mjs"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/mdurl": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
       "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/mimic-function": {
       "version": "5.0.1",
@@ -6899,7 +7715,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/mute-stream": {
@@ -6944,6 +7759,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/node-abi": {
       "version": "3.89.0",
       "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.89.0.tgz",
@@ -6957,12 +7781,33 @@
         "node": ">=10"
       }
     },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/object-deep-merge": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/object-deep-merge/-/object-deep-merge-2.0.0.tgz",
       "integrity": "sha512-3DC3UMpeffLTHiuXSy/UG4NOIYTLlY9u3V82+djSCLYClWobZiS4ivYzpIUWrRY/nfsJ8cWsKyG3QfyLePmhvg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/obug": {
       "version": "2.1.1",
@@ -6975,11 +7820,22 @@
       ],
       "license": "MIT"
     },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -7082,6 +7938,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/path-browserify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
@@ -7128,10 +7993,19 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/pathe": {
@@ -7192,6 +8066,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
       }
     },
     "node_modules/postcss": {
@@ -7309,6 +8192,19 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/pump": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
@@ -7338,6 +8234,45 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/rc": {
@@ -7400,6 +8335,15 @@
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
       "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -7500,6 +8444,22 @@
         "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17"
       }
     },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/run-async": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-4.0.6.tgz",
@@ -7561,6 +8521,51 @@
         "node": ">=10"
       }
     },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/setimmediate": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
@@ -7568,11 +8573,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -7585,10 +8595,81 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/siginfo": {
@@ -7729,6 +8810,15 @@
       "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/std-env": {
       "version": "4.0.0",
@@ -7945,6 +9035,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/ts-algebra": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
@@ -8024,6 +9123,20 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/typedoc": {
@@ -8142,6 +9255,15 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -8158,6 +9280,15 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/vite": {
       "version": "8.0.10",
@@ -8331,7 +9462,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -8427,7 +9557,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/xmlbuilder": {
@@ -8563,6 +9692,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
     "vitest": "^4.0.16"
   },
   "dependencies": {
+    "@anthropic-ai/claude-agent-sdk": "^0.2.132",
     "@anthropic-ai/sdk": "^0.92.0",
     "chalk": "^5.6.2",
     "commander": "^14.0.3",

--- a/src/execution/MockExecutionAdapter.ts
+++ b/src/execution/MockExecutionAdapter.ts
@@ -1,0 +1,112 @@
+/**
+ * MockExecutionAdapter — deterministic in-memory adapter for tests.
+ *
+ * Two modes of use:
+ *
+ * 1. **Default success**: with no scripted handlers, every `execute` resolves
+ *    to a canned successful result. Useful for "does the pipeline call the
+ *    adapter at all" tests.
+ * 2. **Scripted**: pass a list of {@link MockExecutionHandler}s. Handlers are
+ *    matched by predicate against the request, in registration order; the
+ *    first match wins. Unmatched calls fall back to the default success.
+ *
+ * Every call is recorded on {@link MockExecutionAdapter.calls} so tests can
+ * assert against the request payload — most importantly, that `priorOutputs`
+ * was forwarded as documented in ARCH-RFC-001 §4.1.
+ *
+ * @packageDocumentation
+ */
+
+import type {
+  ExecutionAdapter,
+  StageExecutionRequest,
+  StageExecutionResult,
+} from './types.js';
+
+/**
+ * Predicate-driven handler. Return null to defer to the next handler.
+ */
+export interface MockExecutionHandler {
+  readonly match: (req: StageExecutionRequest) => boolean;
+  readonly respond:
+    | StageExecutionResult
+    | ((req: StageExecutionRequest) => StageExecutionResult | Promise<StageExecutionResult>);
+}
+
+/**
+ * Configuration knobs for the mock.
+ */
+export interface MockExecutionAdapterOptions {
+  readonly handlers?: readonly MockExecutionHandler[];
+  readonly defaultResult?: StageExecutionResult;
+}
+
+const DEFAULT_RESULT: StageExecutionResult = {
+  status: 'success',
+  artifacts: [],
+  sessionId: 'mock-session',
+  toolCallCount: 0,
+  tokenUsage: { input: 0, output: 0, cache: 0 },
+};
+
+export class MockExecutionAdapter implements ExecutionAdapter {
+  private readonly handlers: MockExecutionHandler[];
+  private readonly defaultResult: StageExecutionResult;
+  private disposed = false;
+
+  /**
+   * Recorded requests, in invocation order. Tests can assert against this.
+   */
+  readonly calls: StageExecutionRequest[] = [];
+
+  constructor(options: MockExecutionAdapterOptions = {}) {
+    this.handlers = [...(options.handlers ?? [])];
+    this.defaultResult = options.defaultResult ?? DEFAULT_RESULT;
+  }
+
+  async execute(req: StageExecutionRequest): Promise<StageExecutionResult> {
+    if (this.disposed) {
+      throw new Error('MockExecutionAdapter: execute called after dispose');
+    }
+    if (req.signal?.aborted) {
+      return this.abortResult(req);
+    }
+    this.calls.push(req);
+    for (const handler of this.handlers) {
+      if (handler.match(req)) {
+        const value = handler.respond;
+        return typeof value === 'function' ? value(req) : value;
+      }
+    }
+    return this.defaultResult;
+  }
+
+  /**
+   * Add a handler at runtime. Useful when the test arranges expectations
+   * after the adapter is constructed.
+   */
+  addHandler(handler: MockExecutionHandler): void {
+    this.handlers.push(handler);
+  }
+
+  /**
+   * Reset recorded calls. Handlers are preserved.
+   */
+  resetCalls(): void {
+    this.calls.length = 0;
+  }
+
+  async dispose(): Promise<void> {
+    this.disposed = true;
+  }
+
+  private abortResult(req: StageExecutionRequest): StageExecutionResult {
+    return {
+      status: 'aborted',
+      artifacts: [],
+      sessionId: req.resume ?? 'mock-session-aborted',
+      toolCallCount: 0,
+      tokenUsage: { input: 0, output: 0, cache: 0 },
+    };
+  }
+}

--- a/src/execution/README.md
+++ b/src/execution/README.md
@@ -1,0 +1,94 @@
+# Execution Layer
+
+Single Claude Agent SDK entrypoint for the AD-SDLC pipeline. Per
+[ARCH-RFC-001 §4.1](../../docs/architecture/v0.1-hybrid-pipeline-rfc.md#41-executionadapter),
+every stage that needs to call out to an agent goes through one of the
+`ExecutionAdapter` implementations exposed here.
+
+## Why a single funnel
+
+| Concern | What the funnel buys |
+|---|---|
+| Testability | Mock once, every stage benefits |
+| Hooks | `PreToolUse` / `PostToolUse` policy lives in the adapter, not in 35 places |
+| Telemetry | One span emitter; consistent attributes across stages |
+| Endpoint switching | Anthropic / Bedrock / Vertex selection happens behind one interface |
+| Hot-reload | Rotate keys / models without touching pipeline code |
+
+## Public surface
+
+```typescript
+import {
+  type ExecutionAdapter,
+  type StageExecutionRequest,
+  type StageExecutionResult,
+  MockExecutionAdapter,
+  SdkExecutionAdapter,
+} from '@/execution';
+```
+
+## Two implementations
+
+### `SdkExecutionAdapter`
+
+Wraps `@anthropic-ai/claude-agent-sdk`'s `query()` async iterable. The SDK is
+loaded with a dynamic `import()` so this module compiles even in environments
+where the SDK is not yet installed (the dynamic import only runs when
+`execute()` is called). Tests inject a fake `loader` to avoid touching the
+real package.
+
+| Request field | SDK option | Note |
+|---|---|---|
+| `agentType` | (prompt prefix) | Identifies which `.claude/agents/*.md` to load |
+| `workOrder` | prompt body | |
+| `priorOutputs` | prompt context | Verbatim, labeled by key |
+| `skills` | `options.skills` | |
+| `mcpServers` | `options.mcpServers` | |
+| `maxTurns` | `options.maxTurns` | |
+| `resume` | `options.resume` | Continue an earlier session |
+| `signal` | `options.signal` | |
+
+### `MockExecutionAdapter`
+
+Deterministic in-memory adapter for tests. Records every call on
+`adapter.calls` and returns either a default success result or a scripted
+response chosen by predicate.
+
+```typescript
+const adapter = new MockExecutionAdapter({
+  handlers: [
+    {
+      match: (req) => req.agentType === 'worker',
+      respond: { status: 'success', artifacts: [...], sessionId: 'fake', toolCallCount: 1, tokenUsage: { input: 10, output: 20, cache: 0 } },
+    },
+  ],
+});
+
+const result = await adapter.execute({ agentType: 'worker', workOrder: 'do thing', priorOutputs: {} });
+expect(adapter.calls).toHaveLength(1);
+```
+
+## Contract: `priorOutputs` must reach the prompt
+
+Adapters MUST forward every entry of `priorOutputs` into the prompt verbatim.
+The reference implementation (`renderPrompt`) emits a `## Prior outputs`
+section with one `### <key>` block per entry. Stage code relies on these
+section headers when it needs to extract a specific upstream output.
+
+A unit test in `tests/execution/SdkExecutionAdapter.test.ts` asserts this
+contract — modify `renderPrompt` and the test must continue to pass.
+
+## What this module does NOT do (yet)
+
+- Wiring stages to actually call the adapter — see AD-09.
+- Hook pipeline integration — see AD-07.
+- Telemetry bridge — Phase 3.
+- Bedrock / Vertex endpoint selection — Phase 4.
+
+## Issue references
+
+- AD-03 (`#789`): `@anthropic-ai/claude-agent-sdk` dependency add
+- AD-06 (`#790`): this module
+- AD-07 (`#791`): hook pipeline integration
+- AD-08 (`#792`): telemetry bridge integration
+- AD-09 (`#793`): pilot stage cutover

--- a/src/execution/SdkExecutionAdapter.ts
+++ b/src/execution/SdkExecutionAdapter.ts
@@ -1,0 +1,242 @@
+/**
+ * SdkExecutionAdapter — real adapter that drives `@anthropic-ai/claude-agent-sdk`.
+ *
+ * Loads the SDK lazily via dynamic `import()` so this module compiles in
+ * environments where the SDK is not yet installed. Tests inject a fake
+ * `loader` to bypass the actual import.
+ *
+ * Maps {@link StageExecutionRequest} → SDK options as follows:
+ *
+ * | Request field   | SDK option       | Note                                           |
+ * |-----------------|------------------|------------------------------------------------|
+ * | `agentType`     | (prompt prefix)  | Identifies which `.claude/agents/*.md` to load |
+ * | `workOrder`     | prompt body      |                                                |
+ * | `priorOutputs`  | prompt context   | Verbatim, labeled by key                       |
+ * | `skills`        | options.skills   |                                                |
+ * | `mcpServers`    | options.mcpServers |                                              |
+ * | `maxTurns`      | options.maxTurns |                                                |
+ * | `resume`        | options.resume   | Continue an earlier session                    |
+ * | `signal`        | options.signal   |                                                |
+ *
+ * @packageDocumentation
+ */
+
+import { AppError } from '../errors/AppError.js';
+import { ErrorSeverity } from '../errors/types.js';
+import type {
+  ArtifactRef,
+  ExecutionAdapter,
+  McpServerConfig,
+  StageExecutionRequest,
+  StageExecutionResult,
+  TokenUsage,
+} from './types.js';
+
+/**
+ * Minimal subset of `@anthropic-ai/claude-agent-sdk` we depend on. We declare
+ * it locally so tsc can compile this file without the package being installed.
+ * Real SDK types are wider; we only consume what is documented here.
+ */
+export interface SdkQueryOptions {
+  prompt: string;
+  options?: {
+    skills?: readonly string[];
+    mcpServers?: Record<string, McpServerConfig>;
+    maxTurns?: number;
+    resume?: string;
+    signal?: AbortSignal;
+  };
+}
+
+/**
+ * Shape of messages the SDK yields. We pattern-match on `type`.
+ */
+export interface SdkMessage {
+  readonly type: 'system' | 'assistant' | 'user' | 'result';
+  readonly subtype?: string;
+  readonly session_id?: string;
+  readonly result?: string;
+  readonly is_error?: boolean;
+  readonly num_turns?: number;
+  readonly usage?: {
+    readonly input_tokens?: number;
+    readonly output_tokens?: number;
+    readonly cache_read_input_tokens?: number;
+    readonly cache_creation_input_tokens?: number;
+  };
+}
+
+export interface SdkLike {
+  query(opts: SdkQueryOptions): AsyncIterable<SdkMessage>;
+}
+
+/**
+ * Loader function for the SDK module. Defaults to a dynamic import of
+ * `@anthropic-ai/claude-agent-sdk`. Tests pass a fake.
+ */
+export type SdkLoader = () => Promise<SdkLike>;
+
+const defaultLoader: SdkLoader = async () => {
+  const mod: unknown = await import(
+    /* @vite-ignore */ '@anthropic-ai/claude-agent-sdk' as string
+  );
+  if (!mod || typeof (mod as SdkLike).query !== 'function') {
+    throw new AppError(
+      'EXEC-001',
+      '@anthropic-ai/claude-agent-sdk did not export a `query` function',
+      { severity: ErrorSeverity.CRITICAL }
+    );
+  }
+  return mod as SdkLike;
+};
+
+export interface SdkExecutionAdapterOptions {
+  /** Override the SDK loader for tests / alternative endpoints. */
+  readonly loader?: SdkLoader;
+}
+
+export class SdkExecutionAdapter implements ExecutionAdapter {
+  private readonly loader: SdkLoader;
+  private sdkPromise: Promise<SdkLike> | null = null;
+  private disposed = false;
+
+  constructor(options: SdkExecutionAdapterOptions = {}) {
+    this.loader = options.loader ?? defaultLoader;
+  }
+
+  async execute(req: StageExecutionRequest): Promise<StageExecutionResult> {
+    if (this.disposed) {
+      throw new AppError(
+        'EXEC-002',
+        'SdkExecutionAdapter: execute called after dispose',
+        { severity: ErrorSeverity.HIGH }
+      );
+    }
+    if (req.signal?.aborted) {
+      return abortedResult(req.resume);
+    }
+
+    const sdk = await this.getSdk();
+    const prompt = renderPrompt(req);
+    const sdkOptions: SdkQueryOptions['options'] = {
+      skills: req.skills,
+      mcpServers: req.mcpServers,
+      maxTurns: req.maxTurns,
+      resume: req.resume,
+      signal: req.signal,
+    };
+
+    let sessionId = req.resume ?? 'unknown';
+    let toolCallCount = 0;
+    let tokenUsage: TokenUsage = { input: 0, output: 0, cache: 0 };
+    let resultText: string | undefined;
+    let isError = false;
+
+    try {
+      for await (const message of sdk.query({ prompt, options: sdkOptions })) {
+        if (message.session_id) sessionId = message.session_id;
+        if (message.type === 'assistant') toolCallCount += 1;
+        if (message.type === 'result') {
+          resultText = message.result;
+          isError = Boolean(message.is_error);
+          if (typeof message.num_turns === 'number') {
+            toolCallCount = Math.max(toolCallCount, message.num_turns);
+          }
+          if (message.usage) tokenUsage = mapUsage(message.usage);
+        }
+      }
+    } catch (err) {
+      if (req.signal?.aborted) return abortedResult(sessionId);
+      return failedResult(sessionId, err);
+    }
+
+    if (isError || resultText === undefined) {
+      return failedResult(sessionId, new Error(resultText ?? 'SDK returned no result'));
+    }
+
+    return {
+      status: 'success',
+      artifacts: extractArtifacts(resultText),
+      sessionId,
+      toolCallCount,
+      tokenUsage,
+    };
+  }
+
+  async dispose(): Promise<void> {
+    this.disposed = true;
+    this.sdkPromise = null;
+  }
+
+  private getSdk(): Promise<SdkLike> {
+    if (!this.sdkPromise) this.sdkPromise = this.loader();
+    return this.sdkPromise;
+  }
+}
+
+/**
+ * Render a prompt that includes the work order and every prior output verbatim.
+ * The format is intentionally simple — downstream agents parse the section
+ * headers to retrieve specific upstream outputs.
+ */
+export function renderPrompt(req: StageExecutionRequest): string {
+  const blocks: string[] = [`# Stage: ${req.agentType}`, '', '## Work order', '', req.workOrder];
+  const keys = Object.keys(req.priorOutputs);
+  if (keys.length > 0) {
+    blocks.push('', '## Prior outputs');
+    for (const key of keys) {
+      blocks.push('', `### ${key}`, '', req.priorOutputs[key]);
+    }
+  }
+  return blocks.join('\n');
+}
+
+function mapUsage(usage: NonNullable<SdkMessage['usage']>): TokenUsage {
+  const cache =
+    (usage.cache_read_input_tokens ?? 0) + (usage.cache_creation_input_tokens ?? 0);
+  return {
+    input: usage.input_tokens ?? 0,
+    output: usage.output_tokens ?? 0,
+    cache,
+  };
+}
+
+/**
+ * Lift any `path:` annotations the agent emitted into ArtifactRefs. The agent
+ * convention is one per line as `<path>: <description>`. Lines without that
+ * shape are ignored.
+ */
+function extractArtifacts(resultText: string): ArtifactRef[] {
+  const out: ArtifactRef[] = [];
+  for (const raw of resultText.split('\n')) {
+    const match = raw.match(/^\s*([\w./\-_]+):\s*(.+)$/);
+    if (match) out.push({ path: match[1], description: match[2].trim() });
+  }
+  return out;
+}
+
+function abortedResult(sessionId: string | undefined): StageExecutionResult {
+  return {
+    status: 'aborted',
+    artifacts: [],
+    sessionId: sessionId ?? 'unknown',
+    toolCallCount: 0,
+    tokenUsage: { input: 0, output: 0, cache: 0 },
+  };
+}
+
+function failedResult(sessionId: string, err: unknown): StageExecutionResult {
+  const cause = err instanceof Error ? err : new Error(String(err));
+  const error = new AppError('EXEC-003', `SdkExecutionAdapter execute failed: ${cause.message}`, {
+    severity: ErrorSeverity.HIGH,
+    cause,
+  });
+  return {
+    status: 'failed',
+    artifacts: [],
+    sessionId,
+    toolCallCount: 0,
+    tokenUsage: { input: 0, output: 0, cache: 0 },
+    error: error.toJSON(),
+  };
+}

--- a/src/execution/index.ts
+++ b/src/execution/index.ts
@@ -1,0 +1,32 @@
+/**
+ * AD-SDLC Execution layer — single SDK entrypoint for the pipeline.
+ *
+ * See `./README.md` and ARCH-RFC-001 §4.1 for the contract.
+ *
+ * @packageDocumentation
+ */
+
+export type {
+  ArtifactRef,
+  ExecutionAdapter,
+  McpServerConfig,
+  StageExecutionRequest,
+  StageExecutionResult,
+  StageExecutionStatus,
+  TokenUsage,
+} from './types.js';
+
+export { MockExecutionAdapter } from './MockExecutionAdapter.js';
+export type {
+  MockExecutionAdapterOptions,
+  MockExecutionHandler,
+} from './MockExecutionAdapter.js';
+
+export { SdkExecutionAdapter, renderPrompt } from './SdkExecutionAdapter.js';
+export type {
+  SdkExecutionAdapterOptions,
+  SdkLike,
+  SdkLoader,
+  SdkMessage,
+  SdkQueryOptions,
+} from './SdkExecutionAdapter.js';

--- a/src/execution/types.ts
+++ b/src/execution/types.ts
@@ -1,0 +1,96 @@
+/**
+ * ExecutionAdapter — single SDK entrypoint contract for AD-SDLC v0.1.
+ *
+ * All Claude Agent SDK calls in the pipeline funnel through this interface so
+ * that mocking, hooks, telemetry, and endpoint switching (Anthropic / Bedrock /
+ * Vertex) can be applied at one place. See ARCH-RFC-001 §4.1.
+ *
+ * @packageDocumentation
+ */
+
+import type { SerializedError } from '../errors/types.js';
+
+/**
+ * Reference to an artifact produced by a stage. Path is relative to the
+ * project's scratchpad root (e.g., `.ad-sdlc/scratchpad/...`). The optional
+ * checksum lets downstream consumers detect drift between recorded and
+ * on-disk content.
+ */
+export interface ArtifactRef {
+  readonly path: string;
+  readonly description?: string;
+  readonly checksum?: string;
+}
+
+/**
+ * MCP server configuration consumed by the underlying SDK. Mirrors the shape
+ * accepted by `@anthropic-ai/claude-agent-sdk` to keep the boundary thin.
+ */
+export type McpServerConfig =
+  | {
+      readonly type: 'stdio';
+      readonly command: string;
+      readonly args?: readonly string[];
+      readonly env?: Record<string, string>;
+    }
+  | {
+      readonly type: 'http';
+      readonly url: string;
+      readonly headers?: Record<string, string>;
+    };
+
+/**
+ * Token usage breakdown returned by every adapter call.
+ */
+export interface TokenUsage {
+  readonly input: number;
+  readonly output: number;
+  readonly cache: number;
+}
+
+/**
+ * Outcome of a single stage execution.
+ */
+export type StageExecutionStatus = 'success' | 'failed' | 'aborted';
+
+/**
+ * Request payload for {@link ExecutionAdapter.execute}.
+ *
+ * `priorOutputs` is the canonical mechanism to feed upstream stage results
+ * into the prompt. Adapters MUST include all entries verbatim somewhere in
+ * the rendered prompt — see {@link MockExecutionAdapter} for the contract
+ * test that asserts this.
+ */
+export interface StageExecutionRequest {
+  readonly agentType: string;
+  readonly workOrder: string;
+  readonly priorOutputs: Record<string, string>;
+  readonly skills?: readonly string[];
+  readonly mcpServers?: Record<string, McpServerConfig>;
+  readonly maxTurns?: number;
+  readonly resume?: string;
+  readonly signal?: AbortSignal;
+}
+
+/**
+ * Result of a stage execution. `error` is populated only when
+ * `status !== 'success'`.
+ */
+export interface StageExecutionResult {
+  readonly status: StageExecutionStatus;
+  readonly artifacts: readonly ArtifactRef[];
+  readonly sessionId: string;
+  readonly toolCallCount: number;
+  readonly tokenUsage: TokenUsage;
+  readonly error?: SerializedError;
+}
+
+/**
+ * Single SDK entrypoint for the pipeline. Implementations include
+ * {@link SdkExecutionAdapter} (real `@anthropic-ai/claude-agent-sdk`)
+ * and {@link MockExecutionAdapter} (testing).
+ */
+export interface ExecutionAdapter {
+  execute(req: StageExecutionRequest): Promise<StageExecutionResult>;
+  dispose(): Promise<void>;
+}

--- a/tests/execution/MockExecutionAdapter.test.ts
+++ b/tests/execution/MockExecutionAdapter.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect } from 'vitest';
+import { MockExecutionAdapter } from '../../src/execution/MockExecutionAdapter.js';
+import type { StageExecutionRequest, StageExecutionResult } from '../../src/execution/types.js';
+
+const baseRequest: StageExecutionRequest = {
+  agentType: 'worker',
+  workOrder: 'implement issue #1',
+  priorOutputs: {},
+};
+
+describe('MockExecutionAdapter', () => {
+  it('returns the default success result when no handler matches', async () => {
+    const adapter = new MockExecutionAdapter();
+    const result = await adapter.execute(baseRequest);
+    expect(result.status).toBe('success');
+    expect(result.sessionId).toBe('mock-session');
+    expect(result.tokenUsage).toEqual({ input: 0, output: 0, cache: 0 });
+  });
+
+  it('records every call in invocation order', async () => {
+    const adapter = new MockExecutionAdapter();
+    await adapter.execute({ ...baseRequest, agentType: 'a' });
+    await adapter.execute({ ...baseRequest, agentType: 'b' });
+    expect(adapter.calls.map((c) => c.agentType)).toEqual(['a', 'b']);
+  });
+
+  it('uses the first matching handler in registration order', async () => {
+    const winning: StageExecutionResult = {
+      status: 'success',
+      artifacts: [{ path: 'first.txt' }],
+      sessionId: 's-first',
+      toolCallCount: 1,
+      tokenUsage: { input: 1, output: 1, cache: 0 },
+    };
+    const adapter = new MockExecutionAdapter({
+      handlers: [
+        { match: (r) => r.agentType === 'worker', respond: winning },
+        {
+          match: () => true,
+          respond: { ...winning, sessionId: 's-fallback', artifacts: [] },
+        },
+      ],
+    });
+    const result = await adapter.execute(baseRequest);
+    expect(result.sessionId).toBe('s-first');
+    expect(result.artifacts).toEqual([{ path: 'first.txt' }]);
+  });
+
+  it('supports a function-based handler that inspects the request', async () => {
+    const adapter = new MockExecutionAdapter({
+      handlers: [
+        {
+          match: () => true,
+          respond: (req) => ({
+            status: 'success',
+            artifacts: [{ path: `${req.agentType}.out` }],
+            sessionId: `s-${req.agentType}`,
+            toolCallCount: 0,
+            tokenUsage: { input: 0, output: 0, cache: 0 },
+          }),
+        },
+      ],
+    });
+    const result = await adapter.execute({ ...baseRequest, agentType: 'controller' });
+    expect(result.artifacts).toEqual([{ path: 'controller.out' }]);
+    expect(result.sessionId).toBe('s-controller');
+  });
+
+  it('addHandler registers handlers at runtime', async () => {
+    const adapter = new MockExecutionAdapter();
+    adapter.addHandler({
+      match: () => true,
+      respond: {
+        status: 'failed',
+        artifacts: [],
+        sessionId: 's',
+        toolCallCount: 0,
+        tokenUsage: { input: 0, output: 0, cache: 0 },
+      },
+    });
+    const result = await adapter.execute(baseRequest);
+    expect(result.status).toBe('failed');
+  });
+
+  it('returns an aborted result when the signal is already aborted', async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const adapter = new MockExecutionAdapter();
+    const result = await adapter.execute({ ...baseRequest, signal: controller.signal });
+    expect(result.status).toBe('aborted');
+    expect(adapter.calls).toHaveLength(0);
+  });
+
+  it('aborted execute carries the resume sessionId when provided', async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const adapter = new MockExecutionAdapter();
+    const result = await adapter.execute({
+      ...baseRequest,
+      resume: 'prior-session',
+      signal: controller.signal,
+    });
+    expect(result.sessionId).toBe('prior-session');
+  });
+
+  it('resetCalls clears recorded calls but keeps handlers', async () => {
+    const adapter = new MockExecutionAdapter({
+      handlers: [
+        {
+          match: () => true,
+          respond: {
+            status: 'success',
+            artifacts: [],
+            sessionId: 'kept',
+            toolCallCount: 0,
+            tokenUsage: { input: 0, output: 0, cache: 0 },
+          },
+        },
+      ],
+    });
+    await adapter.execute(baseRequest);
+    expect(adapter.calls).toHaveLength(1);
+    adapter.resetCalls();
+    expect(adapter.calls).toHaveLength(0);
+    const result = await adapter.execute(baseRequest);
+    expect(result.sessionId).toBe('kept');
+  });
+
+  it('throws when execute is called after dispose', async () => {
+    const adapter = new MockExecutionAdapter();
+    await adapter.dispose();
+    await expect(adapter.execute(baseRequest)).rejects.toThrow(/dispose/);
+  });
+});

--- a/tests/execution/SdkExecutionAdapter.test.ts
+++ b/tests/execution/SdkExecutionAdapter.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect } from 'vitest';
+import {
+  renderPrompt,
+  SdkExecutionAdapter,
+  type SdkLike,
+  type SdkMessage,
+  type SdkQueryOptions,
+} from '../../src/execution/SdkExecutionAdapter.js';
+import type { StageExecutionRequest } from '../../src/execution/types.js';
+
+function fakeSdk(messages: readonly SdkMessage[], opts: { onCall?: (q: SdkQueryOptions) => void } = {}): SdkLike {
+  return {
+    query(q) {
+      opts.onCall?.(q);
+      return (async function* () {
+        for (const m of messages) yield m;
+      })();
+    },
+  };
+}
+
+const baseRequest: StageExecutionRequest = {
+  agentType: 'worker',
+  workOrder: 'implement issue #42',
+  priorOutputs: {},
+};
+
+const successMessages: SdkMessage[] = [
+  { type: 'system', session_id: 's-123' },
+  { type: 'assistant' },
+  {
+    type: 'result',
+    session_id: 's-123',
+    result: 'src/foo.ts: implementation file\nsrc/foo.test.ts: unit test',
+    is_error: false,
+    num_turns: 4,
+    usage: { input_tokens: 100, output_tokens: 50, cache_read_input_tokens: 30 },
+  },
+];
+
+describe('SdkExecutionAdapter', () => {
+  describe('renderPrompt', () => {
+    it('embeds every priorOutputs entry verbatim under labeled headers', () => {
+      const prompt = renderPrompt({
+        agentType: 'worker',
+        workOrder: 'WORK',
+        priorOutputs: { srs: 'SRS-CONTENT', sds: 'SDS-CONTENT' },
+      });
+      expect(prompt).toContain('# Stage: worker');
+      expect(prompt).toContain('## Work order\n\nWORK');
+      expect(prompt).toContain('### srs\n\nSRS-CONTENT');
+      expect(prompt).toContain('### sds\n\nSDS-CONTENT');
+    });
+
+    it('omits the prior outputs section when none are provided', () => {
+      const prompt = renderPrompt(baseRequest);
+      expect(prompt).not.toContain('## Prior outputs');
+    });
+  });
+
+  describe('execute - success path', () => {
+    it('extracts session id, tool count, token usage and artifacts from messages', async () => {
+      const adapter = new SdkExecutionAdapter({ loader: async () => fakeSdk(successMessages) });
+      const result = await adapter.execute(baseRequest);
+      expect(result.status).toBe('success');
+      expect(result.sessionId).toBe('s-123');
+      expect(result.toolCallCount).toBe(4);
+      expect(result.tokenUsage).toEqual({ input: 100, output: 50, cache: 30 });
+      expect(result.artifacts).toEqual([
+        { path: 'src/foo.ts', description: 'implementation file' },
+        { path: 'src/foo.test.ts', description: 'unit test' },
+      ]);
+    });
+
+    it('forwards skills, mcpServers, maxTurns, resume and signal to the SDK options', async () => {
+      let captured: SdkQueryOptions | undefined;
+      const adapter = new SdkExecutionAdapter({
+        loader: async () => fakeSdk(successMessages, { onCall: (q) => (captured = q) }),
+      });
+      const controller = new AbortController();
+      await adapter.execute({
+        ...baseRequest,
+        skills: ['foo', 'bar'],
+        mcpServers: { github: { type: 'stdio', command: 'gh' } },
+        maxTurns: 7,
+        resume: 'prior-session',
+        signal: controller.signal,
+      });
+      expect(captured?.options?.skills).toEqual(['foo', 'bar']);
+      expect(captured?.options?.mcpServers).toEqual({ github: { type: 'stdio', command: 'gh' } });
+      expect(captured?.options?.maxTurns).toBe(7);
+      expect(captured?.options?.resume).toBe('prior-session');
+      expect(captured?.options?.signal).toBe(controller.signal);
+    });
+
+    it('embeds priorOutputs in the prompt forwarded to the SDK (priorOutputs contract)', async () => {
+      let captured: SdkQueryOptions | undefined;
+      const adapter = new SdkExecutionAdapter({
+        loader: async () => fakeSdk(successMessages, { onCall: (q) => (captured = q) }),
+      });
+      await adapter.execute({
+        ...baseRequest,
+        priorOutputs: { srs: 'srs body', controller: 'controller plan' },
+      });
+      expect(captured?.prompt).toContain('### srs\n\nsrs body');
+      expect(captured?.prompt).toContain('### controller\n\ncontroller plan');
+    });
+  });
+
+  describe('execute - failure paths', () => {
+    it('returns failed when the result message has is_error=true', async () => {
+      const adapter = new SdkExecutionAdapter({
+        loader: async () =>
+          fakeSdk([
+            { type: 'result', session_id: 's-err', result: 'something went wrong', is_error: true },
+          ]),
+      });
+      const result = await adapter.execute(baseRequest);
+      expect(result.status).toBe('failed');
+      expect(result.sessionId).toBe('s-err');
+      expect(result.error?.code).toBe('EXEC-003');
+    });
+
+    it('returns failed when no result message is emitted', async () => {
+      const adapter = new SdkExecutionAdapter({
+        loader: async () => fakeSdk([{ type: 'system', session_id: 's-empty' }]),
+      });
+      const result = await adapter.execute(baseRequest);
+      expect(result.status).toBe('failed');
+      expect(result.sessionId).toBe('s-empty');
+    });
+
+    it('returns failed and serializes the thrown error', async () => {
+      const adapter = new SdkExecutionAdapter({
+        loader: async () => ({
+          query() {
+            throw new Error('boom');
+          },
+        }),
+      });
+      const result = await adapter.execute(baseRequest);
+      expect(result.status).toBe('failed');
+      expect(result.error?.message).toContain('boom');
+    });
+  });
+
+  describe('execute - cancellation', () => {
+    it('returns aborted when the signal is already aborted', async () => {
+      const controller = new AbortController();
+      controller.abort();
+      const adapter = new SdkExecutionAdapter({ loader: async () => fakeSdk(successMessages) });
+      const result = await adapter.execute({ ...baseRequest, signal: controller.signal });
+      expect(result.status).toBe('aborted');
+    });
+  });
+
+  describe('lifecycle', () => {
+    it('throws when execute is called after dispose', async () => {
+      const adapter = new SdkExecutionAdapter({ loader: async () => fakeSdk(successMessages) });
+      await adapter.dispose();
+      await expect(adapter.execute(baseRequest)).rejects.toThrow(/dispose/);
+    });
+
+    it('caches the resolved sdk so the loader runs once', async () => {
+      let calls = 0;
+      const adapter = new SdkExecutionAdapter({
+        loader: async () => {
+          calls += 1;
+          return fakeSdk(successMessages);
+        },
+      });
+      await adapter.execute(baseRequest);
+      await adapter.execute(baseRequest);
+      expect(calls).toBe(1);
+    });
+  });
+});


### PR DESCRIPTION
## What

src/execution/ 모듈을 신설해 ARCH-RFC-001 §4.1의 **ExecutionAdapter** 단일 SDK 진입점을 도입합니다. 함께 #789(AD-03) — `@anthropic-ai/claude-agent-sdk@^0.2.132` 의존성 추가도 한 PR에 포함했습니다 (AD-06이 이 패키지를 import하므로 결합).

### 산출물 (8 파일 추가)

| 파일 | 역할 |
|---|---|
| `src/execution/types.ts` | `StageExecutionRequest` / `StageExecutionResult` / `ArtifactRef` / `McpServerConfig` / `TokenUsage` / `ExecutionAdapter` |
| `src/execution/MockExecutionAdapter.ts` | 테스트용 결정적 어댑터 (handler 매칭, 호출 기록, dispose) |
| `src/execution/SdkExecutionAdapter.ts` | 실 SDK 어댑터 (dynamic `import()` 사용 — 빌드 타임에 SDK 미설치 환경도 컴파일) |
| `src/execution/index.ts` | public surface re-export |
| `src/execution/README.md` | 모듈 가이드, 계약, scope |
| `tests/execution/MockExecutionAdapter.test.ts` | 9 단위 테스트 |
| `tests/execution/SdkExecutionAdapter.test.ts` | 11 단위 테스트, fake SDK 주입 |
| `package.json` | `@anthropic-ai/claude-agent-sdk@^0.2.132` deps 추가 |

## Why

- RFC §4.1 명시: 모든 SDK 호출이 한 곳을 통과해야 (1) 테스트 모킹 일원화, (2) hook 정책 단일 지점, (3) telemetry 일관, (4) endpoint 전환(Anthropic/Bedrock/Vertex)이 어댑터 내부에서 가능
- 현재 `AgentBridge` 3종은 도구 루프를 자체 구현 — 일관성 결여
- 본 어댑터는 P2 파일럿(#793, AD-09)의 전제 조건

## How

### Dynamic import으로 컴파일 결합 회피

`SdkExecutionAdapter`는 `@anthropic-ai/claude-agent-sdk`를 dynamic `import()`로 lazy load합니다. 결과:
- SDK가 설치되지 않은 환경에서도 `tsc`가 본 모듈을 컴파일 통과
- 단위 테스트가 `loader` 주입으로 SDK 모듈 자체를 우회 가능
- runtime에서만 실제 SDK 필요 — 사용처 0개인 상태에서는 SDK 부재가 빌드를 깨지 않음

### priorOutputs 계약

`MockExecutionAdapter` / `SdkExecutionAdapter` 양쪽 모두가 `priorOutputs` 항목을 prompt에 verbatim으로 전달함을 단위 테스트로 보장합니다 (`SdkExecutionAdapter.test.ts > "embeds priorOutputs in the prompt forwarded to the SDK"` 어설션).

### 에러 처리

`AppError(code, message, { severity, cause })` 시그니처를 준수합니다. SDK 예외/`is_error: true`/empty result 모두 `failedResult()`로 일관 매핑하여 `error: SerializedError`를 결과에 첨부.

### Acceptance Criteria

- [x] `ExecutionAdapter` 인터페이스가 RFC §4.1 시그니처 100% 일치
- [x] `SdkExecutionAdapter` 작성 (dynamic import, 메시지 스트림 처리)
- [x] `MockExecutionAdapter` 작성 (예측 가능한 결과)
- [x] 양 어댑터 동일 인터페이스 만족 (Liskov)
- [x] 단위 테스트 20개 (Mock 9 + SDK 11)
- [x] `src/execution/README.md` 초안 (AD-08에서 확장)
- [x] priorOutputs 보장 단위 테스트
- [x] 어댑터 사용처 0 — 본 PR은 인프라만
- [ ] CI test/build 그린 — develop push 시 자동 검증
- [ ] `@anthropic-ai/claude-agent-sdk` deps 추가 (AD-03)
- [ ] **package-lock.json 갱신**: sandbox 한계로 `npm install` 미수행 — **머지 직전 maintainer가 `npm install && git commit -am "chore(deps): regen lock"`** 필요 ⚠️

## Out of Scope

- 실제 stage가 어댑터를 사용하도록 변경 (#793 AD-09)
- Hook pipeline 통합 (#791 AD-07)
- Telemetry bridge (#792 AD-08)

## Linked

- Closes #790 (AD-06)
- Closes #789 (AD-03)
- Unblocks #791 (AD-07), #793 (AD-09)
- Refs ARCH-RFC-001 §4.1

## Reviewer Checklist

- [ ] 인터페이스 시그니처가 RFC와 일치
- [ ] dynamic import 패턴이 vitest mock 가능
- [ ] AppError 사용이 sibling 코드 패턴과 일관
- [ ] `priorOutputs`가 prompt에 정확히 들어감 (테스트 통과 확인)
- [ ] package.json deps 추가가 정확 (semver, alphabetical)
- [ ] 머지 전 `npm install`로 package-lock.json 갱신 필요 인지
