### PR TITLE
refactor(orchestrator): cutover Doc Writers via ExecutionAdapter (AD-13-A)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Separate Database Schema Specification (DBS) from SDS into standalone document (#760)
+- Cut over the eight Doc Writers stages (PRD, SRS, SDP, SDS, UI Spec, Threat Model, Tech Decision, SVP) from `AgentDispatcher` to the SDK `ExecutionAdapter`; routing for these stages no longer consults the `AD_SDLC_USE_SDK_FOR_WORKER` feature flag (#823, AD-13-A, part of #797)
 
 ## [0.0.1] - 2025-12-27
 

--- a/src/ad-sdlc-orchestrator/AdsdlcOrchestratorAgent.ts
+++ b/src/ad-sdlc-orchestrator/AdsdlcOrchestratorAgent.ts
@@ -97,6 +97,32 @@ export const WORKER_PILOT_ENV_FLAG = ENV_USE_SDK_FOR_WORKER;
 const WORKER_PILOT_AGENT_TYPE = 'worker';
 
 /**
+ * Doc Writers stages cut over to the ExecutionAdapter unconditionally
+ * (issue #823, AD-13-A — sub-PR of AD-13 meta #797).
+ *
+ * Unlike the worker stage, which is gated by the
+ * `AD_SDLC_USE_SDK_FOR_WORKER` feature flag during the pilot phase, these
+ * eight Doc Writers always route through {@link executeViaAdapter}. The
+ * legacy {@link executeViaBridge} path is no longer reachable for these
+ * agent types — the AgentDispatcher remains in place only for the
+ * remaining stages handled by sibling sub-PRs (AD-13-B..E).
+ *
+ * The set is frozen so a typo cannot silently re-enable the bridge path.
+ */
+export const DOC_WRITERS_ADAPTER_AGENT_TYPES: ReadonlySet<string> = Object.freeze(
+  new Set<string>([
+    'prd-writer',
+    'srs-writer',
+    'sdp-writer',
+    'sds-writer',
+    'ui-spec-writer',
+    'threat-model-writer',
+    'tech-decision-writer',
+    'svp-writer',
+  ])
+);
+
+/**
  * AD-SDLC Orchestrator Agent
  *
  * Coordinates the full AD-SDLC pipeline execution by invoking subagents
@@ -902,6 +928,14 @@ export class AdsdlcOrchestratorAgent implements IAgent {
    * remains supported and tests that set
    * `process.env.AD_SDLC_USE_SDK_FOR_WORKER` keep working unchanged.
    *
+   * Doc Writers cutover (issue #823, AD-13-A): the eight Doc Writers
+   * agent types listed in {@link DOC_WRITERS_ADAPTER_AGENT_TYPES} are
+   * routed to {@link executeViaAdapter} unconditionally — the bridge
+   * path is no longer reachable for those stages. This is the first of
+   * five sub-PRs that progressively cut every stage over to the adapter
+   * (parent meta-issue #797). The remaining stages still flow through
+   * {@link executeViaBridge} until their respective sub-PRs land.
+   *
    * Override this method in tests to bypass real agent execution.
    *
    * @param stage - The stage definition identifying which agent to invoke
@@ -912,6 +946,9 @@ export class AdsdlcOrchestratorAgent implements IAgent {
     stage: PipelineStageDefinition,
     session: OrchestratorSession
   ): Promise<string> {
+    if (DOC_WRITERS_ADAPTER_AGENT_TYPES.has(stage.agentType)) {
+      return this.executeViaAdapter(stage, session);
+    }
     if (stage.agentType === WORKER_PILOT_AGENT_TYPE && this.getFeatureFlags().useSdkForWorker()) {
       return this.executeViaAdapter(stage, session);
     }

--- a/tests/ad-sdlc-orchestrator/docWritersCutover.test.ts
+++ b/tests/ad-sdlc-orchestrator/docWritersCutover.test.ts
@@ -1,0 +1,222 @@
+/**
+ * Doc Writers ExecutionAdapter cutover tests (issue #823, AD-13-A).
+ *
+ * Verifies that the eight Doc Writers stages always route through
+ * {@link AdsdlcOrchestratorAgent.executeViaAdapter} and never through
+ * {@link AdsdlcOrchestratorAgent.executeViaBridge}, regardless of the
+ * `AD_SDLC_USE_SDK_FOR_WORKER` feature flag.
+ *
+ * Stages in scope (8): PRD, SRS, SDP, SDS, UI, Threat Model, Tech
+ * Decision, SVP Writers. The remaining 25 stages (handled by sibling
+ * sub-PRs AD-13-B..E) must still flow through the bridge path; that
+ * regression-zero promise is asserted via the `collector` stage.
+ *
+ * Acceptance Criteria mapping:
+ *   AC-1  All 8 stages route exclusively through ExecutionAdapter.
+ *   AC-2  No `executeViaBridge` call site for these 8 stages.
+ *   AC-3  Other stages (e.g. `collector`) still use the bridge path.
+ *   AC-4  Routing decision does not depend on the worker feature flag.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+import {
+  AdsdlcOrchestratorAgent,
+  DOC_WRITERS_ADAPTER_AGENT_TYPES,
+  WORKER_PILOT_ENV_FLAG,
+} from '../../src/ad-sdlc-orchestrator/AdsdlcOrchestratorAgent.js';
+import type {
+  OrchestratorSession,
+  PipelineStageDefinition,
+} from '../../src/ad-sdlc-orchestrator/types.js';
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Test subclass that records which routing path was selected for each
+ * `invokeAgent` call. Both `executeViaBridge` and `executeViaAdapter`
+ * are stubbed so no real agent execution occurs.
+ */
+class RoutingProbeOrchestrator extends AdsdlcOrchestratorAgent {
+  bridgeCalls: string[] = [];
+  adapterCalls: string[] = [];
+
+  async callInvokeAgent(
+    stage: PipelineStageDefinition,
+    session: OrchestratorSession
+  ): Promise<string> {
+    return this.invokeAgent(stage, session);
+  }
+
+  protected override async executeViaBridge(
+    stage: PipelineStageDefinition,
+    _session: OrchestratorSession
+  ): Promise<string> {
+    this.bridgeCalls.push(stage.agentType);
+    return JSON.stringify({ via: 'agent-bridge', agentType: stage.agentType });
+  }
+
+  protected override async executeViaAdapter(
+    stage: PipelineStageDefinition,
+    _session: OrchestratorSession
+  ): Promise<string> {
+    this.adapterCalls.push(stage.agentType);
+    return JSON.stringify({ via: 'execution-adapter', agentType: stage.agentType });
+  }
+}
+
+function buildStage(agentType: string, name = 'doc-writer-stage'): PipelineStageDefinition {
+  return {
+    name: name as PipelineStageDefinition['name'],
+    agentType,
+    description: `Test stage for ${agentType}`,
+    parallel: false,
+    approvalRequired: false,
+    dependsOn: [],
+  };
+}
+
+function buildSession(): OrchestratorSession {
+  return {
+    sessionId: 'doc-writers-cutover-test',
+    projectDir: '/tmp/doc-writers-test',
+    userRequest: 'Generate documentation artifacts',
+    mode: 'greenfield',
+    startedAt: new Date().toISOString(),
+    status: 'running',
+    stageResults: [],
+    scratchpadDir: '/tmp/doc-writers-test/.ad-sdlc/scratchpad',
+    localMode: true,
+  };
+}
+
+// The full set the cutover applies to. Hard-coded here so the test
+// catches accidental drift in `DOC_WRITERS_ADAPTER_AGENT_TYPES`.
+const EXPECTED_DOC_WRITERS = [
+  'prd-writer',
+  'srs-writer',
+  'sdp-writer',
+  'sds-writer',
+  'ui-spec-writer',
+  'threat-model-writer',
+  'tech-decision-writer',
+  'svp-writer',
+] as const;
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('Doc Writers ExecutionAdapter cutover (#823)', () => {
+  let originalFlag: string | undefined;
+  let orchestrator: RoutingProbeOrchestrator;
+
+  beforeEach(() => {
+    originalFlag = process.env[WORKER_PILOT_ENV_FLAG];
+    delete process.env[WORKER_PILOT_ENV_FLAG];
+    orchestrator = new RoutingProbeOrchestrator();
+  });
+
+  afterEach(async () => {
+    if (originalFlag === undefined) {
+      delete process.env[WORKER_PILOT_ENV_FLAG];
+    } else {
+      process.env[WORKER_PILOT_ENV_FLAG] = originalFlag;
+    }
+    await orchestrator.dispose().catch(() => {
+      // tolerate dispose errors in cleanup
+    });
+  });
+
+  describe('Constant integrity', () => {
+    it('exports the expected set of 8 Doc Writers agent types', () => {
+      expect(DOC_WRITERS_ADAPTER_AGENT_TYPES.size).toBe(EXPECTED_DOC_WRITERS.length);
+      for (const agentType of EXPECTED_DOC_WRITERS) {
+        expect(DOC_WRITERS_ADAPTER_AGENT_TYPES.has(agentType)).toBe(true);
+      }
+    });
+
+    it('does not include the worker agent type (worker is feature-flag gated)', () => {
+      expect(DOC_WRITERS_ADAPTER_AGENT_TYPES.has('worker')).toBe(false);
+    });
+  });
+
+  describe('AC-1: all 8 Doc Writers route through the ExecutionAdapter', () => {
+    for (const agentType of EXPECTED_DOC_WRITERS) {
+      it(`routes ${agentType} via executeViaAdapter (flag unset)`, async () => {
+        const stage = buildStage(agentType);
+        const session = buildSession();
+
+        const output = await orchestrator.callInvokeAgent(stage, session);
+
+        expect(orchestrator.adapterCalls).toEqual([agentType]);
+        expect(orchestrator.bridgeCalls).toEqual([]);
+        expect(JSON.parse(output)).toMatchObject({
+          via: 'execution-adapter',
+          agentType,
+        });
+      });
+    }
+  });
+
+  describe('AC-4: routing is independent of AD_SDLC_USE_SDK_FOR_WORKER', () => {
+    for (const flagValue of ['1', '0', 'true', 'false']) {
+      it(`routes prd-writer via adapter when flag is "${flagValue}"`, async () => {
+        process.env[WORKER_PILOT_ENV_FLAG] = flagValue;
+        const stage = buildStage('prd-writer');
+        const session = buildSession();
+
+        await orchestrator.callInvokeAgent(stage, session);
+
+        expect(orchestrator.adapterCalls).toEqual(['prd-writer']);
+        expect(orchestrator.bridgeCalls).toEqual([]);
+      });
+    }
+  });
+
+  describe('AC-3: regression-zero for other stages', () => {
+    it('still routes the collector stage via the bridge path', async () => {
+      const stage = buildStage('collector', 'collection');
+      const session = buildSession();
+
+      await orchestrator.callInvokeAgent(stage, session);
+
+      expect(orchestrator.bridgeCalls).toEqual(['collector']);
+      expect(orchestrator.adapterCalls).toEqual([]);
+    });
+
+    it('still routes the issue-generator stage via the bridge path', async () => {
+      const stage = buildStage('issue-generator', 'issue_generation');
+      const session = buildSession();
+
+      await orchestrator.callInvokeAgent(stage, session);
+
+      expect(orchestrator.bridgeCalls).toEqual(['issue-generator']);
+      expect(orchestrator.adapterCalls).toEqual([]);
+    });
+
+    it('routes worker via bridge when feature flag is unset (regression-zero)', async () => {
+      delete process.env[WORKER_PILOT_ENV_FLAG];
+      const stage = buildStage('worker', 'implementation');
+      const session = buildSession();
+
+      await orchestrator.callInvokeAgent(stage, session);
+
+      expect(orchestrator.bridgeCalls).toEqual(['worker']);
+      expect(orchestrator.adapterCalls).toEqual([]);
+    });
+
+    it('routes worker via adapter when feature flag is on (existing #795 behaviour)', async () => {
+      process.env[WORKER_PILOT_ENV_FLAG] = '1';
+      const stage = buildStage('worker', 'implementation');
+      const session = buildSession();
+
+      await orchestrator.callInvokeAgent(stage, session);
+
+      expect(orchestrator.adapterCalls).toEqual(['worker']);
+      expect(orchestrator.bridgeCalls).toEqual([]);
+    });
+  });
+});


### PR DESCRIPTION
Closes #823

## Summary
- Routes the 8 Doc Writers stages (PRD/SRS/SDP/SDS/TM/TD/UI/SVP) through ExecutionAdapter only.
- Removes or hard-fails the executeViaBridge branch for these 8 stages.
- Other 25 stages still routed via AgentDispatcher (sibling sub-PRs handle them).

## Test Plan
- npm run build (passes locally if toolchain available, otherwise CI).
- npm test (no regression in unit/integration suites).
- grep -rn 'executeViaBridge' src/ — no live call sites for these 8 stages.

Part of #797.