### PR TITLE
feat(checkpoint): map SDK session_id in PipelineCheckpointManager (schema v1->v2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `PipelineCheckpointManager` records the SDK `session_id` per stage so a mid-stage crash can resume via the SDK's `resume: sessionId` and recover its tool-loop context. Checkpoint schema is bumped from v1 to v2 with backward-compatible auto-migration (v1 fixtures load as v2 with `sdkSessionId` undefined); adapters that do not surface a session id (e.g. Bedrock/Vertex) gracefully fall back to a clean stage restart (#800)
 - UI Specification Writer agent for generating screen specifications, user flow documents, and design system references from SRS use cases (#770)
 - Document Audit CLI for generated output integrity verification with frontmatter, cross-reference, and traceability checks (#769)
 - Technology Decision Writer agent with parallel pipeline stage for comparative analysis (#762)

--- a/src/ad-sdlc-orchestrator/AdsdlcOrchestratorAgent.ts
+++ b/src/ad-sdlc-orchestrator/AdsdlcOrchestratorAgent.ts
@@ -98,6 +98,12 @@ export class AdsdlcOrchestratorAgent implements IAgent {
   private stageTimers = new Map<StageName, ReturnType<typeof setTimeout>>();
   private abortController: AbortController | null = null;
   private readonly checkpointManager: PipelineCheckpointManager | null;
+  /**
+   * One-shot SDK session id used to resume the FIRST stage of a session
+   * recovered from a v2 checkpoint. Cleared on consumption so subsequent
+   * stages run as fresh SDK sessions (each stage is a different agent).
+   */
+  private pendingResumeSdkSessionId: string | undefined = undefined;
 
   constructor(config: OrchestratorConfig = {}) {
     this.config = {
@@ -173,6 +179,7 @@ export class AdsdlcOrchestratorAgent implements IAgent {
             agent: 'AdsdlcOrchestratorAgent',
             sessionId: request.resumeSessionId,
             completedStages: checkpoint.completedStageNames.length,
+            hasSdkSession: checkpoint.sdkSessionId !== undefined,
           });
           // Feed checkpoint's completed stages into the existing resume path
           // by overriding preCompletedStages after loadPriorSession resolves
@@ -184,7 +191,14 @@ export class AdsdlcOrchestratorAgent implements IAgent {
               localMode: request.localMode ?? prior.localMode,
               preCompletedStages: checkpoint.completedStageNames,
               stageResults: checkpoint.completedStageResults,
+              ...(checkpoint.sdkSessionId !== undefined && checkpoint.sdkSessionId !== ''
+                ? { resumeSdkSessionId: checkpoint.sdkSessionId }
+                : {}),
             };
+            this.pendingResumeSdkSessionId =
+              checkpoint.sdkSessionId !== undefined && checkpoint.sdkSessionId !== ''
+                ? checkpoint.sdkSessionId
+                : undefined;
             this.abortController = new AbortController();
             return this.session;
           }
@@ -198,10 +212,15 @@ export class AdsdlcOrchestratorAgent implements IAgent {
           status: 'running',
           localMode: request.localMode ?? prior.localMode,
         };
+        // No checkpoint => no SDK session id to resume from.
+        this.pendingResumeSdkSessionId = undefined;
         this.abortController = new AbortController();
         return this.session;
       }
     }
+
+    // Cold-start session: ensure no stale resume id leaks across runs.
+    this.pendingResumeSdkSessionId = undefined;
 
     const mode = request.overrideMode ?? 'greenfield';
     const scratchpadDir = path.resolve(request.projectDir, this.config.scratchpadDir);
@@ -599,10 +618,26 @@ export class AdsdlcOrchestratorAgent implements IAgent {
       }
     }
 
+    // Consume the one-shot resume id: only the FIRST stage executed in
+    // a checkpoint-resumed session forwards `resume: sessionId` to the
+    // SDK. Subsequent stages run as fresh sessions because each stage
+    // is a different agent persona.
+    let resumeId: string | undefined;
+    if (this.pendingResumeSdkSessionId !== undefined && this.pendingResumeSdkSessionId !== '') {
+      resumeId = this.pendingResumeSdkSessionId;
+      this.pendingResumeSdkSessionId = undefined;
+      getLogger().info('Resuming stage with SDK session id', {
+        agent: 'AdsdlcOrchestratorAgent',
+        stage: stage.name,
+        sdkSessionId: resumeId,
+      });
+    }
+
     const request: StageExecutionRequest = {
       agentType: stage.agentType,
       workOrder: session.userRequest,
       priorOutputs,
+      ...(resumeId !== undefined ? { resume: resumeId } : {}),
       ...(this.abortController !== null ? { signal: this.abortController.signal } : {}),
     };
     return request;

--- a/src/ad-sdlc-orchestrator/PipelineCheckpointManager.ts
+++ b/src/ad-sdlc-orchestrator/PipelineCheckpointManager.ts
@@ -30,6 +30,12 @@ const DEFAULT_CONFIG: Required<CheckpointConfig> = {
 };
 
 /**
+ * Latest checkpoint schema version. Save paths always emit this; load
+ * paths auto-migrate older payloads in memory.
+ */
+const CURRENT_CHECKPOINT_VERSION = 2 as const;
+
+/**
  * Manages pipeline checkpoint persistence for crash recovery.
  */
 export class PipelineCheckpointManager {
@@ -56,6 +62,11 @@ export class PipelineCheckpointManager {
    * @param scratchpadDir - Scratchpad directory
    * @param completedResults - Stage results accumulated so far
    * @param completedNames - Names of completed stages
+   * @param sdkSessionId - Optional SDK session id from the most recent
+   *   ExecutionAdapter call. Persisted so a resumed stage can pass
+   *   `resume: sessionId` to the SDK and recover its tool-loop context.
+   *   Pass `undefined` (or omit) when the adapter does not surface a
+   *   session id.
    */
   public async saveCheckpoint(
     sessionId: string,
@@ -64,7 +75,8 @@ export class PipelineCheckpointManager {
     userRequest: string,
     scratchpadDir: string,
     completedResults: readonly StageResult[],
-    completedNames: readonly StageName[]
+    completedNames: readonly StageName[],
+    sdkSessionId?: string
   ): Promise<string> {
     const checkpointDir = this.getCheckpointDir(scratchpadDir);
     await fs.promises.mkdir(checkpointDir, { recursive: true });
@@ -74,7 +86,7 @@ export class PipelineCheckpointManager {
     const filePath = path.join(checkpointDir, filename);
 
     const checkpoint: PipelineCheckpoint = {
-      version: 1,
+      version: CURRENT_CHECKPOINT_VERSION,
       sessionId,
       mode,
       projectDir,
@@ -82,6 +94,7 @@ export class PipelineCheckpointManager {
       createdAt: new Date().toISOString(),
       completedStageResults: completedResults,
       completedStageNames: completedNames,
+      ...(sdkSessionId !== undefined && sdkSessionId !== '' ? { sdkSessionId } : {}),
     };
 
     await fs.promises.writeFile(filePath, yaml.dump(checkpoint), 'utf-8');
@@ -128,17 +141,27 @@ export class PipelineCheckpointManager {
         return null;
       }
       const content = await fs.promises.readFile(path.join(checkpointDir, latestFile), 'utf-8');
-      const raw = yaml.load(content) as Record<string, unknown>;
+      const raw = yaml.load(content) as Record<string, unknown> | null;
 
-      if (raw['version'] !== 1 || raw['sessionId'] !== sessionId) {
+      if (raw === null || typeof raw !== 'object') {
         logger.warn('Invalid checkpoint data', {
           agent: 'PipelineCheckpointManager',
           file: latestFile,
+          reason: 'not an object',
         });
         return null;
       }
 
-      return raw as unknown as PipelineCheckpoint;
+      if (raw['sessionId'] !== sessionId) {
+        logger.warn('Invalid checkpoint data', {
+          agent: 'PipelineCheckpointManager',
+          file: latestFile,
+          reason: 'sessionId mismatch',
+        });
+        return null;
+      }
+
+      return migrateCheckpoint(raw, latestFile);
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
         return null;
@@ -212,4 +235,55 @@ export class PipelineCheckpointManager {
   private getCheckpointDir(scratchpadDir: string): string {
     return path.join(scratchpadDir, 'pipeline', 'checkpoints');
   }
+}
+
+/**
+ * Auto-migrate a raw checkpoint payload to the current schema version.
+ *
+ * v1 → v2: rewrites `version` to 2 and leaves `sdkSessionId` undefined.
+ * v2 → v2: returned as-is.
+ *
+ * Unknown / future versions are rejected (returns `null`) so callers can
+ * fall back to a clean restart.
+ *
+ * The on-disk file is left untouched — migrations happen in memory and
+ * the next `saveCheckpoint` call will persist a v2 record.
+ *
+ * @param raw - YAML-decoded checkpoint payload (already validated to be a
+ *   non-null object whose `sessionId` matches the caller's request).
+ * @param sourceFile - Filename for diagnostic logging.
+ */
+function migrateCheckpoint(
+  raw: Record<string, unknown>,
+  sourceFile: string
+): PipelineCheckpoint | null {
+  const rawVersion = raw['version'];
+
+  // v1 (or missing version): augment to v2 with sdkSessionId undefined.
+  if (rawVersion === undefined || rawVersion === 1) {
+    logger.debug('Migrated v1 checkpoint to v2', {
+      agent: 'PipelineCheckpointManager',
+      file: sourceFile,
+    });
+    const migrated = {
+      ...raw,
+      version: CURRENT_CHECKPOINT_VERSION,
+    };
+    delete (migrated as Record<string, unknown>)['sdkSessionId'];
+    return migrated as unknown as PipelineCheckpoint;
+  }
+
+  // v2 (current): pass through.
+  if (rawVersion === 2) {
+    return raw as unknown as PipelineCheckpoint;
+  }
+
+  // Unknown / future schema — refuse to load so the orchestrator can
+  // fall back to a clean session rather than misinterpret the payload.
+  logger.warn('Unsupported checkpoint schema version', {
+    agent: 'PipelineCheckpointManager',
+    file: sourceFile,
+    version: rawVersion,
+  });
+  return null;
 }

--- a/src/ad-sdlc-orchestrator/StageScheduler.ts
+++ b/src/ad-sdlc-orchestrator/StageScheduler.ts
@@ -98,6 +98,37 @@ export function checkDependencies(
 }
 
 /**
+ * Extract the SDK session id from the most recent stage result.
+ *
+ * `invokeAgent` returns a JSON-serialised summary (see
+ * {@link AdsdlcOrchestratorAgent.toStageOutput}) whose `sessionId` field
+ * is the SDK's session id. We walk the result list newest-first looking
+ * for a parseable `sessionId`; the first non-empty match wins.
+ *
+ * Returns `undefined` when no parseable id is present (legacy outputs,
+ * adapters that do not surface a session id, parse failures).
+ * @param results
+ */
+function extractLatestSdkSessionId(results: readonly StageResult[]): string | undefined {
+  for (let i = results.length - 1; i >= 0; i--) {
+    const result = results[i];
+    if (result === undefined || result.output === '') {
+      continue;
+    }
+    try {
+      const parsed = JSON.parse(result.output) as Record<string, unknown>;
+      const candidate = parsed['sessionId'];
+      if (typeof candidate === 'string' && candidate !== '' && candidate !== 'unknown') {
+        return candidate;
+      }
+    } catch {
+      // Output is not JSON (legacy bridge path, error stub, etc.) — keep looking.
+    }
+  }
+  return undefined;
+}
+
+/**
  * Best-effort checkpoint persistence. Failures are logged at WARN and
  * never propagated — checkpoint loss must not abort the pipeline.
  * @param host
@@ -115,6 +146,7 @@ async function saveCheckpoint(
     return;
   }
   try {
+    const sdkSessionId = extractLatestSdkSessionId(results);
     await host.checkpointManager.saveCheckpoint(
       session.sessionId,
       session.mode,
@@ -122,7 +154,8 @@ async function saveCheckpoint(
       session.userRequest,
       session.scratchpadDir,
       results,
-      [...completedStages]
+      [...completedStages],
+      sdkSessionId
     );
   } catch (err) {
     getLogger().warn('Checkpoint save failed (non-critical)', {

--- a/src/ad-sdlc-orchestrator/types.ts
+++ b/src/ad-sdlc-orchestrator/types.ts
@@ -730,10 +730,19 @@ export interface StageSummary {
 /**
  * Pipeline checkpoint capturing progress between stages.
  * Written to disk after each stage completes for crash recovery.
+ *
+ * Schema versioning:
+ * - `version: 1` is the legacy v0.0.1 layout without `sdkSessionId`.
+ * - `version: 2` adds the optional `sdkSessionId` so resumes can pass
+ *   the SDK's `resume: sessionId` to the ExecutionAdapter and preserve
+ *   tool-loop context across mid-stage crashes.
+ *
+ * Loaders auto-migrate v1 payloads to v2 in memory; persisted writes
+ * always emit v2.
  */
 export interface PipelineCheckpoint {
-  /** Checkpoint format version */
-  readonly version: 1;
+  /** Checkpoint format version (1 = legacy, 2 = adds sdkSessionId) */
+  readonly version: 1 | 2;
   /** Session ID this checkpoint belongs to */
   readonly sessionId: string;
   /** Pipeline mode */
@@ -748,4 +757,11 @@ export interface PipelineCheckpoint {
   readonly completedStageResults: readonly StageResult[];
   /** Names of stages confirmed completed */
   readonly completedStageNames: readonly StageName[];
+  /**
+   * SDK session id from the most recent ExecutionAdapter invocation.
+   * Used as `resume: sessionId` when re-entering an interrupted stage to
+   * preserve the SDK's tool-loop context. Absent for v1 payloads and for
+   * adapters that do not surface a session id (e.g. Bedrock/Vertex).
+   */
+  readonly sdkSessionId?: string;
 }

--- a/src/ad-sdlc-orchestrator/types.ts
+++ b/src/ad-sdlc-orchestrator/types.ts
@@ -218,6 +218,16 @@ export interface OrchestratorSession {
   readonly preCompletedStages?: readonly StageName[];
   /** Whether the pipeline runs in local mode (no GitHub dependency) */
   readonly localMode: boolean;
+  /**
+   * SDK session id loaded from a v2 checkpoint when resuming. Forwarded
+   * as `resume: sessionId` on the FIRST stage executed in the resumed
+   * session so the SDK can recover its tool-loop context. Cleared after
+   * the first invocation; subsequent stages run fresh sessions.
+   *
+   * Absent (or empty) for: cold-start sessions, v1 checkpoint resumes,
+   * and adapters that do not surface a session id (Bedrock/Vertex).
+   */
+  readonly resumeSdkSessionId?: string;
 }
 
 /**

--- a/tests/ad-sdlc-orchestrator/PipelineCheckpointManager.test.ts
+++ b/tests/ad-sdlc-orchestrator/PipelineCheckpointManager.test.ts
@@ -1,0 +1,206 @@
+/**
+ * PipelineCheckpointManager — schema_version + sdk_session_id tests.
+ *
+ * Covers the four scenarios required by issue #800:
+ *   1. v1 (legacy) checkpoint loads and is auto-migrated to v2.
+ *   2. v2 checkpoint round-trips (save -> load -> save -> load) preserving
+ *      every field including `sdkSessionId`.
+ *   3. Missing `version` field is treated as v1 and migrated.
+ *   4. v2 save with `sdkSessionId` absent leaves the field unset on load.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import * as yaml from 'js-yaml';
+
+import { PipelineCheckpointManager } from '../../src/ad-sdlc-orchestrator/PipelineCheckpointManager.js';
+import type { PipelineCheckpoint, StageResult } from '../../src/ad-sdlc-orchestrator/types.js';
+
+const SESSION_ID = 'sess-test-800';
+const COMPLETED_NAMES = ['mode_detector', 'collector'] as const;
+
+function makeCompletedResults(): readonly StageResult[] {
+  return [
+    {
+      name: 'mode_detector',
+      agentType: 'mode-detector',
+      status: 'completed',
+      durationMs: 12,
+      output: '{"mode":"greenfield"}',
+      artifacts: [],
+      error: null,
+      retryCount: 0,
+    },
+    {
+      name: 'collector',
+      agentType: 'collector',
+      status: 'completed',
+      durationMs: 34,
+      output: '{}',
+      artifacts: [],
+      error: null,
+      retryCount: 0,
+    },
+  ];
+}
+
+describe('PipelineCheckpointManager — schema_version + sdkSessionId', () => {
+  let scratchpadDir: string;
+  let manager: PipelineCheckpointManager;
+
+  beforeEach(() => {
+    scratchpadDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ckpt-800-'));
+    manager = new PipelineCheckpointManager();
+  });
+
+  afterEach(() => {
+    fs.rmSync(scratchpadDir, { recursive: true, force: true });
+  });
+
+  /**
+   * Helper: write a checkpoint file by hand so we can simulate v1 fixtures.
+   */
+  function writeRawCheckpoint(payload: Record<string, unknown>): void {
+    const dir = path.join(scratchpadDir, 'pipeline', 'checkpoints');
+    fs.mkdirSync(dir, { recursive: true });
+    const filename = `${SESSION_ID}-ckpt-${String(Date.now())}.yaml`;
+    fs.writeFileSync(path.join(dir, filename), yaml.dump(payload), 'utf-8');
+  }
+
+  it('loads a v1 checkpoint and auto-migrates it to v2 with sdkSessionId undefined', async () => {
+    writeRawCheckpoint({
+      version: 1,
+      sessionId: SESSION_ID,
+      mode: 'greenfield',
+      projectDir: '/tmp/proj',
+      userRequest: 'build a thing',
+      createdAt: '2025-01-01T00:00:00.000Z',
+      completedStageResults: makeCompletedResults(),
+      completedStageNames: COMPLETED_NAMES,
+    });
+
+    const loaded = await manager.loadLatestCheckpoint(SESSION_ID, scratchpadDir);
+
+    expect(loaded).not.toBeNull();
+    const ckpt = loaded as PipelineCheckpoint;
+    expect(ckpt.version).toBe(2);
+    expect(ckpt.sdkSessionId).toBeUndefined();
+    expect(ckpt.sessionId).toBe(SESSION_ID);
+    expect(ckpt.completedStageNames).toEqual([...COMPLETED_NAMES]);
+  });
+
+  it('loads a checkpoint missing the version field as v1 (defaults to migrated v2)', async () => {
+    writeRawCheckpoint({
+      // No version field at all — legacy fixture from a hypothetical pre-v1 build.
+      sessionId: SESSION_ID,
+      mode: 'greenfield',
+      projectDir: '/tmp/proj',
+      userRequest: 'build a thing',
+      createdAt: '2025-01-01T00:00:00.000Z',
+      completedStageResults: makeCompletedResults(),
+      completedStageNames: COMPLETED_NAMES,
+    });
+
+    const loaded = await manager.loadLatestCheckpoint(SESSION_ID, scratchpadDir);
+
+    expect(loaded).not.toBeNull();
+    const ckpt = loaded as PipelineCheckpoint;
+    expect(ckpt.version).toBe(2);
+    expect(ckpt.sdkSessionId).toBeUndefined();
+  });
+
+  it('round-trips a v2 checkpoint with sdkSessionId set (save -> load -> save -> load)', async () => {
+    const sdkSessionId = 'sdk-sess-abc-123';
+
+    // First save with sdkSessionId.
+    await manager.saveCheckpoint(
+      SESSION_ID,
+      'greenfield',
+      '/tmp/proj',
+      'build a thing',
+      scratchpadDir,
+      makeCompletedResults(),
+      [...COMPLETED_NAMES],
+      sdkSessionId
+    );
+
+    const firstLoad = await manager.loadLatestCheckpoint(SESSION_ID, scratchpadDir);
+    expect(firstLoad).not.toBeNull();
+    expect(firstLoad?.version).toBe(2);
+    expect(firstLoad?.sdkSessionId).toBe(sdkSessionId);
+
+    // Second save — different SDK session id (e.g. next stage produced a new one).
+    const sdkSessionIdNext = 'sdk-sess-def-456';
+    // Wait 1 ms to guarantee the timestamped filename sorts after the first.
+    await new Promise<void>((resolve) => setTimeout(resolve, 2));
+    await manager.saveCheckpoint(
+      SESSION_ID,
+      'greenfield',
+      '/tmp/proj',
+      'build a thing',
+      scratchpadDir,
+      makeCompletedResults(),
+      [...COMPLETED_NAMES],
+      sdkSessionIdNext
+    );
+
+    const secondLoad = await manager.loadLatestCheckpoint(SESSION_ID, scratchpadDir);
+    expect(secondLoad).not.toBeNull();
+    expect(secondLoad?.version).toBe(2);
+    expect(secondLoad?.sdkSessionId).toBe(sdkSessionIdNext);
+    expect(secondLoad?.completedStageNames).toEqual([...COMPLETED_NAMES]);
+  });
+
+  it('omits sdkSessionId on save when caller passes undefined', async () => {
+    await manager.saveCheckpoint(
+      SESSION_ID,
+      'greenfield',
+      '/tmp/proj',
+      'build a thing',
+      scratchpadDir,
+      makeCompletedResults(),
+      [...COMPLETED_NAMES]
+      // sdkSessionId omitted -- adapter does not surface a session id (e.g. Bedrock).
+    );
+
+    const loaded = await manager.loadLatestCheckpoint(SESSION_ID, scratchpadDir);
+    expect(loaded).not.toBeNull();
+    expect(loaded?.version).toBe(2);
+    expect(loaded?.sdkSessionId).toBeUndefined();
+  });
+
+  it('treats empty-string sdkSessionId as absent (graceful fallback for adapters without session ids)', async () => {
+    await manager.saveCheckpoint(
+      SESSION_ID,
+      'greenfield',
+      '/tmp/proj',
+      'build a thing',
+      scratchpadDir,
+      makeCompletedResults(),
+      [...COMPLETED_NAMES],
+      '' // explicit empty string
+    );
+
+    const loaded = await manager.loadLatestCheckpoint(SESSION_ID, scratchpadDir);
+    expect(loaded).not.toBeNull();
+    expect(loaded?.sdkSessionId).toBeUndefined();
+  });
+
+  it('rejects unknown future schema versions (returns null so caller can cold-restart)', async () => {
+    writeRawCheckpoint({
+      version: 99,
+      sessionId: SESSION_ID,
+      mode: 'greenfield',
+      projectDir: '/tmp/proj',
+      userRequest: 'build a thing',
+      createdAt: '2025-01-01T00:00:00.000Z',
+      completedStageResults: makeCompletedResults(),
+      completedStageNames: COMPLETED_NAMES,
+    });
+
+    const loaded = await manager.loadLatestCheckpoint(SESSION_ID, scratchpadDir);
+    expect(loaded).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #800

## Summary
- Adds schema_version and sdk_session_id fields to Checkpoint type (v2).
- Auto-migrates v1 checkpoints to v2 on load (zero-downtime).
- AdsdlcOrchestratorAgent now passes resume: sdk_session_id to ExecutionAdapter when resuming a stage, preserving SDK tool-loop context across crashes.
- Graceful fallback for endpoints that do not support SDK resume (Bedrock/Vertex): restart from beginning + warning log.

## Test Plan
- 4 unit scenarios (v1 load, v2 load, v1->v2 migrate, sdk_session absent).
- Mid-stage crash simulation integration test.
- npm run build / npm test pass.

## Compatibility
- Existing v1 checkpoints from v0.0.1 users are migrated automatically.
- No breaking changes to checkpoint API for callers reading v1 fields.