### PR TITLE
fix(execution): satisfy exactOptionalPropertyTypes + noUncheckedIndexedAccess (CI hot-fix)

### DIFF
--- a/src/execution/SdkExecutionAdapter.ts
+++ b/src/execution/SdkExecutionAdapter.ts
@@ -125,12 +125,14 @@ export class SdkExecutionAdapter implements ExecutionAdapter {
 
     const sdk = await this.getSdk();
     const prompt = renderPrompt(req);
-    const sdkOptions: SdkQueryOptions['options'] = {
-      skills: req.skills,
-      mcpServers: req.mcpServers,
-      maxTurns: req.maxTurns,
-      resume: req.resume,
-      signal: req.signal,
+    // Build options with conditional spreads so undefined fields are absent
+    // entirely (required by tsconfig `exactOptionalPropertyTypes: true`).
+    const sdkOptions: NonNullable<SdkQueryOptions['options']> = {
+      ...(req.skills !== undefined && { skills: req.skills }),
+      ...(req.mcpServers !== undefined && { mcpServers: req.mcpServers }),
+      ...(req.maxTurns !== undefined && { maxTurns: req.maxTurns }),
+      ...(req.resume !== undefined && { resume: req.resume }),
+      ...(req.signal !== undefined && { signal: req.signal }),
       ...(this.hooks !== undefined && { hooks: this.hooks }),
     };
 
@@ -156,7 +158,10 @@ export class SdkExecutionAdapter implements ExecutionAdapter {
         }
       }
     } catch (err) {
-      if (req.signal?.aborted === true) return abortedResult(sessionId);
+      // The signal may have flipped to aborted between the early-return guard
+      // above and this point; widen the type so TS does not collapse the check.
+      const signal: AbortSignal | undefined = req.signal;
+      if (signal?.aborted === true) return abortedResult(sessionId);
       return failedResult(sessionId, err);
     }
 
@@ -192,11 +197,11 @@ export class SdkExecutionAdapter implements ExecutionAdapter {
  */
 export function renderPrompt(req: StageExecutionRequest): string {
   const blocks: string[] = [`# Stage: ${req.agentType}`, '', '## Work order', '', req.workOrder];
-  const keys = Object.keys(req.priorOutputs);
-  if (keys.length > 0) {
+  const entries = Object.entries(req.priorOutputs);
+  if (entries.length > 0) {
     blocks.push('', '## Prior outputs');
-    for (const key of keys) {
-      blocks.push('', `### ${key}`, '', req.priorOutputs[key]);
+    for (const [key, value] of entries) {
+      blocks.push('', `### ${key}`, '', value);
     }
   }
   return blocks.join('\n');
@@ -220,7 +225,11 @@ function extractArtifacts(resultText: string): ArtifactRef[] {
   const out: ArtifactRef[] = [];
   for (const raw of resultText.split('\n')) {
     const match = raw.match(/^\s*([\w./\-_]+):\s*(.+)$/);
-    if (match) out.push({ path: match[1], description: match[2].trim() });
+    if (match === null) continue;
+    const path = match[1];
+    const description = match[2];
+    if (path === undefined || description === undefined) continue;
+    out.push({ path, description: description.trim() });
   }
   return out;
 }


### PR DESCRIPTION
## What

PR #810 (AD-06)부터 잠복했던 5건의 TypeScript 컴파일 에러를 수정합니다. 본 회귀는 Test 잡 실패가 Build 잡을 skip시켜 5번의 CI run 동안 가려져 있었습니다. PR #820이 Test를 그린으로 회복시키자 Build이 처음 실행되며 노출.

```
src/execution/SdkExecutionAdapter.ts(128,11): error TS2375: ... exactOptionalPropertyTypes
src/execution/SdkExecutionAdapter.ts(144,45): error TS2379: ... exactOptionalPropertyTypes
src/execution/SdkExecutionAdapter.ts(159,11): error TS2367: comparison appears unintentional
src/execution/SdkExecutionAdapter.ts(199,41): error TS2345: string | undefined → string
src/execution/SdkExecutionAdapter.ts(223): error TS2322 + TS2532: undefined index access
```

## Why

`tsconfig.json` 두 strict 옵션이 활성화:
- `exactOptionalPropertyTypes: true` — `signal: AbortSignal | undefined` 같은 source를 `signal?: AbortSignal` target에 직접 할당 불가
- `noUncheckedIndexedAccess: true` — `record[key]`, `match[i]` 모두 `T | undefined`

PR #810 코드는 이 둘을 위반. 이번 PR이 늦은 발견을 메움.

## How

| 라인 | 위반 | 수정 |
|---|---|---|
| 128 sdkOptions | undefined optional 직접 할당 | 모든 필드에 conditional spread, 타입을 `NonNullable<SdkQueryOptions['options']>`로 |
| 159 catch abort | TS 흐름 분석이 line 122 narrow를 catch에 전파해 `false \| undefined === true` 충돌 | `const signal: AbortSignal \| undefined = req.signal` 로 fresh 별칭 |
| 199 priorOutputs index | indexed read | `Object.entries`로 안전 iteration |
| 223 match[i] | regex group nullable | `null`/`undefined` explicit check 후 push |

모두 type-level 정제 — 런타임 동작 변화 0.

## Verification

로컬 tsc는 sandbox에 typescript 모듈 미설치로 실행 불가 → CI에 위임.

## Linked

- Resolves: develop CI Build failure on `4f36fd3a` (run 25529743701)
- Latent regression from: #810 (AD-06 ExecutionAdapter), #818 (AD-07 hooks wiring)
- Follow-up of: #820 (Windows path fix that unblocked Build)
