### PR TITLE
feat(execution): forward HookPipeline to SDK options.hooks (AD-07 wiring)

### DIFF
--- a/src/execution/SdkExecutionAdapter.ts
+++ b/src/execution/SdkExecutionAdapter.ts
@@ -23,6 +23,7 @@
 
 import { AppError } from '../errors/AppError.js';
 import { ErrorSeverity } from '../errors/types.js';
+import type { HookPipeline } from './hooks.js';
 import type {
   ArtifactRef,
   ExecutionAdapter,
@@ -45,6 +46,7 @@ export interface SdkQueryOptions {
     maxTurns?: number;
     resume?: string;
     signal?: AbortSignal;
+    hooks?: HookPipeline;
   };
 }
 
@@ -92,15 +94,23 @@ const defaultLoader: SdkLoader = async () => {
 export interface SdkExecutionAdapterOptions {
   /** Override the SDK loader for tests / alternative endpoints. */
   readonly loader?: SdkLoader;
+  /**
+   * Optional hook pipeline forwarded to the SDK as `options.hooks`. When
+   * omitted, the adapter does not set the `hooks` key on the SDK options at
+   * all (so the SDK sees no hooks key, not `hooks: undefined`).
+   */
+  readonly hooks?: HookPipeline;
 }
 
 export class SdkExecutionAdapter implements ExecutionAdapter {
   private readonly loader: SdkLoader;
+  private readonly hooks: HookPipeline | undefined;
   private sdkPromise: Promise<SdkLike> | null = null;
   private disposed = false;
 
   constructor(options: SdkExecutionAdapterOptions = {}) {
     this.loader = options.loader ?? defaultLoader;
+    this.hooks = options.hooks;
   }
 
   async execute(req: StageExecutionRequest): Promise<StageExecutionResult> {
@@ -121,6 +131,7 @@ export class SdkExecutionAdapter implements ExecutionAdapter {
       maxTurns: req.maxTurns,
       resume: req.resume,
       signal: req.signal,
+      ...(this.hooks !== undefined && { hooks: this.hooks }),
     };
 
     let sessionId = req.resume ?? 'unknown';


### PR DESCRIPTION
## What

`SdkExecutionAdapter`에 `hooks: HookPipeline` 옵션을 추가하고 SDK `query()` 호출 시 `options.hooks`로 전달합니다.

| 변경 | 위치 |
|---|---|
| `import type { HookPipeline } from './hooks.js'` | line 26 |
| `SdkQueryOptions['options']`에 `hooks?: HookPipeline` 추가 | line 48 |
| `SdkExecutionAdapterOptions`에 `hooks?: HookPipeline` 추가 | line 96 |
| 인스턴스 필드 `private readonly hooks` | line 100 |
| 생성자에서 `this.hooks = options.hooks` 저장 | line 105 |
| `sdkOptions`에 conditional spread `...(this.hooks !== undefined && { hooks: this.hooks })` | line 124 |

## Why

PR #816/#817 머지 후 develop CI Test 잡 단 1건이 실패: `tests/execution/hooks.test.ts:199` —

```typescript
const adapter = new SdkExecutionAdapter({ loader: async () => sdk, hooks: pipeline });
await adapter.execute(baseRequest);
expect(captured.value?.options?.hooks).toBe(pipeline);  // ← 실패
```

평행 세션이 `src/execution/hooks.ts` + `tests/execution/hooks.test.ts`를 도입했지만 `SdkExecutionAdapter`의 옵션 wiring이 빠져 있었습니다. 본 PR이 그 갭을 메웁니다.

**테스트 결과 (직전 CI run 25527813437)**: 6759 passed | **1 failed** | 76 skipped — 본 단일 어설션이 마지막 차단 요인.

## How

### 두 어설션 동시 만족

```typescript
// hooks 설정 시
expect(captured.value?.options?.hooks).toBe(pipeline);  // reference equality
expect(captured.value?.options?.hooks?.PostToolUse).toHaveLength(1);

// hooks 미설정 시 (다른 테스트 케이스)
expect(captured.value?.options).not.toHaveProperty('hooks');
```

`...(this.hooks !== undefined && { hooks: this.hooks })`:
- hooks 설정 시 → `{ hooks: pipeline }` 스프레드 → `options.hooks === pipeline` ✓
- hooks 미설정 시 → `false` 스프레드 (no-op) → `options`에 `hooks` 키 없음 ✓

### 검증

- 로컬 `npx prettier --check src/execution/SdkExecutionAdapter.ts` exit=0
- 다른 테스트 회귀 없음 — 변경은 새 옵션 추가뿐, 기존 경로 영향 0

## Linked

- Closes #791 (AD-07 — hooks pipeline wiring)
- Resolves: develop CI Test failure on commit `915be10b` (run 25527813437)
- Follow-up of: #810 (AD-06), #816/#817 (lint/format hot-fixes), parallel #813-815 (worker pilot)

## Out of Scope

- Hook 빌더 자체 (`buildHookPipeline`) — 이미 develop에 존재 (평행 세션 기여)
- PreToolUse / Stop matchers — TODO stubs in develop's hooks.ts (P3 이후)
- 실제 stage가 hooks를 빌드해 어댑터에 주입하도록 wire (worker pilot 통합)
