### PR TITLE
refactor(orchestrator): cutover Setup + Collection via ExecutionAdapter (AD-13-D)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Cut over the eight Doc Writers stages (PRD, SRS, SDP, SDS, UI Spec, Threat Model, Tech Decision, SVP) from `AgentDispatcher` to the SDK `ExecutionAdapter`; routing for these stages no longer consults the `AD_SDLC_USE_SDK_FOR_WORKER` feature flag (#823, AD-13-A, part of #797)
 - Cut over the four Doc Updater + Reader stages (PRD Updater, SRS Updater, SDS Updater, Document Reader) from `AgentDispatcher` to the SDK `ExecutionAdapter`; routing is independent of the `AD_SDLC_USE_SDK_FOR_WORKER` feature flag and disjoint from the AD-13-A Doc Writers cutover set (#824, AD-13-B, part of #797)
 - Cut over the four Analyzer stages (Code Reader, Codebase Analyzer, Doc-Code Comparator, Impact Analyzer) from `AgentDispatcher` to the SDK `ExecutionAdapter`; routing is independent of the `AD_SDLC_USE_SDK_FOR_WORKER` feature flag and disjoint from the AD-13-A and AD-13-B cutover sets (#825, AD-13-C, part of #797)
+- Cut over the six Setup + Collection stages (Project Initializer, Mode Detector, Repo Detector, GitHub Setup, Collector, Issue Reader) from `AgentDispatcher` to the SDK `ExecutionAdapter`; routing is independent of the `AD_SDLC_USE_SDK_FOR_WORKER` feature flag and disjoint from the AD-13-A, AD-13-B, and AD-13-C cutover sets (#826, AD-13-D, part of #797)
 
 ## [0.0.1] - 2025-12-27
 

--- a/src/ad-sdlc-orchestrator/AdsdlcOrchestratorAgent.ts
+++ b/src/ad-sdlc-orchestrator/AdsdlcOrchestratorAgent.ts
@@ -165,6 +165,36 @@ export const ANALYZERS_ADAPTER_AGENT_TYPES: ReadonlySet<string> = Object.freeze(
 );
 
 /**
+ * Setup and Collection stages cut over to the ExecutionAdapter
+ * unconditionally (issue #826, AD-13-D — sub-PR of AD-13 meta #797).
+ *
+ * Sibling of {@link DOC_WRITERS_ADAPTER_AGENT_TYPES} (AD-13-A),
+ * {@link DOC_UPDATERS_READER_ADAPTER_AGENT_TYPES} (AD-13-B), and
+ * {@link ANALYZERS_ADAPTER_AGENT_TYPES} (AD-13-C). These six agent
+ * types always route through {@link executeViaAdapter}; the legacy
+ * {@link executeViaBridge} path is no longer reachable for them. They
+ * cover the early pipeline phases (project initialization, mode
+ * detection, repository detection, GitHub repository setup, project
+ * collection, and issue reading) that prepare the orchestrator's
+ * inputs before document generation begins.
+ *
+ * The remaining stages handled by the final sibling sub-PR (AD-13-E)
+ * still flow through the bridge until that PR lands.
+ *
+ * The set is frozen so a typo cannot silently re-enable the bridge path.
+ */
+export const SETUP_COLLECTION_ADAPTER_AGENT_TYPES: ReadonlySet<string> = Object.freeze(
+  new Set<string>([
+    'project-initializer',
+    'mode-detector',
+    'repo-detector',
+    'github-repo-setup',
+    'collector',
+    'issue-reader',
+  ])
+);
+
+/**
  * AD-SDLC Orchestrator Agent
  *
  * Coordinates the full AD-SDLC pipeline execution by invoking subagents
@@ -988,8 +1018,15 @@ export class AdsdlcOrchestratorAgent implements IAgent {
    * in {@link ANALYZERS_ADAPTER_AGENT_TYPES} (`code-reader`,
    * `codebase-analyzer`, `doc-code-comparator`, `impact-analyzer`) are
    * routed to {@link executeViaAdapter} unconditionally on the same
-   * terms. The remaining stages will be cut over by sibling sub-PRs
-   * AD-13-D and AD-13-E.
+   * terms.
+   *
+   * Setup + Collection cutover (issue #826, AD-13-D): the six agent
+   * types listed in {@link SETUP_COLLECTION_ADAPTER_AGENT_TYPES}
+   * (`project-initializer`, `mode-detector`, `repo-detector`,
+   * `github-repo-setup`, `collector`, `issue-reader`) are routed to
+   * {@link executeViaAdapter} unconditionally on the same terms. The
+   * remaining stages will be cut over by the final sibling sub-PR
+   * AD-13-E.
    *
    * Override this method in tests to bypass real agent execution.
    *
@@ -1008,6 +1045,9 @@ export class AdsdlcOrchestratorAgent implements IAgent {
       return this.executeViaAdapter(stage, session);
     }
     if (ANALYZERS_ADAPTER_AGENT_TYPES.has(stage.agentType)) {
+      return this.executeViaAdapter(stage, session);
+    }
+    if (SETUP_COLLECTION_ADAPTER_AGENT_TYPES.has(stage.agentType)) {
       return this.executeViaAdapter(stage, session);
     }
     if (stage.agentType === WORKER_PILOT_AGENT_TYPE && this.getFeatureFlags().useSdkForWorker()) {

--- a/tests/ad-sdlc-orchestrator/AdsdlcOrchestratorAgent.test.ts
+++ b/tests/ad-sdlc-orchestrator/AdsdlcOrchestratorAgent.test.ts
@@ -554,6 +554,18 @@ describe('AdsdlcOrchestratorAgent', () => {
             decidedAt: new Date().toISOString(),
           });
         }
+
+        // Stub invokeAgent so the import pipeline does not exercise the
+        // real adapter / bridge paths. After AD-13-D (#826) the
+        // `issue-reader` import-pipeline entry stage routes through
+        // ExecutionAdapter, which would trigger real SDK execution
+        // unless overridden here.
+        protected override async invokeAgent(
+          stage: PipelineStageDefinition,
+          _session: OrchestratorSession
+        ): Promise<string> {
+          return `Stage "${stage.name}" executed by ${stage.agentType}`;
+        }
       }
 
       const customAgent = new CustomApprovalOrchestrator({ approvalMode: 'custom' });

--- a/tests/ad-sdlc-orchestrator/analyzersCutover.test.ts
+++ b/tests/ad-sdlc-orchestrator/analyzersCutover.test.ts
@@ -17,7 +17,10 @@
  * Acceptance Criteria mapping:
  *   AC-1  All 4 Analyzer stages route exclusively through ExecutionAdapter.
  *   AC-2  No `executeViaBridge` call site for these 4 stages.
- *   AC-3  Other stages (e.g. `collector`) still use the bridge path.
+ *   AC-3  Other stages (e.g. `regression-tester`) still use the bridge
+ *         path. (After AD-13-D landed, the previously-bridge `collector`
+ *         stage is now adapter-routed, so the regression probe was
+ *         retargeted at a still-bridge stage.)
  *   AC-4  Routing decision does not depend on the worker feature flag.
  *   AC-5  Doc Writers (AD-13-A) and Doc Updaters + Reader (AD-13-B)
  *         regression-zero: still adapter-routed.
@@ -203,13 +206,13 @@ describe('Analyzer ExecutionAdapter cutover (#825)', () => {
   });
 
   describe('AC-3: regression-zero for non-cutover stages', () => {
-    it('still routes the collector stage via the bridge path', async () => {
-      const stage = buildStage('collector', 'collection');
+    it('still routes the regression-tester stage via the bridge path', async () => {
+      const stage = buildStage('regression-tester', 'regression');
       const session = buildSession();
 
       await orchestrator.callInvokeAgent(stage, session);
 
-      expect(orchestrator.bridgeCalls).toEqual(['collector']);
+      expect(orchestrator.bridgeCalls).toEqual(['regression-tester']);
       expect(orchestrator.adapterCalls).toEqual([]);
     });
 

--- a/tests/ad-sdlc-orchestrator/docWritersCutover.test.ts
+++ b/tests/ad-sdlc-orchestrator/docWritersCutover.test.ts
@@ -7,14 +7,18 @@
  * `AD_SDLC_USE_SDK_FOR_WORKER` feature flag.
  *
  * Stages in scope (8): PRD, SRS, SDP, SDS, UI, Threat Model, Tech
- * Decision, SVP Writers. The remaining 25 stages (handled by sibling
+ * Decision, SVP Writers. The remaining stages (handled by sibling
  * sub-PRs AD-13-B..E) must still flow through the bridge path; that
- * regression-zero promise is asserted via the `collector` stage.
+ * regression-zero promise is asserted via a still-bridge stage such as
+ * `regression-tester`. (After AD-13-D landed, the previously-bridge
+ * `collector` stage is now adapter-routed, so the regression probe was
+ * retargeted.)
  *
  * Acceptance Criteria mapping:
  *   AC-1  All 8 stages route exclusively through ExecutionAdapter.
  *   AC-2  No `executeViaBridge` call site for these 8 stages.
- *   AC-3  Other stages (e.g. `collector`) still use the bridge path.
+ *   AC-3  Other stages (e.g. `regression-tester`) still use the bridge
+ *         path.
  *   AC-4  Routing decision does not depend on the worker feature flag.
  */
 
@@ -177,13 +181,13 @@ describe('Doc Writers ExecutionAdapter cutover (#823)', () => {
   });
 
   describe('AC-3: regression-zero for other stages', () => {
-    it('still routes the collector stage via the bridge path', async () => {
-      const stage = buildStage('collector', 'collection');
+    it('still routes the regression-tester stage via the bridge path', async () => {
+      const stage = buildStage('regression-tester', 'regression');
       const session = buildSession();
 
       await orchestrator.callInvokeAgent(stage, session);
 
-      expect(orchestrator.bridgeCalls).toEqual(['collector']);
+      expect(orchestrator.bridgeCalls).toEqual(['regression-tester']);
       expect(orchestrator.adapterCalls).toEqual([]);
     });
 

--- a/tests/ad-sdlc-orchestrator/featureFlags-integration.test.ts
+++ b/tests/ad-sdlc-orchestrator/featureFlags-integration.test.ts
@@ -149,13 +149,16 @@ describe('Orchestrator + FeatureFlagsResolver integration (#795)', () => {
     expect(orch.lastRoute).toBe('bridge');
   });
 
-  it('non-worker stages always go through bridge regardless of flag', async () => {
+  it('non-worker non-cutover stages always go through bridge regardless of flag', async () => {
     process.env[ENV_USE_SDK_FOR_WORKER] = '1';
     const orch = new RouteCapturingOrchestrator({ featureFlagsBaseDir: tmpRoot });
+    // Note: `collector` is now adapter-routed after AD-13-D (#826), so
+    // probe a still-bridge stage to verify the flag-independent bridge
+    // path is preserved for non-cutover, non-worker stages.
     const stage: PipelineStageDefinition = {
-      name: 'collection',
-      agentType: 'collector',
-      description: 'Collector stage',
+      name: 'regression',
+      agentType: 'regression-tester',
+      description: 'Regression tester stage',
       parallel: false,
       approvalRequired: false,
       dependsOn: [],

--- a/tests/ad-sdlc-orchestrator/invokeAgent-dispatcher.test.ts
+++ b/tests/ad-sdlc-orchestrator/invokeAgent-dispatcher.test.ts
@@ -26,11 +26,15 @@ import { AgentDispatcher } from '../../src/agents/AgentDispatcher.js';
 
 /**
  * Minimal stage definition for testing invokeAgent()
+ *
+ * Uses `regression-tester` so the dispatcher path is exercised; the
+ * previously-used `collector` stage is now adapter-routed after AD-13-D
+ * (#826) and would bypass the dispatcher this suite is validating.
  */
 function createStage(overrides?: Partial<PipelineStageDefinition>): PipelineStageDefinition {
   return {
-    name: 'collection',
-    agentType: 'collector',
+    name: 'regression',
+    agentType: 'regression-tester',
     description: 'Test stage',
     parallel: false,
     approvalRequired: false,
@@ -222,9 +226,7 @@ describe('invokeAgent() dispatcher wiring', () => {
       }
 
       const dispatcher = orchestrator.getInternalDispatcher()!;
-      vi.spyOn(dispatcher, 'dispatch').mockRejectedValue(
-        new Error('Agent execution failed')
-      );
+      vi.spyOn(dispatcher, 'dispatch').mockRejectedValue(new Error('Agent execution failed'));
 
       await expect(orchestrator.callInvokeAgent(stage, session)).rejects.toThrow(
         'Agent execution failed'

--- a/tests/ad-sdlc-orchestrator/setupCollectionCutover.test.ts
+++ b/tests/ad-sdlc-orchestrator/setupCollectionCutover.test.ts
@@ -1,34 +1,39 @@
 /**
- * Doc Updaters + Reader ExecutionAdapter cutover tests
- * (issue #824, AD-13-B).
+ * Setup + Collection ExecutionAdapter cutover tests
+ * (issue #826, AD-13-D).
  *
- * Verifies that the four target stages always route through
- * {@link AdsdlcOrchestratorAgent.executeViaAdapter} and never through
- * {@link AdsdlcOrchestratorAgent.executeViaBridge}, regardless of the
- * `AD_SDLC_USE_SDK_FOR_WORKER` feature flag.
+ * Verifies that the six target Setup + Collection stages always route
+ * through {@link AdsdlcOrchestratorAgent.executeViaAdapter} and never
+ * through {@link AdsdlcOrchestratorAgent.executeViaBridge}, regardless
+ * of the `AD_SDLC_USE_SDK_FOR_WORKER` feature flag.
  *
- * Stages in scope (4): PRD Updater, SRS Updater, SDS Updater, Document
- * Reader. The 8 Doc Writers stages cut over by AD-13-A (#823) must keep
- * routing through the adapter; the remaining 21 stages handled by
- * sibling sub-PRs AD-13-C..E must still flow through the bridge path.
+ * Stages in scope (6): Project Initializer, Mode Detector, Repo
+ * Detector, GitHub Setup, Collector, Issue Reader. The 8 Doc Writers
+ * stages cut over by AD-13-A (#823), the 4 Doc Updater + Reader stages
+ * cut over by AD-13-B (#824), and the 4 Analyzer stages cut over by
+ * AD-13-C (#825) must keep routing through the adapter; the remaining
+ * stages handled by the final sibling sub-PR AD-13-E must still flow
+ * through the bridge path.
  *
  * Acceptance Criteria mapping:
- *   AC-1  All 4 stages route exclusively through ExecutionAdapter.
- *   AC-2  No `executeViaBridge` call site for these 4 stages.
- *   AC-3  Other stages (e.g. `regression-tester`) still use the bridge
- *         path. (After AD-13-D landed, the previously-bridge `collector`
- *         stage is now adapter-routed, so the regression probe was
- *         retargeted at a still-bridge stage.)
+ *   AC-1  All 6 Setup + Collection stages route exclusively through
+ *         ExecutionAdapter.
+ *   AC-2  No `executeViaBridge` call site for these 6 stages.
+ *   AC-3  Other stages (e.g. `issue-generator`, `controller`) still use
+ *         the bridge path.
  *   AC-4  Routing decision does not depend on the worker feature flag.
- *   AC-5  Doc Writers (AD-13-A) regression-zero: still adapter-routed.
+ *   AC-5  Doc Writers (AD-13-A), Doc Updaters + Reader (AD-13-B), and
+ *         Analyzers (AD-13-C) regression-zero: still adapter-routed.
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 
 import {
   AdsdlcOrchestratorAgent,
+  ANALYZERS_ADAPTER_AGENT_TYPES,
   DOC_UPDATERS_READER_ADAPTER_AGENT_TYPES,
   DOC_WRITERS_ADAPTER_AGENT_TYPES,
+  SETUP_COLLECTION_ADAPTER_AGENT_TYPES,
   WORKER_PILOT_ENV_FLAG,
 } from '../../src/ad-sdlc-orchestrator/AdsdlcOrchestratorAgent.js';
 import type {
@@ -73,7 +78,7 @@ class RoutingProbeOrchestrator extends AdsdlcOrchestratorAgent {
   }
 }
 
-function buildStage(agentType: string, name = 'doc-updater-stage'): PipelineStageDefinition {
+function buildStage(agentType: string, name = 'setup-stage'): PipelineStageDefinition {
   return {
     name: name as PipelineStageDefinition['name'],
     agentType,
@@ -86,32 +91,34 @@ function buildStage(agentType: string, name = 'doc-updater-stage'): PipelineStag
 
 function buildSession(): OrchestratorSession {
   return {
-    sessionId: 'doc-updaters-reader-cutover-test',
-    projectDir: '/tmp/doc-updaters-test',
-    userRequest: 'Update documentation artifacts',
-    mode: 'brownfield',
+    sessionId: 'setup-collection-cutover-test',
+    projectDir: '/tmp/setup-collection-test',
+    userRequest: 'Initialize project and collect inputs',
+    mode: 'greenfield',
     startedAt: new Date().toISOString(),
     status: 'running',
     stageResults: [],
-    scratchpadDir: '/tmp/doc-updaters-test/.ad-sdlc/scratchpad',
+    scratchpadDir: '/tmp/setup-collection-test/.ad-sdlc/scratchpad',
     localMode: true,
   };
 }
 
-// The full set the AD-13-B cutover applies to. Hard-coded here so the
-// test catches accidental drift in `DOC_UPDATERS_READER_ADAPTER_AGENT_TYPES`.
-const EXPECTED_DOC_UPDATERS_READER = [
-  'prd-updater',
-  'srs-updater',
-  'sds-updater',
-  'document-reader',
+// The full set the AD-13-D cutover applies to. Hard-coded here so the
+// test catches accidental drift in `SETUP_COLLECTION_ADAPTER_AGENT_TYPES`.
+const EXPECTED_SETUP_COLLECTION = [
+  'project-initializer',
+  'mode-detector',
+  'repo-detector',
+  'github-repo-setup',
+  'collector',
+  'issue-reader',
 ] as const;
 
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
-describe('Doc Updaters + Reader ExecutionAdapter cutover (#824)', () => {
+describe('Setup + Collection ExecutionAdapter cutover (#826)', () => {
   let originalFlag: string | undefined;
   let orchestrator: RoutingProbeOrchestrator;
 
@@ -133,28 +140,38 @@ describe('Doc Updaters + Reader ExecutionAdapter cutover (#824)', () => {
   });
 
   describe('Constant integrity', () => {
-    it('exports the expected set of 4 Doc Updater + Reader agent types', () => {
-      expect(DOC_UPDATERS_READER_ADAPTER_AGENT_TYPES.size).toBe(
-        EXPECTED_DOC_UPDATERS_READER.length
-      );
-      for (const agentType of EXPECTED_DOC_UPDATERS_READER) {
-        expect(DOC_UPDATERS_READER_ADAPTER_AGENT_TYPES.has(agentType)).toBe(true);
+    it('exports the expected set of 6 Setup + Collection agent types', () => {
+      expect(SETUP_COLLECTION_ADAPTER_AGENT_TYPES.size).toBe(EXPECTED_SETUP_COLLECTION.length);
+      for (const agentType of EXPECTED_SETUP_COLLECTION) {
+        expect(SETUP_COLLECTION_ADAPTER_AGENT_TYPES.has(agentType)).toBe(true);
       }
     });
 
     it('does not include the worker agent type (worker is feature-flag gated)', () => {
-      expect(DOC_UPDATERS_READER_ADAPTER_AGENT_TYPES.has('worker')).toBe(false);
+      expect(SETUP_COLLECTION_ADAPTER_AGENT_TYPES.has('worker')).toBe(false);
     });
 
     it('is disjoint from the Doc Writers cutover set (AD-13-A)', () => {
-      for (const agentType of DOC_UPDATERS_READER_ADAPTER_AGENT_TYPES) {
+      for (const agentType of SETUP_COLLECTION_ADAPTER_AGENT_TYPES) {
         expect(DOC_WRITERS_ADAPTER_AGENT_TYPES.has(agentType)).toBe(false);
+      }
+    });
+
+    it('is disjoint from the Doc Updaters + Reader cutover set (AD-13-B)', () => {
+      for (const agentType of SETUP_COLLECTION_ADAPTER_AGENT_TYPES) {
+        expect(DOC_UPDATERS_READER_ADAPTER_AGENT_TYPES.has(agentType)).toBe(false);
+      }
+    });
+
+    it('is disjoint from the Analyzer cutover set (AD-13-C)', () => {
+      for (const agentType of SETUP_COLLECTION_ADAPTER_AGENT_TYPES) {
+        expect(ANALYZERS_ADAPTER_AGENT_TYPES.has(agentType)).toBe(false);
       }
     });
   });
 
-  describe('AC-1: all 4 Doc Updaters + Reader route through the ExecutionAdapter', () => {
-    for (const agentType of EXPECTED_DOC_UPDATERS_READER) {
+  describe('AC-1: all 6 Setup + Collection stages route through the ExecutionAdapter', () => {
+    for (const agentType of EXPECTED_SETUP_COLLECTION) {
       it(`routes ${agentType} via executeViaAdapter (flag unset)`, async () => {
         const stage = buildStage(agentType);
         const session = buildSession();
@@ -173,41 +190,42 @@ describe('Doc Updaters + Reader ExecutionAdapter cutover (#824)', () => {
 
   describe('AC-4: routing is independent of AD_SDLC_USE_SDK_FOR_WORKER', () => {
     for (const flagValue of ['1', '0', 'true', 'false']) {
-      it(`routes prd-updater via adapter when flag is "${flagValue}"`, async () => {
+      it(`routes project-initializer via adapter when flag is "${flagValue}"`, async () => {
         process.env[WORKER_PILOT_ENV_FLAG] = flagValue;
-        const stage = buildStage('prd-updater');
+        const stage = buildStage('project-initializer');
         const session = buildSession();
 
         await orchestrator.callInvokeAgent(stage, session);
 
-        expect(orchestrator.adapterCalls).toEqual(['prd-updater']);
+        expect(orchestrator.adapterCalls).toEqual(['project-initializer']);
         expect(orchestrator.bridgeCalls).toEqual([]);
       });
 
-      it(`routes document-reader via adapter when flag is "${flagValue}"`, async () => {
+      it(`routes collector via adapter when flag is "${flagValue}"`, async () => {
         process.env[WORKER_PILOT_ENV_FLAG] = flagValue;
-        const stage = buildStage('document-reader');
+        const stage = buildStage('collector');
         const session = buildSession();
 
         await orchestrator.callInvokeAgent(stage, session);
 
-        expect(orchestrator.adapterCalls).toEqual(['document-reader']);
+        expect(orchestrator.adapterCalls).toEqual(['collector']);
+        expect(orchestrator.bridgeCalls).toEqual([]);
+      });
+
+      it(`routes issue-reader via adapter when flag is "${flagValue}"`, async () => {
+        process.env[WORKER_PILOT_ENV_FLAG] = flagValue;
+        const stage = buildStage('issue-reader');
+        const session = buildSession();
+
+        await orchestrator.callInvokeAgent(stage, session);
+
+        expect(orchestrator.adapterCalls).toEqual(['issue-reader']);
         expect(orchestrator.bridgeCalls).toEqual([]);
       });
     }
   });
 
   describe('AC-3: regression-zero for non-cutover stages', () => {
-    it('still routes the regression-tester stage via the bridge path', async () => {
-      const stage = buildStage('regression-tester', 'regression');
-      const session = buildSession();
-
-      await orchestrator.callInvokeAgent(stage, session);
-
-      expect(orchestrator.bridgeCalls).toEqual(['regression-tester']);
-      expect(orchestrator.adapterCalls).toEqual([]);
-    });
-
     it('still routes the issue-generator stage via the bridge path', async () => {
       const stage = buildStage('issue-generator', 'issue_generation');
       const session = buildSession();
@@ -218,16 +236,23 @@ describe('Doc Updaters + Reader ExecutionAdapter cutover (#824)', () => {
       expect(orchestrator.adapterCalls).toEqual([]);
     });
 
-    // Note: `code-reader` was cut over to the ExecutionAdapter by AD-13-C
-    // (issue #825). Use a still-bridged stage as the regression-zero
-    // probe instead.
-    it('still routes the regression-tester stage via the bridge path', async () => {
-      const stage = buildStage('regression-tester', 'regression_testing');
+    it('still routes the controller stage via the bridge path', async () => {
+      const stage = buildStage('controller', 'orchestration');
       const session = buildSession();
 
       await orchestrator.callInvokeAgent(stage, session);
 
-      expect(orchestrator.bridgeCalls).toEqual(['regression-tester']);
+      expect(orchestrator.bridgeCalls).toEqual(['controller']);
+      expect(orchestrator.adapterCalls).toEqual([]);
+    });
+
+    it('still routes the validation-agent stage via the bridge path', async () => {
+      const stage = buildStage('validation-agent', 'validation');
+      const session = buildSession();
+
+      await orchestrator.callInvokeAgent(stage, session);
+
+      expect(orchestrator.bridgeCalls).toEqual(['validation-agent']);
       expect(orchestrator.adapterCalls).toEqual([]);
     });
 
@@ -257,6 +282,34 @@ describe('Doc Updaters + Reader ExecutionAdapter cutover (#824)', () => {
   describe('AC-5: AD-13-A Doc Writers regression-zero', () => {
     for (const agentType of DOC_WRITERS_ADAPTER_AGENT_TYPES) {
       it(`Doc Writer ${agentType} still routes via the adapter`, async () => {
+        const stage = buildStage(agentType);
+        const session = buildSession();
+
+        await orchestrator.callInvokeAgent(stage, session);
+
+        expect(orchestrator.adapterCalls).toEqual([agentType]);
+        expect(orchestrator.bridgeCalls).toEqual([]);
+      });
+    }
+  });
+
+  describe('AC-5: AD-13-B Doc Updaters + Reader regression-zero', () => {
+    for (const agentType of DOC_UPDATERS_READER_ADAPTER_AGENT_TYPES) {
+      it(`Doc Updater/Reader ${agentType} still routes via the adapter`, async () => {
+        const stage = buildStage(agentType);
+        const session = buildSession();
+
+        await orchestrator.callInvokeAgent(stage, session);
+
+        expect(orchestrator.adapterCalls).toEqual([agentType]);
+        expect(orchestrator.bridgeCalls).toEqual([]);
+      });
+    }
+  });
+
+  describe('AC-5: AD-13-C Analyzers regression-zero', () => {
+    for (const agentType of ANALYZERS_ADAPTER_AGENT_TYPES) {
+      it(`Analyzer ${agentType} still routes via the adapter`, async () => {
         const stage = buildStage(agentType);
         const session = buildSession();
 


### PR DESCRIPTION
Closes #826

## Summary
- Routes the 6 Setup + Collection stages (Project Initializer, Mode Detector, Repo Detector, GitHub Setup, Collector, Issue Reader) through ExecutionAdapter only.
- Sibling of AD-13-A (#828, 8 Doc Writers), AD-13-B (#829, 4 Doc Updaters + Reader), AD-13-C (#830, 6 Analyzers).
- Other 9 stages still routed via AgentDispatcher (AD-13-E handles them).

## Test Plan
- npm run build / npm test.
- grep -rn 'executeViaBridge' src/ — no live call sites for these 6 stages.

Part of #797.