### PR TITLE
refactor(orchestrator): cutover Analyzers via ExecutionAdapter (AD-13-C)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Separate Database Schema Specification (DBS) from SDS into standalone document (#760)
 - Cut over the eight Doc Writers stages (PRD, SRS, SDP, SDS, UI Spec, Threat Model, Tech Decision, SVP) from `AgentDispatcher` to the SDK `ExecutionAdapter`; routing for these stages no longer consults the `AD_SDLC_USE_SDK_FOR_WORKER` feature flag (#823, AD-13-A, part of #797)
 - Cut over the four Doc Updater + Reader stages (PRD Updater, SRS Updater, SDS Updater, Document Reader) from `AgentDispatcher` to the SDK `ExecutionAdapter`; routing is independent of the `AD_SDLC_USE_SDK_FOR_WORKER` feature flag and disjoint from the AD-13-A Doc Writers cutover set (#824, AD-13-B, part of #797)
+- Cut over the four Analyzer stages (Code Reader, Codebase Analyzer, Doc-Code Comparator, Impact Analyzer) from `AgentDispatcher` to the SDK `ExecutionAdapter`; routing is independent of the `AD_SDLC_USE_SDK_FOR_WORKER` feature flag and disjoint from the AD-13-A and AD-13-B cutover sets (#825, AD-13-C, part of #797)
 
 ## [0.0.1] - 2025-12-27
 

--- a/src/ad-sdlc-orchestrator/AdsdlcOrchestratorAgent.ts
+++ b/src/ad-sdlc-orchestrator/AdsdlcOrchestratorAgent.ts
@@ -140,6 +140,31 @@ export const DOC_UPDATERS_READER_ADAPTER_AGENT_TYPES: ReadonlySet<string> = Obje
 );
 
 /**
+ * Analyzer stages cut over to the ExecutionAdapter unconditionally
+ * (issue #825, AD-13-C — sub-PR of AD-13 meta #797).
+ *
+ * Sibling of {@link DOC_WRITERS_ADAPTER_AGENT_TYPES} (AD-13-A) and
+ * {@link DOC_UPDATERS_READER_ADAPTER_AGENT_TYPES} (AD-13-B). These four
+ * Analyzer agent types always route through {@link executeViaAdapter};
+ * the legacy {@link executeViaBridge} path is no longer reachable for
+ * them. The Analyzer stages share `grep` / `Read` heavy tool patterns,
+ * making them a coherent group for one PR.
+ *
+ * Note: Issue #825 originally listed six Analyzer stages including
+ * "Architecture Analyzer" and "Component Analyzer", but those names do
+ * not correspond to existing orchestrator agent types — only the four
+ * Analyzer-class stages defined in {@link ENHANCEMENT_STAGES} are
+ * cut over here. The remaining stages handled by sibling sub-PRs
+ * (AD-13-D, AD-13-E) still flow through the bridge until those PRs
+ * land.
+ *
+ * The set is frozen so a typo cannot silently re-enable the bridge path.
+ */
+export const ANALYZERS_ADAPTER_AGENT_TYPES: ReadonlySet<string> = Object.freeze(
+  new Set<string>(['code-reader', 'codebase-analyzer', 'doc-code-comparator', 'impact-analyzer'])
+);
+
+/**
  * AD-SDLC Orchestrator Agent
  *
  * Coordinates the full AD-SDLC pipeline execution by invoking subagents
@@ -957,8 +982,14 @@ export class AdsdlcOrchestratorAgent implements IAgent {
    * agent types listed in {@link DOC_UPDATERS_READER_ADAPTER_AGENT_TYPES}
    * (`prd-updater`, `srs-updater`, `sds-updater`, `document-reader`)
    * are routed to {@link executeViaAdapter} unconditionally on the
-   * same terms. The remaining 21 stages will be cut over by sibling
-   * sub-PRs AD-13-C..E.
+   * same terms.
+   *
+   * Analyzer cutover (issue #825, AD-13-C): the four agent types listed
+   * in {@link ANALYZERS_ADAPTER_AGENT_TYPES} (`code-reader`,
+   * `codebase-analyzer`, `doc-code-comparator`, `impact-analyzer`) are
+   * routed to {@link executeViaAdapter} unconditionally on the same
+   * terms. The remaining stages will be cut over by sibling sub-PRs
+   * AD-13-D and AD-13-E.
    *
    * Override this method in tests to bypass real agent execution.
    *
@@ -974,6 +1005,9 @@ export class AdsdlcOrchestratorAgent implements IAgent {
       return this.executeViaAdapter(stage, session);
     }
     if (DOC_UPDATERS_READER_ADAPTER_AGENT_TYPES.has(stage.agentType)) {
+      return this.executeViaAdapter(stage, session);
+    }
+    if (ANALYZERS_ADAPTER_AGENT_TYPES.has(stage.agentType)) {
       return this.executeViaAdapter(stage, session);
     }
     if (stage.agentType === WORKER_PILOT_AGENT_TYPE && this.getFeatureFlags().useSdkForWorker()) {

--- a/tests/ad-sdlc-orchestrator/analyzersCutover.test.ts
+++ b/tests/ad-sdlc-orchestrator/analyzersCutover.test.ts
@@ -1,29 +1,33 @@
 /**
- * Doc Updaters + Reader ExecutionAdapter cutover tests
- * (issue #824, AD-13-B).
+ * Analyzer ExecutionAdapter cutover tests
+ * (issue #825, AD-13-C).
  *
- * Verifies that the four target stages always route through
+ * Verifies that the four target Analyzer stages always route through
  * {@link AdsdlcOrchestratorAgent.executeViaAdapter} and never through
  * {@link AdsdlcOrchestratorAgent.executeViaBridge}, regardless of the
  * `AD_SDLC_USE_SDK_FOR_WORKER` feature flag.
  *
- * Stages in scope (4): PRD Updater, SRS Updater, SDS Updater, Document
- * Reader. The 8 Doc Writers stages cut over by AD-13-A (#823) must keep
- * routing through the adapter; the remaining 21 stages handled by
- * sibling sub-PRs AD-13-C..E must still flow through the bridge path.
+ * Stages in scope (4): Code Reader, Codebase Analyzer, Doc-Code
+ * Comparator, Impact Analyzer. The 8 Doc Writers stages cut over by
+ * AD-13-A (#823) and the 4 Doc Updater + Reader stages cut over by
+ * AD-13-B (#824) must keep routing through the adapter; the remaining
+ * stages handled by sibling sub-PRs AD-13-D and AD-13-E must still flow
+ * through the bridge path.
  *
  * Acceptance Criteria mapping:
- *   AC-1  All 4 stages route exclusively through ExecutionAdapter.
+ *   AC-1  All 4 Analyzer stages route exclusively through ExecutionAdapter.
  *   AC-2  No `executeViaBridge` call site for these 4 stages.
  *   AC-3  Other stages (e.g. `collector`) still use the bridge path.
  *   AC-4  Routing decision does not depend on the worker feature flag.
- *   AC-5  Doc Writers (AD-13-A) regression-zero: still adapter-routed.
+ *   AC-5  Doc Writers (AD-13-A) and Doc Updaters + Reader (AD-13-B)
+ *         regression-zero: still adapter-routed.
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 
 import {
   AdsdlcOrchestratorAgent,
+  ANALYZERS_ADAPTER_AGENT_TYPES,
   DOC_UPDATERS_READER_ADAPTER_AGENT_TYPES,
   DOC_WRITERS_ADAPTER_AGENT_TYPES,
   WORKER_PILOT_ENV_FLAG,
@@ -70,7 +74,7 @@ class RoutingProbeOrchestrator extends AdsdlcOrchestratorAgent {
   }
 }
 
-function buildStage(agentType: string, name = 'doc-updater-stage'): PipelineStageDefinition {
+function buildStage(agentType: string, name = 'analyzer-stage'): PipelineStageDefinition {
   return {
     name: name as PipelineStageDefinition['name'],
     agentType,
@@ -83,32 +87,32 @@ function buildStage(agentType: string, name = 'doc-updater-stage'): PipelineStag
 
 function buildSession(): OrchestratorSession {
   return {
-    sessionId: 'doc-updaters-reader-cutover-test',
-    projectDir: '/tmp/doc-updaters-test',
-    userRequest: 'Update documentation artifacts',
+    sessionId: 'analyzers-cutover-test',
+    projectDir: '/tmp/analyzers-test',
+    userRequest: 'Analyze codebase and documentation',
     mode: 'brownfield',
     startedAt: new Date().toISOString(),
     status: 'running',
     stageResults: [],
-    scratchpadDir: '/tmp/doc-updaters-test/.ad-sdlc/scratchpad',
+    scratchpadDir: '/tmp/analyzers-test/.ad-sdlc/scratchpad',
     localMode: true,
   };
 }
 
-// The full set the AD-13-B cutover applies to. Hard-coded here so the
-// test catches accidental drift in `DOC_UPDATERS_READER_ADAPTER_AGENT_TYPES`.
-const EXPECTED_DOC_UPDATERS_READER = [
-  'prd-updater',
-  'srs-updater',
-  'sds-updater',
-  'document-reader',
+// The full set the AD-13-C cutover applies to. Hard-coded here so the
+// test catches accidental drift in `ANALYZERS_ADAPTER_AGENT_TYPES`.
+const EXPECTED_ANALYZERS = [
+  'code-reader',
+  'codebase-analyzer',
+  'doc-code-comparator',
+  'impact-analyzer',
 ] as const;
 
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
-describe('Doc Updaters + Reader ExecutionAdapter cutover (#824)', () => {
+describe('Analyzer ExecutionAdapter cutover (#825)', () => {
   let originalFlag: string | undefined;
   let orchestrator: RoutingProbeOrchestrator;
 
@@ -130,28 +134,32 @@ describe('Doc Updaters + Reader ExecutionAdapter cutover (#824)', () => {
   });
 
   describe('Constant integrity', () => {
-    it('exports the expected set of 4 Doc Updater + Reader agent types', () => {
-      expect(DOC_UPDATERS_READER_ADAPTER_AGENT_TYPES.size).toBe(
-        EXPECTED_DOC_UPDATERS_READER.length
-      );
-      for (const agentType of EXPECTED_DOC_UPDATERS_READER) {
-        expect(DOC_UPDATERS_READER_ADAPTER_AGENT_TYPES.has(agentType)).toBe(true);
+    it('exports the expected set of 4 Analyzer agent types', () => {
+      expect(ANALYZERS_ADAPTER_AGENT_TYPES.size).toBe(EXPECTED_ANALYZERS.length);
+      for (const agentType of EXPECTED_ANALYZERS) {
+        expect(ANALYZERS_ADAPTER_AGENT_TYPES.has(agentType)).toBe(true);
       }
     });
 
     it('does not include the worker agent type (worker is feature-flag gated)', () => {
-      expect(DOC_UPDATERS_READER_ADAPTER_AGENT_TYPES.has('worker')).toBe(false);
+      expect(ANALYZERS_ADAPTER_AGENT_TYPES.has('worker')).toBe(false);
     });
 
     it('is disjoint from the Doc Writers cutover set (AD-13-A)', () => {
-      for (const agentType of DOC_UPDATERS_READER_ADAPTER_AGENT_TYPES) {
+      for (const agentType of ANALYZERS_ADAPTER_AGENT_TYPES) {
         expect(DOC_WRITERS_ADAPTER_AGENT_TYPES.has(agentType)).toBe(false);
+      }
+    });
+
+    it('is disjoint from the Doc Updaters + Reader cutover set (AD-13-B)', () => {
+      for (const agentType of ANALYZERS_ADAPTER_AGENT_TYPES) {
+        expect(DOC_UPDATERS_READER_ADAPTER_AGENT_TYPES.has(agentType)).toBe(false);
       }
     });
   });
 
-  describe('AC-1: all 4 Doc Updaters + Reader route through the ExecutionAdapter', () => {
-    for (const agentType of EXPECTED_DOC_UPDATERS_READER) {
+  describe('AC-1: all 4 Analyzers route through the ExecutionAdapter', () => {
+    for (const agentType of EXPECTED_ANALYZERS) {
       it(`routes ${agentType} via executeViaAdapter (flag unset)`, async () => {
         const stage = buildStage(agentType);
         const session = buildSession();
@@ -170,25 +178,25 @@ describe('Doc Updaters + Reader ExecutionAdapter cutover (#824)', () => {
 
   describe('AC-4: routing is independent of AD_SDLC_USE_SDK_FOR_WORKER', () => {
     for (const flagValue of ['1', '0', 'true', 'false']) {
-      it(`routes prd-updater via adapter when flag is "${flagValue}"`, async () => {
+      it(`routes code-reader via adapter when flag is "${flagValue}"`, async () => {
         process.env[WORKER_PILOT_ENV_FLAG] = flagValue;
-        const stage = buildStage('prd-updater');
+        const stage = buildStage('code-reader');
         const session = buildSession();
 
         await orchestrator.callInvokeAgent(stage, session);
 
-        expect(orchestrator.adapterCalls).toEqual(['prd-updater']);
+        expect(orchestrator.adapterCalls).toEqual(['code-reader']);
         expect(orchestrator.bridgeCalls).toEqual([]);
       });
 
-      it(`routes document-reader via adapter when flag is "${flagValue}"`, async () => {
+      it(`routes impact-analyzer via adapter when flag is "${flagValue}"`, async () => {
         process.env[WORKER_PILOT_ENV_FLAG] = flagValue;
-        const stage = buildStage('document-reader');
+        const stage = buildStage('impact-analyzer');
         const session = buildSession();
 
         await orchestrator.callInvokeAgent(stage, session);
 
-        expect(orchestrator.adapterCalls).toEqual(['document-reader']);
+        expect(orchestrator.adapterCalls).toEqual(['impact-analyzer']);
         expect(orchestrator.bridgeCalls).toEqual([]);
       });
     }
@@ -215,16 +223,13 @@ describe('Doc Updaters + Reader ExecutionAdapter cutover (#824)', () => {
       expect(orchestrator.adapterCalls).toEqual([]);
     });
 
-    // Note: `code-reader` was cut over to the ExecutionAdapter by AD-13-C
-    // (issue #825). Use a still-bridged stage as the regression-zero
-    // probe instead.
-    it('still routes the regression-tester stage via the bridge path', async () => {
-      const stage = buildStage('regression-tester', 'regression_testing');
+    it('still routes the controller stage via the bridge path', async () => {
+      const stage = buildStage('controller', 'orchestration');
       const session = buildSession();
 
       await orchestrator.callInvokeAgent(stage, session);
 
-      expect(orchestrator.bridgeCalls).toEqual(['regression-tester']);
+      expect(orchestrator.bridgeCalls).toEqual(['controller']);
       expect(orchestrator.adapterCalls).toEqual([]);
     });
 
@@ -254,6 +259,20 @@ describe('Doc Updaters + Reader ExecutionAdapter cutover (#824)', () => {
   describe('AC-5: AD-13-A Doc Writers regression-zero', () => {
     for (const agentType of DOC_WRITERS_ADAPTER_AGENT_TYPES) {
       it(`Doc Writer ${agentType} still routes via the adapter`, async () => {
+        const stage = buildStage(agentType);
+        const session = buildSession();
+
+        await orchestrator.callInvokeAgent(stage, session);
+
+        expect(orchestrator.adapterCalls).toEqual([agentType]);
+        expect(orchestrator.bridgeCalls).toEqual([]);
+      });
+    }
+  });
+
+  describe('AC-5: AD-13-B Doc Updaters + Reader regression-zero', () => {
+    for (const agentType of DOC_UPDATERS_READER_ADAPTER_AGENT_TYPES) {
+      it(`Doc Updater/Reader ${agentType} still routes via the adapter`, async () => {
         const stage = buildStage(agentType);
         const session = buildSession();
 


### PR DESCRIPTION
Closes #825

## Summary
- Routes the 4 Analyzer stages (`code-reader`, `codebase-analyzer`, `doc-code-comparator`, `impact-analyzer`) through ExecutionAdapter only.
- Sibling of AD-13-A (PR #828, 8 Doc Writers) and AD-13-B (PR #829, 4 Doc Updaters + Reader).
- Other stages still routed via AgentDispatcher (sibling sub-PRs AD-13-D/E handle them).

### Note on stage count
Issue #825 listed six Analyzer stages (Code Reader, Codebase Analyzer, Doc-Code Comparator, Impact Analyzer, Architecture Analyzer, Component Analyzer), but only the four Analyzer-class stages defined in `ENHANCEMENT_STAGES` exist in the orchestrator. The names "Architecture Analyzer" and "Component Analyzer" do not correspond to current agent types; this PR cuts over the four that do exist. Sibling sub-PRs may revisit the remaining names if/when those stages are introduced.

## Test Plan
- `npm run build` passes.
- `npm test` — 250 orchestrator tests pass (full suite: 6797 pass; 2 pre-existing failures in `doc-audit/audit-docs.cli.test.ts` are unrelated and reproduce on `develop`).
- New test file `tests/ad-sdlc-orchestrator/analyzersCutover.test.ts` (33 tests) verifies adapter routing, feature-flag independence, regression-zero for AD-13-A/B sets, and disjointness between cutover sets.
- AD-13-B test updated: the assertion that `code-reader` still routes via the bridge is replaced with `regression-tester` (still bridged) since AD-13-C now routes `code-reader` via the adapter.
- `grep -rn 'executeViaBridge' src/` shows no live call sites for these 4 stages.

Part of #797.