### PR TITLE
feat(config): formalize AD_SDLC_USE_SDK_FOR_WORKER via FeatureFlagsResolver

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -62,9 +62,9 @@ Creates and initializes a ConfigManager instance.
 
 ```typescript
 const config = await ConfigManager.create({
-  baseDir: '/path/to/project',  // Base directory for config files
-  validate: true,                // Whether to validate configs (default: true)
-  resolveEnvVars: true,          // Resolve ${VAR} patterns (default: true)
+  baseDir: '/path/to/project', // Base directory for config files
+  validate: true, // Whether to validate configs (default: true)
+  resolveEnvVars: true, // Resolve ${VAR} patterns (default: true)
 });
 ```
 
@@ -75,12 +75,12 @@ Returns global configuration settings with defaults applied.
 ```typescript
 const global = config.getGlobalConfig();
 
-console.log(global.projectRoot);      // e.g., '/path/to/project'
-console.log(global.scratchpadDir);    // e.g., '.ad-sdlc/scratchpad'
-console.log(global.logLevel);         // 'DEBUG' | 'INFO' | 'WARN' | 'ERROR'
-console.log(global.approvalGates);    // Approval gates configuration
-console.log(global.retryPolicy);      // Retry policy settings
-console.log(global.timeouts);         // Timeout settings
+console.log(global.projectRoot); // e.g., '/path/to/project'
+console.log(global.scratchpadDir); // e.g., '.ad-sdlc/scratchpad'
+console.log(global.logLevel); // 'DEBUG' | 'INFO' | 'WARN' | 'ERROR'
+console.log(global.approvalGates); // Approval gates configuration
+console.log(global.retryPolicy); // Retry policy settings
+console.log(global.timeouts); // Timeout settings
 ```
 
 #### getRetryPolicy()
@@ -90,10 +90,10 @@ Returns retry policy configuration.
 ```typescript
 const retry = config.getRetryPolicy();
 
-console.log(retry.maxAttempts);       // e.g., 3
-console.log(retry.backoff);           // 'linear' | 'exponential'
-console.log(retry.baseDelaySeconds);  // e.g., 5
-console.log(retry.maxDelaySeconds);   // e.g., 60
+console.log(retry.maxAttempts); // e.g., 3
+console.log(retry.backoff); // 'linear' | 'exponential'
+console.log(retry.baseDelaySeconds); // e.g., 5
+console.log(retry.maxDelaySeconds); // e.g., 60
 ```
 
 #### getPipelineStages()
@@ -104,13 +104,13 @@ Returns ordered array of pipeline stages.
 const stages = config.getPipelineStages();
 
 for (const stage of stages) {
-  console.log(stage.name);            // Stage name
-  console.log(stage.agent);           // Agent ID
-  console.log(stage.inputs);          // Input file patterns
-  console.log(stage.outputs);         // Output file patterns
-  console.log(stage.next);            // Next stage name or null
+  console.log(stage.name); // Stage name
+  console.log(stage.agent); // Agent ID
+  console.log(stage.inputs); // Input file patterns
+  console.log(stage.outputs); // Output file patterns
+  console.log(stage.next); // Next stage name or null
   console.log(stage.approvalRequired); // Whether approval is needed
-  console.log(stage.parallel);        // Whether can run in parallel
+  console.log(stage.parallel); // Whether can run in parallel
 }
 ```
 
@@ -133,12 +133,12 @@ Returns workflow configuration for a specific agent.
 const agentConfig = config.getAgentConfig('collector');
 
 if (agentConfig) {
-  console.log(agentConfig.model);       // 'sonnet' | 'opus' | 'haiku'
-  console.log(agentConfig.tools);       // ['Read', 'Write', 'Bash', ...]
-  console.log(agentConfig.template);    // Template file path
+  console.log(agentConfig.model); // 'sonnet' | 'opus' | 'haiku'
+  console.log(agentConfig.tools); // ['Read', 'Write', 'Bash', ...]
+  console.log(agentConfig.template); // Template file path
   console.log(agentConfig.maxQuestions); // Max clarification questions
-  console.log(agentConfig.github);      // GitHub settings
-  console.log(agentConfig.coding);      // Coding settings
+  console.log(agentConfig.github); // GitHub settings
+  console.log(agentConfig.coding); // Coding settings
   console.log(agentConfig.verification); // Verification settings
 }
 ```
@@ -151,11 +151,11 @@ Returns agent definition from agents.yaml.
 const definition = config.getAgentDefinition('collector');
 
 if (definition) {
-  console.log(definition.id);           // Agent ID
-  console.log(definition.name);         // Agent name
-  console.log(definition.description);  // Description
+  console.log(definition.id); // Agent ID
+  console.log(definition.name); // Agent name
+  console.log(definition.description); // Description
   console.log(definition.capabilities); // Capability list
-  console.log(definition.io);           // Input/output specs
+  console.log(definition.io); // Input/output specs
 }
 ```
 
@@ -191,10 +191,10 @@ Returns GitHub integration settings.
 ```typescript
 const github = config.getGitHubConfig();
 
-console.log(github.repo);              // e.g., 'owner/repo'
-console.log(github.defaultBranch);     // e.g., 'main'
-console.log(github.issueLabels);       // Default issue labels
-console.log(github.prLabels);          // Default PR labels
+console.log(github.repo); // e.g., 'owner/repo'
+console.log(github.defaultBranch); // e.g., 'main'
+console.log(github.issueLabels); // Default issue labels
+console.log(github.prLabels); // Default PR labels
 ```
 
 #### getLoggingConfig()
@@ -204,19 +204,15 @@ Returns logging configuration.
 ```typescript
 const logging = config.getLoggingConfig();
 
-console.log(logging.level);            // Log level
-console.log(logging.format);           // 'json' | 'text'
-console.log(logging.outputs);          // Output configurations
+console.log(logging.level); // Log level
+console.log(logging.format); // 'json' | 'text'
+console.log(logging.outputs); // Output configurations
 ```
 
 ### Singleton Management
 
 ```typescript
-import {
-  getConfigManager,
-  resetConfigManager,
-  isConfigManagerInitialized,
-} from 'ad-sdlc';
+import { getConfigManager, resetConfigManager, isConfigManagerInitialized } from 'ad-sdlc';
 
 // Get or create singleton instance
 const config = await getConfigManager();
@@ -255,8 +251,8 @@ const resolved = resolveEnvVars('${HOME}/projects');
 Main workflow configuration file located at `.ad-sdlc/config/workflow.yaml`:
 
 ```yaml
-version: "1.0.0"
-name: "my-project"
+version: '1.0.0'
+name: 'my-project'
 
 global:
   project_root: ${PWD}
@@ -288,7 +284,7 @@ agents:
 Agent definitions file located at `.ad-sdlc/config/agents.yaml`:
 
 ```yaml
-version: "1.0.0"
+version: '1.0.0'
 
 agents:
   collector:
@@ -308,11 +304,7 @@ The loader module includes built-in caching to avoid repeated file reads. Cache 
 ### Cache Management
 
 ```typescript
-import {
-  clearConfigCache,
-  invalidateConfigCache,
-  getConfigCacheStats,
-} from 'ad-sdlc';
+import { clearConfigCache, invalidateConfigCache, getConfigCacheStats } from 'ad-sdlc';
 
 // Clear all cached configurations
 clearConfigCache();
@@ -339,11 +331,7 @@ The caching is transparent to normal usage - `loadWorkflowConfig()` and `loadAge
 For direct file loading without ConfigManager:
 
 ```typescript
-import {
-  loadWorkflowConfig,
-  loadAgentsConfig,
-  loadAllConfigs,
-} from 'ad-sdlc';
+import { loadWorkflowConfig, loadAgentsConfig, loadAllConfigs } from 'ad-sdlc';
 
 // Load individual configs
 const workflow = await loadWorkflowConfig({ baseDir: '/path/to/project' });
@@ -358,11 +346,7 @@ const { workflow, agents } = await loadAllConfigs();
 For validating configuration data:
 
 ```typescript
-import {
-  validateWorkflowConfig,
-  validateAgentsConfig,
-  ConfigValidationError,
-} from 'ad-sdlc';
+import { validateWorkflowConfig, validateAgentsConfig, ConfigValidationError } from 'ad-sdlc';
 
 const result = validateWorkflowConfig(data);
 
@@ -412,11 +396,7 @@ await watcher.start();
 ## Error Handling
 
 ```typescript
-import {
-  ConfigNotFoundError,
-  ConfigParseError,
-  ConfigValidationError,
-} from 'ad-sdlc';
+import { ConfigNotFoundError, ConfigParseError, ConfigValidationError } from 'ad-sdlc';
 
 try {
   const config = await getConfigManager();
@@ -447,4 +427,64 @@ import type {
   ValidationResult,
   FieldError,
 } from 'ad-sdlc';
+```
+
+## Feature Flags
+
+Feature flags toggle optional code paths that are still being piloted. The
+`FeatureFlagsResolver` consults the following sources, picking the first that
+provides a value:
+
+1. **Environment variable** (highest priority)
+2. **CLI option**
+3. **YAML config** at `.ad-sdlc/config/feature-flags.yaml` (opt-in only)
+4. **Built-in default**
+
+The YAML file is **never auto-created** by AD-SDLC — users must opt in by
+creating it manually. Missing or empty files are silently treated as
+"not configured".
+
+### Recognized Flags
+
+| Flag              | Type    | Default | Env variable                 | CLI flag               | YAML path               | Description                                                                                                                                                                                                    |
+| ----------------- | ------- | ------- | ---------------------------- | ---------------------- | ----------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `useSdkForWorker` | boolean | `false` | `AD_SDLC_USE_SDK_FOR_WORKER` | `--use-sdk-for-worker` | `flags.useSdkForWorker` | Routes the `worker` pipeline stage through the SDK `ExecutionAdapter` (with the AD-07 hook pipeline) instead of the legacy AgentBridge path. Default flip is tracked separately under P3 cutover (issue #798). |
+
+### Environment Variable Tokens
+
+Boolean environment variables accept the following tokens (case-insensitive,
+whitespace-trimmed):
+
+- **Truthy**: `1`, `true`, `yes`, `on`
+- **Falsy**: `0`, `false`, `no`, `off`, `` (empty)
+
+Any other value raises a readable error rather than silently coercing to
+`false`.
+
+### YAML Schema
+
+`.ad-sdlc/config/feature-flags.yaml` is validated against
+[`schemas/feature-flags.schema.json`](../schemas/feature-flags.schema.json)
+with Zod. Unknown keys are rejected (strict mode). Example:
+
+```yaml
+# Optional. Reserved for future schema migrations.
+version: '1.0.0'
+flags:
+  useSdkForWorker: true
+```
+
+### Programmatic Use
+
+```typescript
+import { FeatureFlagsResolver } from 'ad-sdlc';
+
+const resolver = FeatureFlagsResolver.fromSources({
+  cli: { useSdkForWorker: true },
+  baseDir: '/path/to/project',
+});
+
+if (resolver.useSdkForWorker()) {
+  // Route worker stage through ExecutionAdapter
+}
 ```

--- a/schemas/feature-flags.schema.json
+++ b/schemas/feature-flags.schema.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/kcenon/claude_code_agent/schemas/feature-flags.schema.json",
+  "title": "AD-SDLC Feature Flags Configuration",
+  "description": "Schema for .ad-sdlc/config/feature-flags.yaml. The file is opt-in: AD-SDLC never auto-creates it. Each flag may be omitted; missing flags fall through to lower-priority sources (env, CLI, default).",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "version": {
+      "type": "string",
+      "pattern": "^\\d+\\.\\d+\\.\\d+$",
+      "description": "Schema version (semver). Optional; reserved for future migrations."
+    },
+    "flags": {
+      "type": "object",
+      "description": "Feature flag values. Currently only useSdkForWorker is recognized.",
+      "additionalProperties": false,
+      "properties": {
+        "useSdkForWorker": {
+          "type": "boolean",
+          "description": "When true, route the worker stage through ExecutionAdapter (SDK path). Default: false. See AD_SDLC_USE_SDK_FOR_WORKER."
+        }
+      }
+    }
+  }
+}

--- a/src/ad-sdlc-orchestrator/AdsdlcOrchestratorAgent.ts
+++ b/src/ad-sdlc-orchestrator/AdsdlcOrchestratorAgent.ts
@@ -28,6 +28,7 @@ import {
 import { SdkExecutionAdapter } from '../execution/index.js';
 import { Semaphore } from '../utilities/Semaphore.js';
 import { getLogger } from '../logging/index.js';
+import { ENV_USE_SDK_FOR_WORKER, FeatureFlagsResolver } from '../config/featureFlags.js';
 import { PipelineCheckpointManager } from './PipelineCheckpointManager.js';
 import type {
   AgentInvocation,
@@ -81,32 +82,19 @@ export const ADSDLC_ORCHESTRATOR_AGENT_ID = 'ad-sdlc-orchestrator-agent';
 /**
  * Environment flag enabling the worker-stage ExecutionAdapter pilot path.
  *
- * Issue #793: when set to `'1'`, `worker` stage agent invocations route through
- * the new {@link ExecutionAdapter} (default: {@link SdkExecutionAdapter}) with
- * the AD-07 hook pipeline. Any other value keeps the existing AgentBridge path
- * untouched, preserving regression-zero for the non-pilot scenario.
- *
- * Issue #795 will replace this raw env lookup with `FeatureFlagsResolver`.
+ * Issue #793 introduced this raw env-var read directly in the orchestrator.
+ * Issue #795 promotes the toggle to a first-class config surface via
+ * {@link FeatureFlagsResolver} (priority: env > CLI > YAML > default). The
+ * exported constant is preserved as an alias so existing tests and callers
+ * referencing `WORKER_PILOT_ENV_FLAG` continue to compile.
  */
-export const WORKER_PILOT_ENV_FLAG = 'AD_SDLC_USE_SDK_FOR_WORKER';
+export const WORKER_PILOT_ENV_FLAG = ENV_USE_SDK_FOR_WORKER;
 
 /**
  * Agent type that the pilot routes through the ExecutionAdapter. Kept narrow on
  * purpose — broadening to other stages is the P3 scope (issue #798).
  */
 const WORKER_PILOT_AGENT_TYPE = 'worker';
-
-/**
- * Determine whether the worker-pilot SDK adapter path is enabled.
- *
- * Reads {@link WORKER_PILOT_ENV_FLAG} from `process.env`. The check is
- * intentionally a function (not a module-level constant) so tests can flip the
- * variable between cases without restarting the module.
- * @returns `true` if the env flag is set to `'1'`, otherwise `false`.
- */
-function isWorkerPilotEnabled(): boolean {
-  return process.env[WORKER_PILOT_ENV_FLAG] === '1';
-}
 
 /**
  * AD-SDLC Orchestrator Agent
@@ -126,6 +114,12 @@ export class AdsdlcOrchestratorAgent implements IAgent {
   private _dispatcher: AgentDispatcher | null = null;
   private _bridgeRegistry: BridgeRegistry | null = null;
   private readonly checkpointManager: PipelineCheckpointManager | null;
+  /**
+   * Lazy-initialized feature-flags resolver (Issue #795). Built on first
+   * use from CLI overrides + YAML config; subsequent calls reuse the same
+   * instance so YAML / env lookups do not happen on every stage dispatch.
+   */
+  private _featureFlags: FeatureFlagsResolver | null = null;
 
   constructor(config: OrchestratorConfig = {}) {
     this.config = {
@@ -138,6 +132,29 @@ export class AdsdlcOrchestratorAgent implements IAgent {
     };
     const ckptConfig: CheckpointConfig = this.config.checkpoint;
     this.checkpointManager = ckptConfig.enabled ? new PipelineCheckpointManager(ckptConfig) : null;
+  }
+
+  /**
+   * Get or lazily build the feature-flags resolver.
+   *
+   * The resolver is constructed once per orchestrator instance using the
+   * CLI overrides supplied via `OrchestratorConfig.featureFlagsCli` and
+   * the optional `feature-flags.yaml` file under
+   * `featureFlagsBaseDir/.ad-sdlc/config/`. Tests override this method
+   * (or pass an explicit `featureFlagsCli`) to drive deterministic
+   * behaviour without touching the live environment.
+   *
+   * @returns The cached feature-flags resolver.
+   */
+  protected getFeatureFlags(): FeatureFlagsResolver {
+    if (this._featureFlags === null) {
+      const baseDir = this.config.featureFlagsBaseDir;
+      this._featureFlags = FeatureFlagsResolver.fromSources({
+        cli: this.config.featureFlagsCli,
+        ...(baseDir !== '' && { baseDir }),
+      });
+    }
+    return this._featureFlags;
   }
 
   /**
@@ -876,12 +893,14 @@ export class AdsdlcOrchestratorAgent implements IAgent {
    * "AgentBridge path") which resolves the agentType to a real agent
    * instance and calls the appropriate adapter.
    *
-   * Worker-pilot branch (issue #793): when {@link WORKER_PILOT_ENV_FLAG}
-   * is set to `'1'` AND the stage is the `worker` agent type, the call
-   * is rerouted through {@link executeViaAdapter} which drives the
-   * {@link ExecutionAdapter} (SDK path) with the AD-07 hook pipeline.
-   * For every other (stage, flag) combination behaviour is identical to
-   * before — the AgentBridge path is preserved verbatim.
+   * Worker-pilot branch (issue #793, formalized in #795): when the
+   * {@link FeatureFlagsResolver} reports `useSdkForWorker = true` AND
+   * the stage is the `worker` agent type, the call is rerouted through
+   * {@link executeViaAdapter} which drives the {@link ExecutionAdapter}
+   * (SDK path) with the AD-07 hook pipeline. The resolver consults
+   * env > CLI > YAML > default, so the env-only behaviour from #793
+   * remains supported and tests that set
+   * `process.env.AD_SDLC_USE_SDK_FOR_WORKER` keep working unchanged.
    *
    * Override this method in tests to bypass real agent execution.
    *
@@ -893,7 +912,7 @@ export class AdsdlcOrchestratorAgent implements IAgent {
     stage: PipelineStageDefinition,
     session: OrchestratorSession
   ): Promise<string> {
-    if (stage.agentType === WORKER_PILOT_AGENT_TYPE && isWorkerPilotEnabled()) {
+    if (stage.agentType === WORKER_PILOT_AGENT_TYPE && this.getFeatureFlags().useSdkForWorker()) {
       return this.executeViaAdapter(stage, session);
     }
     return this.executeViaBridge(stage, session);

--- a/src/ad-sdlc-orchestrator/types.ts
+++ b/src/ad-sdlc-orchestrator/types.ts
@@ -260,6 +260,18 @@ export interface StageTimeoutConfig {
 }
 
 /**
+ * CLI-supplied feature flag overrides (Issue #795).
+ *
+ * Mirrors the `CliFeatureFlags` shape from `src/config/featureFlags.ts`
+ * but kept as a local interface so the orchestrator does not have to
+ * import the resolver module just for the type.
+ */
+export interface OrchestratorFeatureFlagsCli {
+  /** CLI override for `--use-sdk-for-worker` (`undefined` = not provided). */
+  readonly useSdkForWorker?: boolean;
+}
+
+/**
  * Orchestrator configuration
  */
 export interface OrchestratorConfig {
@@ -281,6 +293,17 @@ export interface OrchestratorConfig {
   readonly checkpoint?: CheckpointConfig;
   /** Enable local mode by default (no GitHub dependency) */
   readonly localMode?: boolean;
+  /**
+   * CLI-supplied feature flag values forwarded to FeatureFlagsResolver.
+   * Issue #795: priority is env > CLI > YAML > default.
+   */
+  readonly featureFlagsCli?: OrchestratorFeatureFlagsCli;
+  /**
+   * Base directory used by FeatureFlagsResolver to locate
+   * `.ad-sdlc/config/feature-flags.yaml`. Defaults to the detected
+   * project root or `process.cwd()`.
+   */
+  readonly featureFlagsBaseDir?: string;
 }
 
 /**
@@ -312,6 +335,8 @@ export const DEFAULT_ORCHESTRATOR_CONFIG: Required<OrchestratorConfig> = {
     maxCheckpoints: 5,
   },
   localMode: false,
+  featureFlagsCli: {},
+  featureFlagsBaseDir: '',
 };
 
 /**

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1035,8 +1035,17 @@ program
     'Approval mode for pipeline stages: auto | manual | critical',
     'auto'
   )
+  .option(
+    '--use-sdk-for-worker',
+    'Route the worker stage through the SDK ExecutionAdapter (feature flag, default: off). Equivalent to AD_SDLC_USE_SDK_FOR_WORKER=1.'
+  )
   .action(async (requirements: string, cmdOptions: Record<string, unknown>) => {
     const modeInput = typeof cmdOptions['mode'] === 'string' ? cmdOptions['mode'] : 'greenfield';
+    // Issue #795: surface --use-sdk-for-worker as a tri-state. `undefined`
+    // means the user did not pass the flag, so the resolver falls through
+    // to YAML / default. `true` means the flag was supplied (boolean opt
+    // with no `--no-` form, so commander only sets it when present).
+    const useSdkForWorkerCli = cmdOptions['useSdkForWorker'] === true ? true : undefined;
     const stopAfter =
       typeof cmdOptions['stopAfter'] === 'string' ? cmdOptions['stopAfter'] : undefined;
     const projectDir =
@@ -1186,7 +1195,11 @@ program
     }
     output.blank();
 
-    const agent = getAdsdlcOrchestratorAgent({ approvalMode });
+    const agent = getAdsdlcOrchestratorAgent({
+      approvalMode,
+      featureFlagsCli: { useSdkForWorker: useSdkForWorkerCli },
+      featureFlagsBaseDir: projectDir,
+    });
 
     try {
       // Build pipeline request

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1197,7 +1197,8 @@ program
 
     const agent = getAdsdlcOrchestratorAgent({
       approvalMode,
-      featureFlagsCli: { useSdkForWorker: useSdkForWorkerCli },
+      featureFlagsCli:
+        useSdkForWorkerCli === undefined ? {} : { useSdkForWorker: useSdkForWorkerCli },
       featureFlagsBaseDir: projectDir,
     });
 

--- a/src/config/featureFlags.ts
+++ b/src/config/featureFlags.ts
@@ -1,0 +1,296 @@
+/**
+ * Feature flags resolver
+ *
+ * Issue #795: Promote the AD-09 worker-pilot environment flag from a raw
+ * `process.env` lookup to a first-class configuration surface.
+ *
+ * The resolver consults three input paths and picks the first defined value
+ * in the following priority order:
+ *
+ *   1. Environment variable (e.g. `AD_SDLC_USE_SDK_FOR_WORKER`)
+ *   2. CLI option (e.g. `--use-sdk-for-worker`)
+ *   3. YAML config file (`.ad-sdlc/config/feature-flags.yaml`)
+ *   4. Built-in default (always `false` for the worker pilot in this PR)
+ *
+ * The YAML file is strictly opt-in. AD-SDLC never auto-creates it; absence is
+ * treated as "not configured" and falls through to lower-priority sources.
+ *
+ * @module config/featureFlags
+ */
+
+import { existsSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import yaml from 'js-yaml';
+import { z } from 'zod';
+
+import { tryGetProjectRoot } from '../utils/index.js';
+import { DEFAULT_PATHS } from './paths.js';
+
+// ============================================================
+// Public constants
+// ============================================================
+
+/**
+ * Environment variable controlling the worker-pilot SDK adapter path.
+ *
+ * Mirrors `WORKER_PILOT_ENV_FLAG` in the orchestrator. Kept here as the
+ * canonical name so the resolver and the orchestrator agree.
+ */
+export const ENV_USE_SDK_FOR_WORKER = 'AD_SDLC_USE_SDK_FOR_WORKER';
+
+/**
+ * Default file name (relative to the config directory) for the feature
+ * flags YAML.
+ */
+export const FEATURE_FLAGS_FILE_NAME = 'feature-flags.yaml';
+
+/**
+ * Built-in defaults used when no source provides a value.
+ *
+ * The worker-pilot flag is intentionally `false` in this PR — flipping the
+ * default is P3 territory (see issue #798), not part of #795.
+ */
+export const DEFAULT_FEATURE_FLAGS = Object.freeze({
+  useSdkForWorker: false,
+} as const);
+
+// ============================================================
+// Schemas (Zod)
+// ============================================================
+
+/**
+ * Zod schema for the `flags` block of `feature-flags.yaml`.
+ *
+ * The schema is `strict()` so unknown keys produce a readable validation
+ * error rather than being silently ignored. Every recognized flag is
+ * optional — missing flags fall through to lower-priority sources.
+ */
+export const FeatureFlagsBlockSchema = z
+  .object({
+    useSdkForWorker: z.boolean().optional(),
+  })
+  .strict();
+
+/**
+ * Zod schema for the full `feature-flags.yaml` document.
+ */
+export const FeatureFlagsFileSchema = z
+  .object({
+    version: z
+      .string()
+      .regex(/^\d+\.\d+\.\d+$/u, 'version must be semver (e.g. "1.0.0")')
+      .optional(),
+    flags: FeatureFlagsBlockSchema.optional(),
+  })
+  .strict();
+
+/** Parsed and validated feature-flags file. */
+export type FeatureFlagsFile = z.infer<typeof FeatureFlagsFileSchema>;
+
+/** Subset of flags the resolver currently understands. */
+export interface FeatureFlagsConfig {
+  readonly useSdkForWorker?: boolean;
+}
+
+// ============================================================
+// CLI input shape
+// ============================================================
+
+/**
+ * CLI-supplied feature flag values. Each property is optional; `undefined`
+ * means the user did not pass the flag, so the resolver should fall through.
+ */
+export interface CliFeatureFlags {
+  readonly useSdkForWorker?: boolean;
+}
+
+// ============================================================
+// Env parsing
+// ============================================================
+
+const TRUTHY_TOKENS = new Set(['1', 'true', 'yes', 'on']);
+const FALSY_TOKENS = new Set(['0', 'false', 'no', 'off', '']);
+
+/**
+ * Parse an environment-variable string into a tri-state boolean.
+ *
+ * @param value - Raw environment-variable value (or `undefined` when unset).
+ * @returns
+ *   - `true` for truthy tokens (`1`, `true`, `yes`, `on`; case-insensitive)
+ *   - `false` for falsy tokens (`0`, `false`, `no`, `off`, empty string)
+ *   - `undefined` when the variable is unset (caller falls through)
+ * @throws Error when the value is set but not recognized.
+ */
+export function parseBooleanEnv(value: string | undefined): boolean | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  const normalized = value.trim().toLowerCase();
+  if (TRUTHY_TOKENS.has(normalized)) {
+    return true;
+  }
+  if (FALSY_TOKENS.has(normalized)) {
+    return false;
+  }
+  throw new Error(
+    `Invalid boolean value "${value}". Use one of: 1, true, yes, on (truthy) / 0, false, no, off (falsy).`
+  );
+}
+
+// ============================================================
+// File loading
+// ============================================================
+
+/**
+ * Resolve the absolute path of `feature-flags.yaml`.
+ *
+ * @param baseDir - Optional project root override (defaults to the detected
+ *   project root or `process.cwd()`).
+ * @returns Absolute path to the feature-flags YAML file.
+ */
+export function getFeatureFlagsFilePath(baseDir?: string): string {
+  const root = baseDir ?? tryGetProjectRoot() ?? process.cwd();
+  return resolve(root, DEFAULT_PATHS.CONFIG_SUBDIR, FEATURE_FLAGS_FILE_NAME);
+}
+
+/**
+ * Load and validate `feature-flags.yaml`.
+ *
+ * @param filePath - Absolute path to the YAML file.
+ * @returns Parsed file contents, or `null` if the file does not exist.
+ * @throws Error with a readable message when the YAML is malformed or fails
+ *   schema validation.
+ */
+export function loadFeatureFlagsFile(filePath: string): FeatureFlagsFile | null {
+  if (!existsSync(filePath)) {
+    return null;
+  }
+  let raw: string;
+  try {
+    raw = readFileSync(filePath, 'utf8');
+  } catch (error) {
+    throw new Error(
+      `Failed to read feature-flags file "${filePath}": ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+      { cause: error }
+    );
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = yaml.load(raw);
+  } catch (error) {
+    throw new Error(
+      `Failed to parse YAML in "${filePath}": ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+      { cause: error }
+    );
+  }
+
+  if (parsed === undefined || parsed === null) {
+    // Empty file — treat as "no flags configured".
+    return {};
+  }
+
+  const result = FeatureFlagsFileSchema.safeParse(parsed);
+  if (!result.success) {
+    const issues = result.error.issues
+      .map((issue) => `  - ${issue.path.join('.')}: ${issue.message}`)
+      .join('\n');
+    throw new Error(`Invalid feature-flags file "${filePath}":\n${issues}`);
+  }
+  return result.data;
+}
+
+// ============================================================
+// Resolver
+// ============================================================
+
+/**
+ * Options accepted by the {@link FeatureFlagsResolver} constructor.
+ */
+export interface FeatureFlagsResolverOptions {
+  /** CLI-supplied flag values (highest priority after env). */
+  readonly cli?: CliFeatureFlags;
+  /**
+   * Override the YAML config block (skips file IO). When provided, the
+   * resolver uses this block instead of reading `feature-flags.yaml`.
+   */
+  readonly config?: FeatureFlagsConfig;
+  /** Base directory for resolving the YAML file path. */
+  readonly baseDir?: string;
+  /**
+   * Inject an environment object (defaults to `process.env`). Tests use
+   * this to drive the env layer without mutating the live environment.
+   */
+  readonly env?: NodeJS.ProcessEnv;
+}
+
+/**
+ * Resolves feature flag values from the priority chain
+ * `env > CLI > config > default`.
+ *
+ * The resolver is constructed once at orchestrator startup with the active
+ * CLI options and reused across stage invocations so YAML / env reads do
+ * not happen on every dispatch. See {@link FeatureFlagsResolver.useSdkForWorker}.
+ */
+export class FeatureFlagsResolver {
+  private readonly cli: CliFeatureFlags;
+  private readonly config: FeatureFlagsConfig;
+  private readonly env: NodeJS.ProcessEnv;
+
+  /**
+   * Build a resolver from explicit inputs.
+   *
+   * @param options - CLI/config/env overrides. Any source that is omitted
+   *   falls through to the next priority layer at lookup time.
+   */
+  constructor(options: FeatureFlagsResolverOptions = {}) {
+    this.cli = options.cli ?? {};
+    this.config = options.config ?? {};
+    this.env = options.env ?? process.env;
+  }
+
+  /**
+   * Build a resolver and load the YAML file (if present).
+   *
+   * @param options - Same as the constructor, but `config` is populated by
+   *   reading `feature-flags.yaml` from disk when not provided.
+   * @returns A ready-to-use resolver.
+   */
+  static fromSources(options: FeatureFlagsResolverOptions = {}): FeatureFlagsResolver {
+    let config = options.config;
+    if (config === undefined) {
+      const filePath = getFeatureFlagsFilePath(options.baseDir);
+      const fileContents = loadFeatureFlagsFile(filePath);
+      config = fileContents?.flags ?? {};
+    }
+    return new FeatureFlagsResolver({ ...options, config });
+  }
+
+  /**
+   * Resolve the worker-pilot flag.
+   *
+   * Priority: env (`AD_SDLC_USE_SDK_FOR_WORKER`) > CLI (`--use-sdk-for-worker`)
+   * > YAML (`flags.useSdkForWorker`) > default (`false`).
+   *
+   * @returns `true` when the worker stage should route through the SDK
+   *   ExecutionAdapter, otherwise `false`.
+   * @throws Error when the env variable is set to an unrecognized value.
+   */
+  useSdkForWorker(): boolean {
+    const envValue = parseBooleanEnv(this.env[ENV_USE_SDK_FOR_WORKER]);
+    if (envValue !== undefined) {
+      return envValue;
+    }
+    if (this.cli.useSdkForWorker !== undefined) {
+      return this.cli.useSdkForWorker;
+    }
+    if (this.config.useSdkForWorker !== undefined) {
+      return this.config.useSdkForWorker;
+    }
+    return DEFAULT_FEATURE_FLAGS.useSdkForWorker;
+  }
+}

--- a/src/config/featureFlags.ts
+++ b/src/config/featureFlags.ts
@@ -261,13 +261,17 @@ export class FeatureFlagsResolver {
    * @returns A ready-to-use resolver.
    */
   static fromSources(options: FeatureFlagsResolverOptions = {}): FeatureFlagsResolver {
-    let config = options.config;
-    if (config === undefined) {
-      const filePath = getFeatureFlagsFilePath(options.baseDir);
-      const fileContents = loadFeatureFlagsFile(filePath);
-      config = fileContents?.flags ?? {};
+    if (options.config !== undefined) {
+      return new FeatureFlagsResolver(options);
     }
-    return new FeatureFlagsResolver({ ...options, config });
+    const filePath = getFeatureFlagsFilePath(options.baseDir);
+    const fileContents = loadFeatureFlagsFile(filePath);
+    const flags = fileContents?.flags;
+    const resolved: FeatureFlagsConfig = {};
+    if (flags?.useSdkForWorker !== undefined) {
+      (resolved as { useSdkForWorker?: boolean }).useSdkForWorker = flags.useSdkForWorker;
+    }
+    return new FeatureFlagsResolver({ ...options, config: resolved });
   }
 
   /**

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -101,6 +101,25 @@ export type {
   ConfigManagerOptions,
 } from './ConfigManager.js';
 
+// Feature flags resolver (Issue #795)
+export {
+  FeatureFlagsResolver,
+  ENV_USE_SDK_FOR_WORKER,
+  FEATURE_FLAGS_FILE_NAME,
+  DEFAULT_FEATURE_FLAGS,
+  FeatureFlagsBlockSchema,
+  FeatureFlagsFileSchema,
+  parseBooleanEnv,
+  getFeatureFlagsFilePath,
+  loadFeatureFlagsFile,
+} from './featureFlags.js';
+export type {
+  FeatureFlagsFile,
+  FeatureFlagsConfig,
+  CliFeatureFlags,
+  FeatureFlagsResolverOptions,
+} from './featureFlags.js';
+
 // Paths
 export {
   getProjectPaths,

--- a/tests/ad-sdlc-orchestrator/featureFlags-integration.test.ts
+++ b/tests/ad-sdlc-orchestrator/featureFlags-integration.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Orchestrator + FeatureFlagsResolver integration tests (Issue #795).
+ *
+ * Verifies that the worker-pilot dispatch path is selected based on the
+ * resolver's priority chain (env > CLI > YAML > default), not on the raw
+ * env-var read that #793 introduced.
+ *
+ * The test subclass overrides `executeViaAdapter` and `executeViaBridge`
+ * to surface which path was chosen without running real agent code.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { AdsdlcOrchestratorAgent } from '../../src/ad-sdlc-orchestrator/AdsdlcOrchestratorAgent.js';
+import type {
+  OrchestratorConfig,
+  OrchestratorSession,
+  PipelineStageDefinition,
+} from '../../src/ad-sdlc-orchestrator/types.js';
+import { ENV_USE_SDK_FOR_WORKER } from '../../src/config/featureFlags.js';
+
+class RouteCapturingOrchestrator extends AdsdlcOrchestratorAgent {
+  public lastRoute: 'adapter' | 'bridge' | null = null;
+
+  constructor(config: OrchestratorConfig = {}) {
+    super(config);
+  }
+
+  async dispatchWorker(session: OrchestratorSession): Promise<string> {
+    const stage: PipelineStageDefinition = {
+      name: 'worker',
+      agentType: 'worker',
+      description: 'Worker stage',
+      parallel: false,
+      approvalRequired: false,
+      dependsOn: [],
+    };
+    return this.invokeAgent(stage, session);
+  }
+
+  protected override async executeViaAdapter(): Promise<string> {
+    this.lastRoute = 'adapter';
+    return '{"route":"adapter"}';
+  }
+
+  protected override async executeViaBridge(): Promise<string> {
+    this.lastRoute = 'bridge';
+    return '{"route":"bridge"}';
+  }
+}
+
+function createSession(projectDir: string): OrchestratorSession {
+  return {
+    sessionId: 'fflag-test-session',
+    projectDir,
+    userRequest: 'test',
+    mode: 'greenfield',
+    startedAt: new Date().toISOString(),
+    status: 'running',
+    stageResults: [],
+    scratchpadDir: join(projectDir, '.ad-sdlc', 'scratchpad'),
+  };
+}
+
+function preserveEnvFlag(): () => void {
+  const original = process.env[ENV_USE_SDK_FOR_WORKER];
+  return () => {
+    if (original === undefined) {
+      delete process.env[ENV_USE_SDK_FOR_WORKER];
+    } else {
+      process.env[ENV_USE_SDK_FOR_WORKER] = original;
+    }
+  };
+}
+
+describe('Orchestrator + FeatureFlagsResolver integration (#795)', () => {
+  let tmpRoot: string;
+  let restoreEnv: () => void;
+
+  beforeEach(() => {
+    tmpRoot = mkdtempSync(join(tmpdir(), 'orch-fflag-'));
+    mkdirSync(join(tmpRoot, '.ad-sdlc', 'config'), { recursive: true });
+    restoreEnv = preserveEnvFlag();
+    delete process.env[ENV_USE_SDK_FOR_WORKER];
+  });
+
+  afterEach(() => {
+    restoreEnv();
+    rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it('routes through bridge by default (env unset, no CLI, no YAML)', async () => {
+    const orch = new RouteCapturingOrchestrator({ featureFlagsBaseDir: tmpRoot });
+    await orch.dispatchWorker(createSession(tmpRoot));
+    expect(orch.lastRoute).toBe('bridge');
+  });
+
+  it('routes through adapter when env AD_SDLC_USE_SDK_FOR_WORKER=1 (regression-zero for #793)', async () => {
+    process.env[ENV_USE_SDK_FOR_WORKER] = '1';
+    const orch = new RouteCapturingOrchestrator({ featureFlagsBaseDir: tmpRoot });
+    await orch.dispatchWorker(createSession(tmpRoot));
+    expect(orch.lastRoute).toBe('adapter');
+  });
+
+  it('routes through adapter when CLI --use-sdk-for-worker is supplied (env unset)', async () => {
+    const orch = new RouteCapturingOrchestrator({
+      featureFlagsBaseDir: tmpRoot,
+      featureFlagsCli: { useSdkForWorker: true },
+    });
+    await orch.dispatchWorker(createSession(tmpRoot));
+    expect(orch.lastRoute).toBe('adapter');
+  });
+
+  it('env beats CLI: env=0 forces bridge even if CLI says true', async () => {
+    process.env[ENV_USE_SDK_FOR_WORKER] = '0';
+    const orch = new RouteCapturingOrchestrator({
+      featureFlagsBaseDir: tmpRoot,
+      featureFlagsCli: { useSdkForWorker: true },
+    });
+    await orch.dispatchWorker(createSession(tmpRoot));
+    expect(orch.lastRoute).toBe('bridge');
+  });
+
+  it('routes through adapter when YAML enables it (env and CLI absent)', async () => {
+    writeFileSync(
+      join(tmpRoot, '.ad-sdlc', 'config', 'feature-flags.yaml'),
+      'flags:\n  useSdkForWorker: true\n',
+      'utf8'
+    );
+    const orch = new RouteCapturingOrchestrator({ featureFlagsBaseDir: tmpRoot });
+    await orch.dispatchWorker(createSession(tmpRoot));
+    expect(orch.lastRoute).toBe('adapter');
+  });
+
+  it('CLI beats YAML when env is unset', async () => {
+    writeFileSync(
+      join(tmpRoot, '.ad-sdlc', 'config', 'feature-flags.yaml'),
+      'flags:\n  useSdkForWorker: true\n',
+      'utf8'
+    );
+    const orch = new RouteCapturingOrchestrator({
+      featureFlagsBaseDir: tmpRoot,
+      featureFlagsCli: { useSdkForWorker: false },
+    });
+    await orch.dispatchWorker(createSession(tmpRoot));
+    expect(orch.lastRoute).toBe('bridge');
+  });
+
+  it('non-worker stages always go through bridge regardless of flag', async () => {
+    process.env[ENV_USE_SDK_FOR_WORKER] = '1';
+    const orch = new RouteCapturingOrchestrator({ featureFlagsBaseDir: tmpRoot });
+    const stage: PipelineStageDefinition = {
+      name: 'collection',
+      agentType: 'collector',
+      description: 'Collector stage',
+      parallel: false,
+      approvalRequired: false,
+      dependsOn: [],
+    };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await (orch as any).invokeAgent(stage, createSession(tmpRoot));
+    expect(orch.lastRoute).toBe('bridge');
+  });
+});

--- a/tests/config/feature-flags.test.ts
+++ b/tests/config/feature-flags.test.ts
@@ -1,0 +1,229 @@
+/**
+ * FeatureFlagsResolver unit tests (Issue #795).
+ *
+ * Verifies the env > CLI > config > default priority chain for the
+ * worker-pilot flag, env tokenization, YAML opt-in semantics, and
+ * malformed-file diagnostics.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  FeatureFlagsResolver,
+  ENV_USE_SDK_FOR_WORKER,
+  FEATURE_FLAGS_FILE_NAME,
+  DEFAULT_FEATURE_FLAGS,
+  parseBooleanEnv,
+  loadFeatureFlagsFile,
+  getFeatureFlagsFilePath,
+} from '../../src/config/featureFlags.js';
+
+describe('FeatureFlagsResolver', () => {
+  describe('parseBooleanEnv', () => {
+    it('returns undefined for unset env', () => {
+      expect(parseBooleanEnv(undefined)).toBeUndefined();
+    });
+
+    it.each([
+      ['1', true],
+      ['true', true],
+      ['TRUE', true],
+      ['yes', true],
+      ['on', true],
+      ['  True  ', true],
+    ])('parses %s as truthy', (input, expected) => {
+      expect(parseBooleanEnv(input)).toBe(expected);
+    });
+
+    it.each([
+      ['0', false],
+      ['false', false],
+      ['FALSE', false],
+      ['no', false],
+      ['off', false],
+      ['', false],
+    ])('parses %s as falsy', (input, expected) => {
+      expect(parseBooleanEnv(input)).toBe(expected);
+    });
+
+    it('throws a readable error for unrecognized values', () => {
+      expect(() => parseBooleanEnv('maybe')).toThrow(/Invalid boolean value "maybe"/);
+    });
+  });
+
+  describe('priority matrix (useSdkForWorker)', () => {
+    const emptyEnv: NodeJS.ProcessEnv = {};
+
+    it('returns the default false when no source provides a value', () => {
+      const resolver = new FeatureFlagsResolver({ env: emptyEnv });
+      expect(resolver.useSdkForWorker()).toBe(DEFAULT_FEATURE_FLAGS.useSdkForWorker);
+      expect(resolver.useSdkForWorker()).toBe(false);
+    });
+
+    it('returns env value (true) when env is set, ignoring lower layers', () => {
+      const resolver = new FeatureFlagsResolver({
+        env: { [ENV_USE_SDK_FOR_WORKER]: '1' },
+        cli: { useSdkForWorker: false },
+        config: { useSdkForWorker: false },
+      });
+      expect(resolver.useSdkForWorker()).toBe(true);
+    });
+
+    it('returns env value (false) when env is set to falsy, ignoring lower layers', () => {
+      const resolver = new FeatureFlagsResolver({
+        env: { [ENV_USE_SDK_FOR_WORKER]: '0' },
+        cli: { useSdkForWorker: true },
+        config: { useSdkForWorker: true },
+      });
+      expect(resolver.useSdkForWorker()).toBe(false);
+    });
+
+    it('falls through to CLI when env is unset', () => {
+      const resolver = new FeatureFlagsResolver({
+        env: emptyEnv,
+        cli: { useSdkForWorker: true },
+        config: { useSdkForWorker: false },
+      });
+      expect(resolver.useSdkForWorker()).toBe(true);
+    });
+
+    it('CLI false beats config true when env is unset', () => {
+      const resolver = new FeatureFlagsResolver({
+        env: emptyEnv,
+        cli: { useSdkForWorker: false },
+        config: { useSdkForWorker: true },
+      });
+      expect(resolver.useSdkForWorker()).toBe(false);
+    });
+
+    it('falls through to YAML config when env and CLI are absent', () => {
+      const resolver = new FeatureFlagsResolver({
+        env: emptyEnv,
+        cli: {},
+        config: { useSdkForWorker: true },
+      });
+      expect(resolver.useSdkForWorker()).toBe(true);
+    });
+
+    it('falls through to default when only YAML is absent (CLI present)', () => {
+      const resolver = new FeatureFlagsResolver({
+        env: emptyEnv,
+        cli: {},
+        config: {},
+      });
+      expect(resolver.useSdkForWorker()).toBe(false);
+    });
+
+    it('propagates env parsing errors instead of silently coercing', () => {
+      const resolver = new FeatureFlagsResolver({
+        env: { [ENV_USE_SDK_FOR_WORKER]: 'maybe' },
+      });
+      expect(() => resolver.useSdkForWorker()).toThrow(/Invalid boolean value "maybe"/);
+    });
+  });
+
+  describe('YAML opt-in behaviour', () => {
+    let tmpRoot: string;
+    let configDir: string;
+    let yamlPath: string;
+
+    beforeEach(() => {
+      tmpRoot = mkdtempSync(join(tmpdir(), 'ad-sdlc-flags-'));
+      configDir = join(tmpRoot, '.ad-sdlc', 'config');
+      mkdirSync(configDir, { recursive: true });
+      yamlPath = join(configDir, FEATURE_FLAGS_FILE_NAME);
+    });
+
+    afterEach(() => {
+      rmSync(tmpRoot, { recursive: true, force: true });
+    });
+
+    it('does NOT auto-create the YAML file', () => {
+      // Build the resolver via fromSources without writing the file.
+      const resolver = FeatureFlagsResolver.fromSources({
+        baseDir: tmpRoot,
+        env: {},
+      });
+      expect(resolver.useSdkForWorker()).toBe(false);
+      expect(existsSync(yamlPath)).toBe(false);
+    });
+
+    it('treats missing file as "not configured" (returns null)', () => {
+      const result = loadFeatureFlagsFile(yamlPath);
+      expect(result).toBeNull();
+    });
+
+    it('reads useSdkForWorker:true from YAML when env/CLI are absent', () => {
+      writeFileSync(yamlPath, 'flags:\n  useSdkForWorker: true\n', 'utf8');
+      const resolver = FeatureFlagsResolver.fromSources({
+        baseDir: tmpRoot,
+        env: {},
+      });
+      expect(resolver.useSdkForWorker()).toBe(true);
+    });
+
+    it('reads useSdkForWorker:false from YAML and overrides nothing higher', () => {
+      writeFileSync(yamlPath, 'flags:\n  useSdkForWorker: false\n', 'utf8');
+      const resolver = FeatureFlagsResolver.fromSources({
+        baseDir: tmpRoot,
+        env: {},
+      });
+      expect(resolver.useSdkForWorker()).toBe(false);
+    });
+
+    it('YAML is overridden by env (env wins)', () => {
+      writeFileSync(yamlPath, 'flags:\n  useSdkForWorker: false\n', 'utf8');
+      const resolver = FeatureFlagsResolver.fromSources({
+        baseDir: tmpRoot,
+        env: { [ENV_USE_SDK_FOR_WORKER]: 'yes' },
+      });
+      expect(resolver.useSdkForWorker()).toBe(true);
+    });
+
+    it('YAML is overridden by CLI when env is absent (CLI wins)', () => {
+      writeFileSync(yamlPath, 'flags:\n  useSdkForWorker: false\n', 'utf8');
+      const resolver = FeatureFlagsResolver.fromSources({
+        baseDir: tmpRoot,
+        env: {},
+        cli: { useSdkForWorker: true },
+      });
+      expect(resolver.useSdkForWorker()).toBe(true);
+    });
+
+    it('treats an empty YAML document as unset', () => {
+      writeFileSync(yamlPath, '', 'utf8');
+      const resolver = FeatureFlagsResolver.fromSources({
+        baseDir: tmpRoot,
+        env: {},
+      });
+      expect(resolver.useSdkForWorker()).toBe(false);
+    });
+
+    it('rejects malformed YAML with a readable error', () => {
+      writeFileSync(yamlPath, 'flags:\n  useSdkForWorker: [not a bool\n', 'utf8');
+      expect(() => loadFeatureFlagsFile(yamlPath)).toThrow(/Failed to parse YAML/);
+    });
+
+    it('rejects unknown keys in strict mode', () => {
+      writeFileSync(yamlPath, 'flags:\n  someUnknownFlag: true\n', 'utf8');
+      expect(() => loadFeatureFlagsFile(yamlPath)).toThrow(/Invalid feature-flags file/);
+    });
+
+    it('rejects wrong types with a readable error', () => {
+      writeFileSync(yamlPath, 'flags:\n  useSdkForWorker: "yes-please"\n', 'utf8');
+      expect(() => loadFeatureFlagsFile(yamlPath)).toThrow(/Invalid feature-flags file/);
+    });
+  });
+
+  describe('getFeatureFlagsFilePath', () => {
+    it('places the YAML under .ad-sdlc/config/feature-flags.yaml relative to baseDir', () => {
+      const baseDir = '/tmp/some-project';
+      const path = getFeatureFlagsFilePath(baseDir);
+      expect(path.endsWith('.ad-sdlc/config/feature-flags.yaml')).toBe(true);
+      expect(path.startsWith(baseDir)).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## What

Promote the `AD_SDLC_USE_SDK_FOR_WORKER` worker-pilot feature flag from a raw `process.env` lookup to a first-class configuration surface. Adds a `FeatureFlagsResolver` that consults env, CLI, and YAML config in priority order and falls back to a built-in default of `false`.

## Why

Closes #795.

The env-only flag introduced in #793 was an interim toggle. Issue #795 formalizes the toggle so users and CI can opt in via either `--use-sdk-for-worker` or a committed `feature-flags.yaml`, without losing the ability to flip the bit ad-hoc with the env var. This also simplifies the rollback story (Migration Guide §6) and makes the future P3 default flip a single-line change rather than a hunt across env-var consumers.

## How

### Resolver

- **`src/config/featureFlags.ts`** — `FeatureFlagsResolver` class with `useSdkForWorker(): boolean`. Priority: `env > CLI > YAML > default(false)`.
  - env tokens: `1/true/yes/on` truthy, `0/false/no/off/empty` falsy, case-insensitive; unknown values throw a readable error rather than silently coercing
  - CLI: tri-state — `undefined` falls through to YAML/default
  - YAML: opt-in only; missing or empty file is treated as "not configured"; malformed YAML and unknown keys both produce readable diagnostics

### Schemas

- **`schemas/feature-flags.schema.json`** — JSON Schema (draft-07) for tooling parity with the existing `agents.schema.json` and `workflow.schema.json`
- Zod schema `FeatureFlagsFileSchema` in `featureFlags.ts` — strict mode rejects unknown keys

### CLI

- **`src/cli.ts`** — `ad-sdlc run --use-sdk-for-worker` boolean option threaded into `OrchestratorConfig.featureFlagsCli`

### Orchestrator wiring

- **`src/ad-sdlc-orchestrator/AdsdlcOrchestratorAgent.ts`** — `invokeAgent()` now consults `this.getFeatureFlags().useSdkForWorker()` instead of reading `process.env` directly. The resolver is built lazily on first use and cached, so per-stage dispatch cost is one method call. The `WORKER_PILOT_ENV_FLAG` export is preserved as an alias for callers and tests that still reference the constant.

### Docs

- **`docs/config.md`** — new "Feature Flags" section with the AC-mandated table (name, type, default, env, CLI flag, YAML path, description), token rules, YAML example, and programmatic-use snippet.

## Acceptance Criteria

| AC | Evidence |
|----|----------|
| Three input paths (env, CLI, YAML) all functional | `tests/config/feature-flags.test.ts` priority-matrix block (env-on/off/unset x CLI-on/off x YAML-on/off) |
| Priority `env > CLI > config` validated | Same file: "env beats CLI", "env beats YAML", "CLI beats YAML when env absent" |
| Default-off preserves legacy AgentBridge path | `tests/ad-sdlc-orchestrator/featureFlags-integration.test.ts` "routes through bridge by default" |
| Flag-on routes worker through ExecutionAdapter | Same file: "routes through adapter when env=1", "...when CLI true", "...when YAML true" |
| `feature-flags.yaml` is opt-in (never auto-created) | `feature-flags.test.ts` "does NOT auto-create the YAML file" |
| CLI help exposes the option | `--use-sdk-for-worker` registered on the `run` command in `src/cli.ts` |
| YAML validated by Zod | `feature-flags.test.ts` "rejects unknown keys in strict mode", "rejects wrong types", "rejects malformed YAML" |

## Test Plan

- `npm test` → full suite. The two pre-existing failures in `tests/doc-audit/audit-docs.cli.test.ts` are unrelated to this PR (verified by re-running on `develop` HEAD).
- `npx vitest run tests/config/feature-flags.test.ts` → 33/33 pass
- `npx vitest run tests/ad-sdlc-orchestrator/featureFlags-integration.test.ts` → 7/7 pass
- `npm run test:integration -- worker-pilot` → 20 pass, 5 skipped (skips need live `ANTHROPIC_API_KEY`; expected). Verifies regression-zero for #794's equivalence matrix after the resolver swap.
- `npm run lint` → clean for new files; pre-existing errors in `MockExecutionAdapter.ts` (unrelated).

## Where

- New: `src/config/featureFlags.ts`, `schemas/feature-flags.schema.json`, `tests/config/feature-flags.test.ts`, `tests/ad-sdlc-orchestrator/featureFlags-integration.test.ts`
- Modified: `src/cli.ts`, `src/config/index.ts`, `src/ad-sdlc-orchestrator/AdsdlcOrchestratorAgent.ts`, `src/ad-sdlc-orchestrator/types.ts`, `docs/config.md`

## Notes

- **Default remains `false`.** This PR formalizes the toggle but does NOT flip the default. Default flip is P3 territory under #798.
- `WORKER_PILOT_ENV_FLAG` constant is retained as an alias for backward compatibility with #794's integration suite and any other tests that import it directly.
- Env input is highest priority by design — tests that set `process.env.AD_SDLC_USE_SDK_FOR_WORKER` continue to work unchanged, preserving the AD-09 rollback path.
