### PR TITLE
fix(test): handle Windows drive-letter prefix in feature-flags path assertion (CI hot-fix)

### DIFF
--- a/tests/config/feature-flags.test.ts
+++ b/tests/config/feature-flags.test.ts
@@ -221,10 +221,10 @@ describe('FeatureFlagsResolver', () => {
   describe('getFeatureFlagsFilePath', () => {
     it('places the YAML under .ad-sdlc/config/feature-flags.yaml relative to baseDir', () => {
       const baseDir = '/tmp/some-project';
-      // Normalize Windows backslashes so the assertions stay portable across OSes.
-      const path = getFeatureFlagsFilePath(baseDir).replace(/\\/g, '/');
-      expect(path.endsWith('.ad-sdlc/config/feature-flags.yaml')).toBe(true);
-      expect(path.startsWith(baseDir)).toBe(true);
+      // Normalize separators because path.resolve emits backslashes on Windows
+      // and may prefix a drive letter (e.g. "C:/tmp/...") that breaks startsWith.
+      const filePath = getFeatureFlagsFilePath(baseDir).replace(/\\/g, '/');
+      expect(filePath.endsWith(`${baseDir}/.ad-sdlc/config/feature-flags.yaml`)).toBe(true);
     });
   });
 });


### PR DESCRIPTION
## What

PR #819 (Windows backslash 정규화)이 line 226 `endsWith`는 통과시켰지만 line 227 `startsWith(baseDir)`가 여전히 실패. Windows의 `path.resolve`는 drive-letter prefix(`C:/tmp/...`)를 추가하므로 `startsWith('/tmp/some-project')`는 false.

```diff
   it('places the YAML under .ad-sdlc/config/feature-flags.yaml relative to baseDir', () => {
     const baseDir = '/tmp/some-project';
-    // Normalize Windows backslashes so the assertions stay portable across OSes.
-    const path = getFeatureFlagsFilePath(baseDir).replace(/\\/g, '/');
-    expect(path.endsWith('.ad-sdlc/config/feature-flags.yaml')).toBe(true);
-    expect(path.startsWith(baseDir)).toBe(true);
+    // Normalize separators because path.resolve emits backslashes on Windows
+    // and may prefix a drive letter (e.g. "C:/tmp/...") that breaks startsWith.
+    const filePath = getFeatureFlagsFilePath(baseDir).replace(/\\/g, '/');
+    expect(filePath.endsWith(`${baseDir}/.ad-sdlc/config/feature-flags.yaml`)).toBe(true);
   });
```

## Why

PR #819 머지 직후 develop CI 직전 run (25529537204)의 실패 어설션:
```
tests/config/feature-flags.test.ts:227:40
  expect(path.startsWith(baseDir)).toBe(true)
  + Received: false
```

원인: Windows의 `path.resolve('/tmp/some-project', ...)` → `C:\tmp\some-project\...`. 내 #819 normalize 후 `C:/tmp/some-project/...` → 여전히 `'/tmp/some-project'`로 시작하지 않음.

## How

두 어설션의 의도("path가 baseDir 아래에 위치하고, suffix가 .ad-sdlc/...")를 단일 `endsWith(`${baseDir}/.ad-sdlc/config/feature-flags.yaml`)`로 통합. drive-letter는 자연스럽게 prefix이므로 OS-agnostic하게 통과:

| OS | filePath (정규화 후) | 어설션 결과 |
|---|---|---|
| Linux | `/tmp/some-project/.ad-sdlc/config/feature-flags.yaml` | endsWith → true ✓ |
| Windows | `C:/tmp/some-project/.ad-sdlc/config/feature-flags.yaml` | endsWith → true ✓ |

### 사후 분석 (3-fail rule)

본 사이클은 같은 테스트가 PR #819 → #820으로 두 번 fix됨. 첫 fix가 `startsWith` 부분의 drive-letter 영향을 놓침. 향후 OS-matrix path 어설션은 PR-level CI에서도 검증 가능하도록 메타 개선 권장.

## Linked

- Resolves: develop CI Test (windows-latest) failure on `d6172f58` (run 25529537204)
- Follow-up of: #819 (incomplete first fix)
- Original cause: #815 (AD-11 FeatureFlagsResolver, 평행 세션)
