### PR TITLE
feat(execution): add minimal hook pipeline for PostToolUse scratchpad capture

### DIFF
--- a/src/execution/SdkExecutionAdapter.ts
+++ b/src/execution/SdkExecutionAdapter.ts
@@ -23,6 +23,7 @@
 
 import { AppError } from '../errors/AppError.js';
 import { ErrorSeverity } from '../errors/types.js';
+import type { HookPipeline } from './hooks.js';
 import type {
   ArtifactRef,
   ExecutionAdapter,
@@ -45,6 +46,7 @@ export interface SdkQueryOptions {
     maxTurns?: number;
     resume?: string;
     signal?: AbortSignal;
+    hooks?: HookPipeline;
   };
 }
 
@@ -77,42 +79,54 @@ export interface SdkLike {
 export type SdkLoader = () => Promise<SdkLike>;
 
 const defaultLoader: SdkLoader = async () => {
-  const mod: unknown = await import(
-    /* @vite-ignore */ '@anthropic-ai/claude-agent-sdk' as string
-  );
-  if (!mod || typeof (mod as SdkLike).query !== 'function') {
+  const mod: unknown = await import(/* @vite-ignore */ '@anthropic-ai/claude-agent-sdk');
+  const candidate = mod as SdkLike | null | undefined;
+  if (candidate === null || candidate === undefined || typeof candidate.query !== 'function') {
     throw new AppError(
       'EXEC-001',
       '@anthropic-ai/claude-agent-sdk did not export a `query` function',
       { severity: ErrorSeverity.CRITICAL }
     );
   }
-  return mod as SdkLike;
+  return candidate;
 };
 
 export interface SdkExecutionAdapterOptions {
   /** Override the SDK loader for tests / alternative endpoints. */
   readonly loader?: SdkLoader;
+  /**
+   * Optional hook pipeline forwarded to the SDK. Built via
+   * `buildHookPipeline()` from `./hooks.ts`. When omitted, the adapter
+   * issues queries with no hooks (current default for tests / pilot).
+   */
+  readonly hooks?: HookPipeline;
 }
 
+/**
+ *
+ */
 export class SdkExecutionAdapter implements ExecutionAdapter {
   private readonly loader: SdkLoader;
+  private readonly hooks: HookPipeline | undefined;
   private sdkPromise: Promise<SdkLike> | null = null;
   private disposed = false;
 
   constructor(options: SdkExecutionAdapterOptions = {}) {
     this.loader = options.loader ?? defaultLoader;
+    this.hooks = options.hooks;
   }
 
+  /**
+   *
+   * @param req
+   */
   async execute(req: StageExecutionRequest): Promise<StageExecutionResult> {
     if (this.disposed) {
-      throw new AppError(
-        'EXEC-002',
-        'SdkExecutionAdapter: execute called after dispose',
-        { severity: ErrorSeverity.HIGH }
-      );
+      throw new AppError('EXEC-002', 'SdkExecutionAdapter: execute called after dispose', {
+        severity: ErrorSeverity.HIGH,
+      });
     }
-    if (req.signal?.aborted) {
+    if (req.signal?.aborted === true) {
       return abortedResult(req.resume);
     }
 
@@ -124,6 +138,7 @@ export class SdkExecutionAdapter implements ExecutionAdapter {
       maxTurns: req.maxTurns,
       resume: req.resume,
       signal: req.signal,
+      ...(this.hooks !== undefined ? { hooks: this.hooks } : {}),
     };
 
     let sessionId = req.resume ?? 'unknown';
@@ -134,19 +149,21 @@ export class SdkExecutionAdapter implements ExecutionAdapter {
 
     try {
       for await (const message of sdk.query({ prompt, options: sdkOptions })) {
-        if (message.session_id) sessionId = message.session_id;
+        if (message.session_id !== undefined && message.session_id !== '') {
+          sessionId = message.session_id;
+        }
         if (message.type === 'assistant') toolCallCount += 1;
         if (message.type === 'result') {
           resultText = message.result;
-          isError = Boolean(message.is_error);
+          isError = message.is_error === true;
           if (typeof message.num_turns === 'number') {
             toolCallCount = Math.max(toolCallCount, message.num_turns);
           }
-          if (message.usage) tokenUsage = mapUsage(message.usage);
+          if (message.usage !== undefined) tokenUsage = mapUsage(message.usage);
         }
       }
     } catch (err) {
-      if (req.signal?.aborted) return abortedResult(sessionId);
+      if (req.signal?.aborted === true) return abortedResult(sessionId);
       return failedResult(sessionId, err);
     }
 
@@ -163,9 +180,13 @@ export class SdkExecutionAdapter implements ExecutionAdapter {
     };
   }
 
-  async dispose(): Promise<void> {
+  /**
+   *
+   */
+  dispose(): Promise<void> {
     this.disposed = true;
     this.sdkPromise = null;
+    return Promise.resolve();
   }
 
   private getSdk(): Promise<SdkLike> {
@@ -178,6 +199,7 @@ export class SdkExecutionAdapter implements ExecutionAdapter {
  * Render a prompt that includes the work order and every prior output verbatim.
  * The format is intentionally simple — downstream agents parse the section
  * headers to retrieve specific upstream outputs.
+ * @param req
  */
 export function renderPrompt(req: StageExecutionRequest): string {
   const blocks: string[] = [`# Stage: ${req.agentType}`, '', '## Work order', '', req.workOrder];
@@ -192,8 +214,7 @@ export function renderPrompt(req: StageExecutionRequest): string {
 }
 
 function mapUsage(usage: NonNullable<SdkMessage['usage']>): TokenUsage {
-  const cache =
-    (usage.cache_read_input_tokens ?? 0) + (usage.cache_creation_input_tokens ?? 0);
+  const cache = (usage.cache_read_input_tokens ?? 0) + (usage.cache_creation_input_tokens ?? 0);
   return {
     input: usage.input_tokens ?? 0,
     output: usage.output_tokens ?? 0,
@@ -205,6 +226,7 @@ function mapUsage(usage: NonNullable<SdkMessage['usage']>): TokenUsage {
  * Lift any `path:` annotations the agent emitted into ArtifactRefs. The agent
  * convention is one per line as `<path>: <description>`. Lines without that
  * shape are ignored.
+ * @param resultText
  */
 function extractArtifacts(resultText: string): ArtifactRef[] {
   const out: ArtifactRef[] = [];

--- a/src/execution/hooks.ts
+++ b/src/execution/hooks.ts
@@ -1,0 +1,214 @@
+/**
+ * Execution hook pipeline — minimal skeleton.
+ *
+ * Builds a hook configuration object that the SDK driver passes through to
+ * `@anthropic-ai/claude-agent-sdk`'s `query()`. The current scope is the
+ * `PostToolUse` matcher for `Edit` and `Write` tools: when the underlying
+ * agent edits or writes a file, the hook captures the `tool_input.file_path`
+ * and forwards it to an injected {@link ArtifactSink} so the next stage can
+ * consume the artifact via its `priorOutputs`.
+ *
+ * Scope is intentionally narrow — `PreToolUse` and `Stop` matchers are
+ * declared as TODO stubs that currently no-op. They will be expanded in
+ * follow-up issues:
+ *
+ * - `PreToolUse` policy enforcement → AD-SDLC P3 (telemetry / policy engine)
+ * - `Stop` finalization → AD-SDLC P3 (telemetry bridge)
+ *
+ * Failure semantics: any hook callback that throws aborts the SDK stage.
+ * This module never swallows errors — it surfaces them up so the
+ * {@link SdkExecutionAdapter} can return a `failed` {@link StageExecutionResult}.
+ *
+ * @packageDocumentation
+ */
+
+import { AppError } from '../errors/AppError.js';
+import { ErrorSeverity } from '../errors/types.js';
+
+/**
+ * Minimal sink the hook needs to record an artifact. Decoupled from the full
+ * Scratchpad to keep the hook trivially testable. Production wiring adapts
+ * the real `Scratchpad` to this interface (a thin shim is sufficient).
+ */
+export interface ArtifactSink {
+  /**
+   * Record that a tool produced or modified the file at `filePath`.
+   * MUST be idempotent — the SDK may re-emit the same path across retries.
+   * Implementations may persist asynchronously; the returned promise is
+   * awaited by the hook so persistence failure aborts the stage.
+   */
+  recordArtifact(entry: ArtifactCaptureEntry): void | Promise<void>;
+}
+
+/**
+ * Single artifact-capture event passed to the {@link ArtifactSink}. The
+ * shape mirrors what a downstream stage needs to pick the file up via
+ * `priorOutputs`.
+ */
+export interface ArtifactCaptureEntry {
+  /** File path the tool wrote or edited (verbatim from `tool_input.file_path`). */
+  readonly filePath: string;
+  /** Tool name that produced the artifact (`Edit` or `Write`). */
+  readonly toolName: 'Edit' | 'Write';
+  /** Wall-clock timestamp the hook fired (ISO-8601). */
+  readonly capturedAt: string;
+  /** SDK session id when available — useful for cross-referencing logs. */
+  readonly sessionId?: string;
+}
+
+/**
+ * Generic shape of a tool-use event the SDK forwards to a hook callback.
+ * We intentionally accept a wide `tool_input` so callers do not need to
+ * keep this in lockstep with the SDK's evolving tool catalog.
+ */
+export interface SdkToolUseEvent {
+  readonly tool_name: string;
+  readonly tool_input?: Record<string, unknown>;
+  readonly session_id?: string;
+}
+
+/**
+ * Callback signature the SDK invokes for matched tool events. Return value
+ * is intentionally `void | Promise<void>` so the hook can be async.
+ */
+export type SdkHookCallback = (event: SdkToolUseEvent) => void | Promise<void>;
+
+/**
+ * Single hook entry: the `matcher` is a regex string the SDK applies to
+ * `tool_name`; the `callback` runs when it matches.
+ */
+export interface SdkHookEntry {
+  readonly matcher: string;
+  readonly callback: SdkHookCallback;
+}
+
+/**
+ * Hook pipeline shape consumed by {@link SdkExecutionAdapter}. Mirrors the
+ * SDK's hook configuration: each top-level key is a hook event name, the
+ * value is the list of (matcher, callback) entries.
+ */
+export interface HookPipeline {
+  readonly PreToolUse?: readonly SdkHookEntry[];
+  readonly PostToolUse?: readonly SdkHookEntry[];
+  readonly Stop?: readonly SdkHookEntry[];
+}
+
+/**
+ * Options accepted by {@link buildHookPipeline}.
+ */
+export interface BuildHookPipelineOptions {
+  /** Optional clock injection point for deterministic tests. */
+  readonly now?: () => Date;
+}
+
+/**
+ * Tools whose `PostToolUse` event we capture into the artifact sink.
+ * Combined into a single regex matcher so the SDK fires one callback for
+ * either tool — keeping the per-event work O(1).
+ */
+const ARTIFACT_TOOL_NAMES = ['Edit', 'Write'] as const;
+type ArtifactToolName = (typeof ARTIFACT_TOOL_NAMES)[number];
+const ARTIFACT_TOOL_MATCHER = ARTIFACT_TOOL_NAMES.join('|');
+
+/**
+ * Build the hook pipeline that captures `Edit`/`Write` tool outputs into the
+ * provided {@link ArtifactSink}.
+ *
+ * The returned object is shaped so the {@link SdkExecutionAdapter} can pass
+ * it straight through to the SDK. Hook callbacks throw {@link AppError} on
+ * any failure path (missing input, sink rejection) — the SDK stage aborts
+ * as a result.
+ *
+ * @param sink Destination for captured artifact events.
+ * @param options Optional knobs; `now` is the only injection point today.
+ * @returns Hook pipeline object suitable for `query({ options: { hooks } })`.
+ */
+export function buildHookPipeline(
+  sink: ArtifactSink,
+  options: BuildHookPipelineOptions = {}
+): HookPipeline {
+  // Runtime guard for callers crossing the type boundary (e.g. JS or
+  // dynamically-built sinks). The cast lets us inspect the value without
+  // the type system insisting it must already be valid.
+  const candidate = sink as ArtifactSink | null | undefined;
+  if (
+    candidate === null ||
+    candidate === undefined ||
+    typeof candidate.recordArtifact !== 'function'
+  ) {
+    throw new AppError('EXEC-101', 'buildHookPipeline: sink.recordArtifact is required', {
+      severity: ErrorSeverity.HIGH,
+    });
+  }
+  const now = options.now ?? ((): Date => new Date());
+
+  const postToolUse: SdkHookEntry[] = [
+    {
+      matcher: ARTIFACT_TOOL_MATCHER,
+      callback: async (event): Promise<void> => captureEditOrWrite(event, sink, now),
+    },
+  ];
+
+  // PreToolUse and Stop are placeholders. We do NOT register no-op callbacks
+  // with the SDK — the matcher list is empty so the SDK skips the hook event
+  // entirely. The keys stay in the type for downstream wiring discoverability.
+  // TODO(AD-P3): PreToolUse policy enforcement (issue follow-up).
+  // TODO(AD-P3): Stop finalization → telemetry bridge (issue follow-up).
+  return {
+    PostToolUse: postToolUse,
+  };
+}
+
+/**
+ * Per-event capture logic. Validates the tool name and `file_path`, builds
+ * an {@link ArtifactCaptureEntry}, and forwards it to the sink. Awaits any
+ * async sink so a rejection aborts the stage.
+ *
+ * @param event Tool-use event the SDK forwarded to the matched hook.
+ * @param sink Destination for the captured artifact entry.
+ * @param now Clock function used to stamp `capturedAt`.
+ */
+async function captureEditOrWrite(
+  event: SdkToolUseEvent,
+  sink: ArtifactSink,
+  now: () => Date
+): Promise<void> {
+  const toolName = event.tool_name;
+  if (!isArtifactToolName(toolName)) {
+    // Defensive: matcher should have filtered, but never trust the SDK.
+    throw new AppError(
+      'EXEC-102',
+      `Hook captureEditOrWrite invoked for unsupported tool: ${toolName}`,
+      { severity: ErrorSeverity.HIGH, context: { toolName } }
+    );
+  }
+
+  const filePath = readFilePath(event.tool_input);
+  if (filePath === null) {
+    throw new AppError('EXEC-103', `Hook PostToolUse(${toolName}) missing tool_input.file_path`, {
+      severity: ErrorSeverity.HIGH,
+      context: { toolName },
+    });
+  }
+
+  const entry: ArtifactCaptureEntry = {
+    filePath,
+    toolName,
+    capturedAt: now().toISOString(),
+    ...(event.session_id !== undefined ? { sessionId: event.session_id } : {}),
+  };
+
+  // Deliberate await: a sink failure must abort the stage.
+  await sink.recordArtifact(entry);
+}
+
+function isArtifactToolName(name: string): name is ArtifactToolName {
+  return (ARTIFACT_TOOL_NAMES as readonly string[]).includes(name);
+}
+
+function readFilePath(input: Record<string, unknown> | undefined): string | null {
+  if (!input) return null;
+  const value = input.file_path;
+  if (typeof value !== 'string' || value.length === 0) return null;
+  return value;
+}

--- a/src/execution/index.ts
+++ b/src/execution/index.ts
@@ -17,10 +17,7 @@ export type {
 } from './types.js';
 
 export { MockExecutionAdapter } from './MockExecutionAdapter.js';
-export type {
-  MockExecutionAdapterOptions,
-  MockExecutionHandler,
-} from './MockExecutionAdapter.js';
+export type { MockExecutionAdapterOptions, MockExecutionHandler } from './MockExecutionAdapter.js';
 
 export { SdkExecutionAdapter, renderPrompt } from './SdkExecutionAdapter.js';
 export type {
@@ -30,3 +27,14 @@ export type {
   SdkMessage,
   SdkQueryOptions,
 } from './SdkExecutionAdapter.js';
+
+export { buildHookPipeline } from './hooks.js';
+export type {
+  ArtifactCaptureEntry,
+  ArtifactSink,
+  BuildHookPipelineOptions,
+  HookPipeline,
+  SdkHookCallback,
+  SdkHookEntry,
+  SdkToolUseEvent,
+} from './hooks.js';

--- a/tests/execution/hooks.test.ts
+++ b/tests/execution/hooks.test.ts
@@ -1,0 +1,279 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  buildHookPipeline,
+  type ArtifactCaptureEntry,
+  type ArtifactSink,
+  type SdkHookCallback,
+  type SdkToolUseEvent,
+} from '../../src/execution/hooks.js';
+import {
+  SdkExecutionAdapter,
+  type SdkLike,
+  type SdkMessage,
+  type SdkQueryOptions,
+} from '../../src/execution/SdkExecutionAdapter.js';
+import { MockExecutionAdapter } from '../../src/execution/MockExecutionAdapter.js';
+import type { StageExecutionRequest } from '../../src/execution/types.js';
+
+/**
+ * Pull the PostToolUse(Edit|Write) callback out of a built pipeline so each
+ * test can drive it directly. Keeps assertions focused on capture behaviour
+ * rather than SDK plumbing.
+ */
+function getPostToolUseCallback(
+  sink: ArtifactSink,
+  options?: { now?: () => Date }
+): SdkHookCallback {
+  const pipeline = buildHookPipeline(sink, options);
+  expect(pipeline.PostToolUse).toBeDefined();
+  expect(pipeline.PostToolUse).toHaveLength(1);
+  const entry = pipeline.PostToolUse![0];
+  expect(entry.matcher).toBe('Edit|Write');
+  return entry.callback;
+}
+
+function fakeSink(): ArtifactSink & { entries: ArtifactCaptureEntry[] } {
+  const entries: ArtifactCaptureEntry[] = [];
+  return {
+    entries,
+    recordArtifact(entry) {
+      entries.push(entry);
+    },
+  };
+}
+
+describe('buildHookPipeline', () => {
+  describe('configuration shape', () => {
+    it('rejects a missing sink', () => {
+      // @ts-expect-error — exercising runtime guard
+      expect(() => buildHookPipeline(undefined)).toThrowError(/recordArtifact/);
+    });
+
+    it('registers a single PostToolUse(Edit|Write) entry and no PreToolUse/Stop entries', () => {
+      const sink = fakeSink();
+      const pipeline = buildHookPipeline(sink);
+      expect(pipeline.PostToolUse).toHaveLength(1);
+      expect(pipeline.PostToolUse![0].matcher).toBe('Edit|Write');
+      // PreToolUse / Stop are TODO stubs — deliberately omitted from the
+      // pipeline so the SDK skips them entirely.
+      expect(pipeline.PreToolUse).toBeUndefined();
+      expect(pipeline.Stop).toBeUndefined();
+    });
+  });
+
+  describe('PostToolUse capture — mock SDK scenarios', () => {
+    it('scenario 1 (success): records Edit/Write file_path with deterministic timestamp', async () => {
+      const sink = fakeSink();
+      const fixedNow = new Date('2026-05-08T00:00:00.000Z');
+      const callback = getPostToolUseCallback(sink, { now: () => fixedNow });
+
+      await callback({
+        tool_name: 'Edit',
+        tool_input: { file_path: 'src/foo.ts', new_string: 'x' },
+        session_id: 'sess-1',
+      });
+      await callback({
+        tool_name: 'Write',
+        tool_input: { file_path: 'src/bar.ts', content: 'y' },
+        session_id: 'sess-1',
+      });
+
+      expect(sink.entries).toEqual([
+        {
+          filePath: 'src/foo.ts',
+          toolName: 'Edit',
+          capturedAt: '2026-05-08T00:00:00.000Z',
+          sessionId: 'sess-1',
+        },
+        {
+          filePath: 'src/bar.ts',
+          toolName: 'Write',
+          capturedAt: '2026-05-08T00:00:00.000Z',
+          sessionId: 'sess-1',
+        },
+      ]);
+    });
+
+    it('scenario 2 (failure aborts): sink rejection propagates so the SDK stage aborts', async () => {
+      const sinkError = new Error('disk full');
+      const sink: ArtifactSink = {
+        recordArtifact: vi.fn().mockRejectedValue(sinkError),
+      };
+      const callback = getPostToolUseCallback(sink);
+
+      await expect(
+        callback({
+          tool_name: 'Write',
+          tool_input: { file_path: 'src/baz.ts' },
+        })
+      ).rejects.toBe(sinkError);
+      expect(sink.recordArtifact).toHaveBeenCalledTimes(1);
+    });
+
+    it('scenario 3 (async sink): awaits async recordArtifact before returning', async () => {
+      const order: string[] = [];
+      const sink: ArtifactSink = {
+        async recordArtifact(entry) {
+          order.push(`enter:${entry.filePath}`);
+          await new Promise((resolve) => setTimeout(resolve, 5));
+          order.push(`done:${entry.filePath}`);
+        },
+      };
+      const callback = getPostToolUseCallback(sink);
+
+      await callback({ tool_name: 'Edit', tool_input: { file_path: 'src/qux.ts' } });
+
+      // The hook awaits the sink, so the "done" event must precede the
+      // resolved promise — i.e. both events are present in order.
+      expect(order).toEqual(['enter:src/qux.ts', 'done:src/qux.ts']);
+    });
+
+    it('throws when tool_input.file_path is missing (no silent failure)', async () => {
+      const sink = fakeSink();
+      const callback = getPostToolUseCallback(sink);
+      await expect(callback({ tool_name: 'Edit', tool_input: {} })).rejects.toThrowError(
+        /file_path/
+      );
+      expect(sink.entries).toHaveLength(0);
+    });
+
+    it('throws when invoked for an unsupported tool (defensive guard)', async () => {
+      const sink = fakeSink();
+      const callback = getPostToolUseCallback(sink);
+      await expect(
+        callback({
+          tool_name: 'Bash' as SdkToolUseEvent['tool_name'],
+          tool_input: { file_path: 'x' },
+        })
+      ).rejects.toThrowError(/unsupported tool/);
+    });
+  });
+});
+
+describe('SdkExecutionAdapter — hooks wiring', () => {
+  function fakeSdkCapturing(messages: readonly SdkMessage[]): {
+    sdk: SdkLike;
+    captured: { value: SdkQueryOptions | undefined };
+  } {
+    const captured: { value: SdkQueryOptions | undefined } = { value: undefined };
+    const sdk: SdkLike = {
+      query(q) {
+        captured.value = q;
+        return (async function* () {
+          for (const m of messages) yield m;
+        })();
+      },
+    };
+    return { sdk, captured };
+  }
+
+  const successMessages: SdkMessage[] = [
+    { type: 'system', session_id: 'sess-A' },
+    {
+      type: 'result',
+      session_id: 'sess-A',
+      result: 'ok',
+      is_error: false,
+      num_turns: 1,
+      usage: { input_tokens: 1, output_tokens: 1 },
+    },
+  ];
+
+  const baseRequest: StageExecutionRequest = {
+    agentType: 'worker',
+    workOrder: 'do thing',
+    priorOutputs: {},
+  };
+
+  it('forwards the hook pipeline to the SDK options', async () => {
+    const sink = fakeSink();
+    const pipeline = buildHookPipeline(sink);
+    const { sdk, captured } = fakeSdkCapturing(successMessages);
+    const adapter = new SdkExecutionAdapter({
+      loader: async () => sdk,
+      hooks: pipeline,
+    });
+
+    await adapter.execute(baseRequest);
+
+    expect(captured.value?.options?.hooks).toBe(pipeline);
+    expect(captured.value?.options?.hooks?.PostToolUse).toHaveLength(1);
+  });
+
+  it('omits the hooks key entirely when none is configured', async () => {
+    const { sdk, captured } = fakeSdkCapturing(successMessages);
+    const adapter = new SdkExecutionAdapter({ loader: async () => sdk });
+
+    await adapter.execute(baseRequest);
+
+    expect(captured.value?.options).toBeDefined();
+    expect(captured.value?.options).not.toHaveProperty('hooks');
+  });
+});
+
+describe('integration — MockExecutionAdapter + hook callback', () => {
+  // Scenario from issue AC #4: confirm a hook callback fed real-looking
+  // tool_use events records exactly what downstream stages will read out
+  // of the artifact sink, and that the MockExecutionAdapter still records
+  // its own request payload independently.
+  it('captures Edit/Write events into the sink while MockExecutionAdapter records the stage call', async () => {
+    const sink = fakeSink();
+    const fixedNow = new Date('2026-05-08T01:00:00.000Z');
+    const callback = getPostToolUseCallback(sink, { now: () => fixedNow });
+
+    const adapter = new MockExecutionAdapter({
+      handlers: [
+        {
+          match: (req) => req.agentType === 'worker',
+          respond: {
+            status: 'success',
+            artifacts: [{ path: 'src/integration.ts', description: 'created' }],
+            sessionId: 'mock-int',
+            toolCallCount: 2,
+            tokenUsage: { input: 5, output: 10, cache: 0 },
+          },
+        },
+      ],
+    });
+
+    // Simulate the SDK flow: stage executes, then PostToolUse fires for each
+    // tool call. We drive the hook callback ourselves to keep the test
+    // independent of the real SDK.
+    const result = await adapter.execute({
+      agentType: 'worker',
+      workOrder: 'implement integration',
+      priorOutputs: { upstream: 'spec' },
+    });
+    await callback({
+      tool_name: 'Write',
+      tool_input: { file_path: 'src/integration.ts' },
+      session_id: 'mock-int',
+    });
+    await callback({
+      tool_name: 'Edit',
+      tool_input: { file_path: 'src/integration.ts' },
+      session_id: 'mock-int',
+    });
+
+    // MockExecutionAdapter recorded the stage call as expected.
+    expect(adapter.calls).toHaveLength(1);
+    expect(adapter.calls[0].priorOutputs).toEqual({ upstream: 'spec' });
+    expect(result.status).toBe('success');
+
+    // The hook captured both tool events with the expected shape.
+    expect(sink.entries).toEqual([
+      {
+        filePath: 'src/integration.ts',
+        toolName: 'Write',
+        capturedAt: '2026-05-08T01:00:00.000Z',
+        sessionId: 'mock-int',
+      },
+      {
+        filePath: 'src/integration.ts',
+        toolName: 'Edit',
+        capturedAt: '2026-05-08T01:00:00.000Z',
+        sessionId: 'mock-int',
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
## What

Add the minimal `PostToolUse(Edit|Write)` hook pipeline so the SDK execution adapter can capture artifact file paths automatically and forward them to a scratchpad-shaped sink. Wires the pipeline through `SdkExecutionAdapter` as an optional constructor option.

### Changes
- New `src/execution/hooks.ts` exporting:
  - `buildHookPipeline(sink, { now? })` — returns the hook config object the SDK consumes.
  - `ArtifactSink`, `ArtifactCaptureEntry`, `HookPipeline`, `SdkToolUseEvent`, `SdkHookEntry`, `SdkHookCallback`, `BuildHookPipelineOptions` types.
- `SdkExecutionAdapter` accepts an optional `hooks` option and forwards it to `SdkQueryOptions.options.hooks` only when present.
- New `tests/execution/hooks.test.ts` covering AC scenarios.
- Re-exports of the hooks surface from `src/execution/index.ts`.
- Folded in mechanical `@typescript-eslint/strict-boolean-expressions` and `no-unnecessary-type-assertion` lint fixes on the modified `SdkExecutionAdapter.ts` so the pre-commit gate passes cleanly. No behavioral change.

## Why

Closes #791. Today `ClaudeCodeBridge` polls scratchpad for worker outputs. The new `SdkExecutionAdapter` (#810) gives us a single funnel where the SDK's hook callbacks can capture `tool_input.file_path` immediately after each `Edit`/`Write`, removing the polling round-trip. This PR is the minimal AD-07 skeleton — `PreToolUse` policy and `Stop` finalization are explicit TODO stubs for AD-SDLC P3 issues.

## How

- The `PostToolUse` matcher uses the regex `Edit|Write` so a single callback handles both tool names.
- Hook callbacks throw `AppError` (`EXEC-101..103`) on missing sink, missing `file_path`, or unsupported tool. The `await sink.recordArtifact(...)` propagates sink rejections, so the SDK stage aborts — no silent failures.
- `PreToolUse` and `Stop` are deliberately omitted from the returned pipeline (not registered as no-ops) so the SDK skips them entirely.
- The `ArtifactSink` interface is intentionally narrow (one method) so the real `Scratchpad` is wired via a thin adapter without coupling this module to the full scratchpad surface.

## Test Plan

`npm test -- tests/execution/hooks.test.ts` — 10 tests pass:

1. **Configuration shape** — rejects missing sink; only `PostToolUse` registered with the `Edit|Write` matcher.
2. **PostToolUse capture (mock SDK)**:
   - Scenario 1 (success): records `Edit` and `Write` events with deterministic timestamp + sessionId.
   - Scenario 2 (failure aborts): sink rejection propagates so the SDK stage aborts.
   - Scenario 3 (async sink): hook awaits async `recordArtifact` before resolving.
   - Throws when `tool_input.file_path` is missing.
   - Throws when invoked for an unsupported tool (defensive guard).
3. **`SdkExecutionAdapter` wiring** — forwards the pipeline to SDK options when set; omits the `hooks` key entirely when not.
4. **Integration** — `MockExecutionAdapter` + hook callback (AC #4): both record their respective events independently.

Existing `tests/execution/` suite (`SdkExecutionAdapter`, `MockExecutionAdapter`) continues to pass — 30/30 green.

## Out of Scope

- `PreToolUse` policy enforcement → AD-SDLC P3
- `Stop` finalization / telemetry bridge → AD-SDLC P3 (#792)
- Real Scratchpad adapter wiring at the call-site → AD-09 (#793)

Closes #791