### PR TITLE
fix(execution): apply prettier format after ESLint hotfix (CI hot-fix)

### DIFF
--- a/src/execution/MockExecutionAdapter.ts
+++ b/src/execution/MockExecutionAdapter.ts
@@ -17,11 +17,7 @@
  * @packageDocumentation
  */
 
-import type {
-  ExecutionAdapter,
-  StageExecutionRequest,
-  StageExecutionResult,
-} from './types.js';
+import type { ExecutionAdapter, StageExecutionRequest, StageExecutionResult } from './types.js';
 
 /**
  * Predicate-driven handler. Return null to defer to the next handler.

--- a/src/execution/SdkExecutionAdapter.ts
+++ b/src/execution/SdkExecutionAdapter.ts
@@ -105,11 +105,9 @@ export class SdkExecutionAdapter implements ExecutionAdapter {
 
   async execute(req: StageExecutionRequest): Promise<StageExecutionResult> {
     if (this.disposed) {
-      throw new AppError(
-        'EXEC-002',
-        'SdkExecutionAdapter: execute called after dispose',
-        { severity: ErrorSeverity.HIGH }
-      );
+      throw new AppError('EXEC-002', 'SdkExecutionAdapter: execute called after dispose', {
+        severity: ErrorSeverity.HIGH,
+      });
     }
     if (req.signal?.aborted === true) {
       return abortedResult(req.resume);
@@ -194,8 +192,7 @@ export function renderPrompt(req: StageExecutionRequest): string {
 }
 
 function mapUsage(usage: NonNullable<SdkMessage['usage']>): TokenUsage {
-  const cache =
-    (usage.cache_read_input_tokens ?? 0) + (usage.cache_creation_input_tokens ?? 0);
+  const cache = (usage.cache_read_input_tokens ?? 0) + (usage.cache_creation_input_tokens ?? 0);
   return {
     input: usage.input_tokens ?? 0,
     output: usage.output_tokens ?? 0,


### PR DESCRIPTION
## What

PR #816(ESLint strict 룰 fix) 머지 후 develop CI `format:check`가 두 파일에서 prettier 위반을 보고했습니다.

- `src/execution/MockExecutionAdapter.ts`
- `src/execution/SdkExecutionAdapter.ts`

## Why

#816에서 추가한 `// eslint-disable-next-line` 주석과 `=== true` 명시 비교 등이 prettier의 line wrapping 결정을 바꿨습니다. eslint와 prettier 둘 다 strict한 환경에서 흔한 패턴으로, prettier --write로 일관 형식 회복.

## How

```bash
npx prettier --write src/execution/MockExecutionAdapter.ts src/execution/SdkExecutionAdapter.ts
npx prettier --check src/execution/MockExecutionAdapter.ts src/execution/SdkExecutionAdapter.ts  # exit=0
```

eslint-disable 주석이 여전히 `async dispose()` 위에 위치함을 검증.

의미 변화 0.

## Linked

- Resolves: develop CI `format:check` failure on `ae9f7f4f` (run 25525553077)
- Follow-up of: #816 (which followed up #810 / AD-06)
- Unblocks: AD-07, AD-09 진행