### PR TITLE
fix(test): normalize Windows backslashes in feature-flags path assertion (CI hot-fix)

### DIFF
--- a/tests/config/feature-flags.test.ts
+++ b/tests/config/feature-flags.test.ts
@@ -221,7 +221,8 @@ describe('FeatureFlagsResolver', () => {
   describe('getFeatureFlagsFilePath', () => {
     it('places the YAML under .ad-sdlc/config/feature-flags.yaml relative to baseDir', () => {
       const baseDir = '/tmp/some-project';
-      const path = getFeatureFlagsFilePath(baseDir);
+      // Normalize Windows backslashes so the assertions stay portable across OSes.
+      const path = getFeatureFlagsFilePath(baseDir).replace(/\\/g, '/');
       expect(path.endsWith('.ad-sdlc/config/feature-flags.yaml')).toBe(true);
       expect(path.startsWith(baseDir)).toBe(true);
     });


### PR DESCRIPTION
## What

`tests/config/feature-flags.test.ts:225`의 path-separator 의존 어설션을 OS-agnostic하게 만듭니다.

```diff
   it('places the YAML under .ad-sdlc/config/feature-flags.yaml relative to baseDir', () => {
     const baseDir = '/tmp/some-project';
-    const path = getFeatureFlagsFilePath(baseDir);
+    // Normalize Windows backslashes so the assertions stay portable across OSes.
+    const path = getFeatureFlagsFilePath(baseDir).replace(/\\/g, '/');
     expect(path.endsWith('.ad-sdlc/config/feature-flags.yaml')).toBe(true);
     expect(path.startsWith(baseDir)).toBe(true);
   });
```

## Why

PR #818 (AD-07 hooks wiring) 머지 후 develop CI:
- ✅ Lint, CodeQL, Security
- ✅ Test (ubuntu-latest) — 6759 passed (AD-07 포함 모두 통과)
- ❌ Test (windows-latest) — **1 failed**: `expected false to be true`

Windows의 `path.join`은 backslash로 정규화하므로 `\tmp\some-project\.ad-sdlc\config\feature-flags.yaml`. 어설션의 forward-slash suffix와 매칭 실패.

**원인 PR**: #815 (FeatureFlagsResolver, AD-11) — Linux 러너만 도는 PR-level CI는 없으므로 머지 시점에 노출 안 됨. develop의 push CI(matrix Windows 포함)가 첫 노출.

## How

테스트 코드만 수정. 구현체(`getFeatureFlagsFilePath`)는 그대로 — 실 파일 I/O는 OS-native separator 사용이 정상이므로 구현 변경은 부적절. 단일 라인 정규화로 양 어설션 portability 회복.

### Acceptance Criteria

- [x] 단일 라인 변경 + 설명 주석
- [x] 양 어설션이 ubuntu, macos, windows에서 동일 결과
- [x] 다른 테스트 회귀 없음
- [ ] CI Test (windows-latest) 그린 — 머지 후 자동 검증

## Linked

- Resolves: develop CI Test (windows-latest) failure on `c55f9076` (run 25529173244)
- Follow-up of: #815 (AD-11 FeatureFlagsResolver), parallel session
- Unblocks: develop의 push CI 안정화 → 후속 AD 작업 진입

## Out of Scope

- `getFeatureFlagsFilePath` 구현체 — 의도된 OS-native I/O 유지
- 같은 클래스의 다른 path 어설션 — 본 1건만 노출됨
- 평행 세션 PR #815에 대한 추가 회고 — 별도 후속 이슈
