### PR TITLE
refactor(worker): migrate WorkerAgent to ExecutionAdapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Migrate `WorkerAgent` off `AgentBridge` to `ExecutionAdapter`. The `setBridge`/`AgentBridge` typed API on `WorkerAgent` is replaced by `setExecutionAdapter`/`ExecutionAdapter`; code generation now records artifacts returned by the adapter (the SDK writes files directly via Edit/Write tools) instead of parsing JSON output from a bridge response. Worker tests use `MockExecutionAdapter` (#835)
 - Separate Database Schema Specification (DBS) from SDS into standalone document (#760)
 - Cut over the eight Doc Writers stages (PRD, SRS, SDP, SDS, UI Spec, Threat Model, Tech Decision, SVP) from `AgentDispatcher` to the SDK `ExecutionAdapter`; routing for these stages no longer consults the `AD_SDLC_USE_SDK_FOR_WORKER` feature flag (#823, AD-13-A, part of #797)
 - Cut over the four Doc Updater + Reader stages (PRD Updater, SRS Updater, SDS Updater, Document Reader) from `AgentDispatcher` to the SDK `ExecutionAdapter`; routing is independent of the `AD_SDLC_USE_SDK_FOR_WORKER` feature flag and disjoint from the AD-13-A Doc Writers cutover set (#824, AD-13-B, part of #797)

--- a/src/worker/WorkerAgent.ts
+++ b/src/worker/WorkerAgent.ts
@@ -27,9 +27,8 @@
  */
 
 import { join, normalize, resolve, relative, isAbsolute } from 'node:path';
-import { mkdir, writeFile as fsWriteFile, unlink } from 'node:fs/promises';
 import type { IAgent } from '../agents/types.js';
-import type { AgentBridge, AgentRequest } from '../agents/AgentBridge.js';
+import type { ExecutionAdapter, StageExecutionRequest } from '../execution/index.js';
 import { getLogger } from '../logging/index.js';
 
 import type {
@@ -141,7 +140,7 @@ export class WorkerAgent implements IAgent {
   private lastTestGenerationResult: TestGenerationResult | null;
   private currentBranchName: string | null;
   private initialized = false;
-  private bridge?: AgentBridge;
+  private executionAdapter?: ExecutionAdapter;
 
   constructor(
     config: WorkerAgentConfig = {},
@@ -191,12 +190,14 @@ export class WorkerAgent implements IAgent {
   }
 
   /**
-   * Set the AgentBridge for AI-backed code generation.
-   * When set, generateCode() delegates to the bridge instead of using stub behavior.
-   * @param bridge - The AgentBridge implementation to use
+   * Set the ExecutionAdapter for AI-backed code generation.
+   * When set, generateCode() delegates to the adapter instead of using stub behavior.
+   * The adapter's underlying SDK writes file changes directly via Edit/Write tools;
+   * the WorkerAgent records the resulting artifacts as file changes.
+   * @param adapter - The ExecutionAdapter implementation to use
    */
-  public setBridge(bridge: AgentBridge): void {
-    this.bridge = bridge;
+  public setExecutionAdapter(adapter: ExecutionAdapter): void {
+    this.executionAdapter = adapter;
   }
 
   /**
@@ -726,11 +727,12 @@ export class WorkerAgent implements IAgent {
   /**
    * Generate code based on work order.
    *
-   * When an AgentBridge is configured (via setBridge()), delegates code
-   * generation to the AI backend. The bridge response is parsed for file
-   * changes which are then applied to disk and recorded.
+   * When an ExecutionAdapter is configured (via setExecutionAdapter()),
+   * delegates code generation to the AI backend. The adapter's underlying
+   * SDK writes files directly via Edit/Write tools; the returned artifacts
+   * are recorded as file changes.
    *
-   * When no bridge is set, falls back to stub behavior: records the target
+   * When no adapter is set, falls back to stub behavior: records the target
    * files from the work order context so that subsequent pipeline steps
    * (test generation, verification) have awareness of the intended scope.
    *
@@ -739,41 +741,40 @@ export class WorkerAgent implements IAgent {
   public async generateCode(context: ExecutionContext): Promise<void> {
     const { workOrder, codeContext } = context;
 
-    // Delegate to bridge when available
-    if (this.bridge) {
-      const request: AgentRequest = {
+    // Delegate to ExecutionAdapter when available
+    if (this.executionAdapter) {
+      const request: StageExecutionRequest = {
         agentType: 'worker',
-        input: this.buildCodeGenPrompt(workOrder, codeContext),
-        scratchpadDir: this.config.resultsPath,
-        projectDir: this.config.projectRoot,
-        priorStageOutputs: {
+        workOrder: this.buildCodeGenPrompt(workOrder, codeContext),
+        priorOutputs: {
           issue: JSON.stringify(workOrder),
           codeContext: JSON.stringify(codeContext),
         },
       };
 
-      const response = await this.bridge.execute(request);
-      if (!response.success) {
-        throw new CodeGenerationError(
-          workOrder.issueId,
-          new Error(response.error ?? 'Unknown code generation error')
-        );
+      const result = await this.executionAdapter.execute(request);
+      if (result.status !== 'success') {
+        const cause = result.error?.message ?? `ExecutionAdapter status=${result.status}`;
+        throw new CodeGenerationError(workOrder.issueId, new Error(cause));
       }
 
-      const changes = this.parseCodeGenOutput(response.output);
-      for (const change of changes) {
-        await this.applyFileChange(change);
+      // SDK has already written files via Edit/Write tools captured in artifacts.
+      // Record each artifact as a file change. We treat artifacts as "modify"
+      // unless the path did not exist before — but determining that retroactively
+      // is unreliable, so we conservatively record as 'modify' (the SDK does
+      // not distinguish Edit vs Write here).
+      for (const artifact of result.artifacts) {
+        const relativePath = this.toProjectRelativePath(artifact.path);
+        if (relativePath === null) {
+          // Skip artifacts outside project root rather than record them.
+          continue;
+        }
         this.recordFileChange({
-          filePath: change.filePath,
-          changeType:
-            change.action === 'delete'
-              ? 'delete'
-              : change.action === 'create'
-                ? 'create'
-                : 'modify',
-          description: change.description,
-          linesAdded: change.linesAdded,
-          linesRemoved: change.linesRemoved,
+          filePath: relativePath,
+          changeType: 'modify',
+          description: artifact.description ?? `Updated by worker: ${relativePath}`,
+          linesAdded: 0,
+          linesRemoved: 0,
         });
       }
       return;
@@ -1517,44 +1518,29 @@ export class WorkerAgent implements IAgent {
   }
 
   /**
-   * Apply a file change to disk, respecting project root boundaries.
-   * Creates parent directories as needed. Validates path traversal.
-   * @param change - The code change to apply
-   * @throws CodeGenerationError if path escapes project root
+   * Normalize an artifact path returned by the ExecutionAdapter into a
+   * project-root-relative path. Returns null when the artifact escapes the
+   * project root (path traversal protection).
+   * @param artifactPath - Path as returned by the adapter (absolute or relative)
+   * @returns Project-relative path, or null if the path is outside the project
    */
-  private async applyFileChange(change: CodeChange): Promise<void> {
-    // Validate file path stays within project root
+  private toProjectRelativePath(artifactPath: string): string | null {
     const projectRoot = resolve(this.config.projectRoot);
-    const targetPath = isAbsolute(change.filePath)
-      ? resolve(change.filePath)
-      : resolve(projectRoot, change.filePath);
+    const targetPath = isAbsolute(artifactPath)
+      ? resolve(artifactPath)
+      : resolve(projectRoot, artifactPath);
     const normalizedTarget = normalize(targetPath);
     const relativePath = relative(projectRoot, normalizedTarget);
 
     if (relativePath.startsWith('..') || isAbsolute(relativePath)) {
-      throw new CodeGenerationError(
-        `path-traversal:${change.filePath}`,
-        new Error(`File path "${change.filePath}" escapes project root`)
-      );
+      getLogger().warn('Artifact path escapes project root, skipping', {
+        agent: 'WorkerAgent',
+        artifactPath,
+      });
+      return null;
     }
 
-    if (change.action === 'delete') {
-      try {
-        await unlink(normalizedTarget);
-      } catch (error) {
-        getLogger().debug('File to delete not found, skipping', {
-          agent: 'WorkerAgent',
-          filePath: change.filePath,
-          error: error instanceof Error ? error.message : String(error),
-        });
-      }
-      return;
-    }
-
-    // create or modify
-    const dir = join(normalizedTarget, '..');
-    await mkdir(dir, { recursive: true });
-    await fsWriteFile(normalizedTarget, change.content ?? '', 'utf-8');
+    return relativePath;
   }
 
   /**

--- a/tests/worker/WorkerAgent.codeGen.test.ts
+++ b/tests/worker/WorkerAgent.codeGen.test.ts
@@ -1,25 +1,52 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { rm, mkdir, readFile } from 'node:fs/promises';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { rm, mkdir } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { WorkerAgent, CodeGenerationError } from '../../src/worker/index.js';
-import type { CodeChange } from '../../src/worker/index.js';
 import type { WorkOrder, CodeContext, ExecutionContext } from '../../src/worker/index.js';
-import type { AgentBridge, AgentRequest, AgentResponse } from '../../src/agents/AgentBridge.js';
+import { MockExecutionAdapter } from '../../src/execution/index.js';
+import type {
+  ArtifactRef,
+  StageExecutionRequest,
+  StageExecutionResult,
+} from '../../src/execution/index.js';
+import { ErrorSeverity } from '../../src/errors/types.js';
 
 /**
- * Create a minimal stub bridge for testing.
+ * Build a successful StageExecutionResult with the given artifacts.
  */
-function createStubBridge(response: AgentResponse): AgentBridge {
+function successResult(artifacts: ArtifactRef[]): StageExecutionResult {
   return {
-    execute: vi.fn().mockResolvedValue(response),
-    supports: vi.fn().mockReturnValue(true),
-    dispose: vi.fn().mockResolvedValue(undefined),
+    status: 'success',
+    artifacts,
+    sessionId: 'mock-session',
+    toolCallCount: 0,
+    tokenUsage: { input: 0, output: 0, cache: 0 },
   };
 }
 
-describe('WorkerAgent - generateCode with bridge delegation', () => {
+/**
+ * Build a failed StageExecutionResult with the given error message.
+ */
+function failedResult(message: string): StageExecutionResult {
+  return {
+    status: 'failed',
+    artifacts: [],
+    sessionId: 'mock-session',
+    toolCallCount: 0,
+    tokenUsage: { input: 0, output: 0, cache: 0 },
+    error: {
+      code: 'EXEC-TEST',
+      message,
+      severity: ErrorSeverity.HIGH,
+      context: {},
+      timestamp: new Date().toISOString(),
+    },
+  };
+}
+
+describe('WorkerAgent - generateCode with ExecutionAdapter delegation', () => {
   let agent: WorkerAgent;
   let testDir: string;
 
@@ -81,91 +108,38 @@ describe('WorkerAgent - generateCode with bridge delegation', () => {
     }
   });
 
-  describe('setBridge', () => {
-    it('should allow setting a bridge', () => {
-      const bridge = createStubBridge({
-        output: '[]',
-        artifacts: [],
-        success: true,
-      });
+  describe('setExecutionAdapter', () => {
+    it('should allow setting an execution adapter', () => {
+      const adapter = new MockExecutionAdapter();
       // Should not throw
-      agent.setBridge(bridge);
+      agent.setExecutionAdapter(adapter);
     });
   });
 
-  describe('generateCode with bridge', () => {
-    it('should delegate to bridge when set', async () => {
-      const bridgeResponse: AgentResponse = {
-        output: JSON.stringify([
-          {
-            filePath: 'src/hello.ts',
-            action: 'create',
-            content: 'export const hello = "world";',
-            description: 'Create hello module',
-            linesAdded: 1,
-            linesRemoved: 0,
-          },
-        ]),
-        artifacts: [],
-        success: true,
-      };
-      const bridge = createStubBridge(bridgeResponse);
-      agent.setBridge(bridge);
+  describe('generateCode with adapter', () => {
+    it('should delegate to adapter when set', async () => {
+      const adapter = new MockExecutionAdapter({
+        defaultResult: successResult([]),
+      });
+      agent.setExecutionAdapter(adapter);
 
       const workOrder = createWorkOrder();
       const ctx = createExecutionContext(workOrder);
       await agent.generateCode(ctx);
 
-      expect(bridge.execute).toHaveBeenCalledOnce();
-      const request = (bridge.execute as ReturnType<typeof vi.fn>).mock.calls[0][0] as AgentRequest;
+      expect(adapter.calls).toHaveLength(1);
+      const request = adapter.calls[0] as StageExecutionRequest;
       expect(request.agentType).toBe('worker');
-      expect(request.projectDir).toBe(testDir);
+      expect(request.workOrder).toContain('ISS-001');
     });
 
-    it('should write files to disk on successful bridge response', async () => {
-      const fileContent = 'export const greet = (name: string) => `Hello ${name}`;';
-      const bridgeResponse: AgentResponse = {
-        output: JSON.stringify([
-          {
-            filePath: 'src/greet.ts',
-            action: 'create',
-            content: fileContent,
-            description: 'Create greet module',
-            linesAdded: 1,
-            linesRemoved: 0,
-          },
+    it('should record file changes from adapter artifacts', async () => {
+      const adapter = new MockExecutionAdapter({
+        defaultResult: successResult([
+          { path: 'src/new-file.ts', description: 'Created new file' },
         ]),
-        artifacts: [],
-        success: true,
-      };
-      const bridge = createStubBridge(bridgeResponse);
-      agent.setBridge(bridge);
-
-      const workOrder = createWorkOrder();
-      const ctx = createExecutionContext(workOrder);
-      await agent.generateCode(ctx);
-
-      const written = await readFile(join(testDir, 'src/greet.ts'), 'utf-8');
-      expect(written).toBe(fileContent);
-    });
-
-    it('should record file changes from bridge output', async () => {
-      const bridgeResponse: AgentResponse = {
-        output: JSON.stringify([
-          {
-            filePath: 'src/new-file.ts',
-            action: 'create',
-            content: 'export const x = 1;',
-            description: 'Create new file',
-            linesAdded: 1,
-            linesRemoved: 0,
-          },
-        ]),
-        artifacts: [],
-        success: true,
-      };
-      const bridge = createStubBridge(bridgeResponse);
-      agent.setBridge(bridge);
+      });
+      agent.setExecutionAdapter(adapter);
 
       const workOrder = createWorkOrder();
       const ctx = createExecutionContext(workOrder);
@@ -174,19 +148,14 @@ describe('WorkerAgent - generateCode with bridge delegation', () => {
       const changes = agent.getFileChanges();
       expect(changes.has('src/new-file.ts')).toBe(true);
       const change = changes.get('src/new-file.ts');
-      expect(change?.changeType).toBe('create');
-      expect(change?.linesAdded).toBe(1);
+      expect(change?.changeType).toBe('modify');
     });
 
-    it('should throw CodeGenerationError when bridge returns failure', async () => {
-      const bridgeResponse: AgentResponse = {
-        output: '',
-        artifacts: [],
-        success: false,
-        error: 'LLM returned an error',
-      };
-      const bridge = createStubBridge(bridgeResponse);
-      agent.setBridge(bridge);
+    it('should throw CodeGenerationError when adapter returns failure', async () => {
+      const adapter = new MockExecutionAdapter({
+        defaultResult: failedResult('LLM returned an error'),
+      });
+      agent.setExecutionAdapter(adapter);
 
       const workOrder = createWorkOrder();
       const ctx = createExecutionContext(workOrder);
@@ -194,31 +163,14 @@ describe('WorkerAgent - generateCode with bridge delegation', () => {
       await expect(agent.generateCode(ctx)).rejects.toThrow(CodeGenerationError);
     });
 
-    it('should handle multiple file changes in one response', async () => {
-      const bridgeResponse: AgentResponse = {
-        output: JSON.stringify([
-          {
-            filePath: 'src/a.ts',
-            action: 'create',
-            content: 'export const a = 1;',
-            description: 'Create a',
-            linesAdded: 1,
-            linesRemoved: 0,
-          },
-          {
-            filePath: 'src/b.ts',
-            action: 'create',
-            content: 'export const b = 2;',
-            description: 'Create b',
-            linesAdded: 1,
-            linesRemoved: 0,
-          },
+    it('should handle multiple artifacts in one response', async () => {
+      const adapter = new MockExecutionAdapter({
+        defaultResult: successResult([
+          { path: 'src/a.ts', description: 'Created a' },
+          { path: 'src/b.ts', description: 'Created b' },
         ]),
-        artifacts: [],
-        success: true,
-      };
-      const bridge = createStubBridge(bridgeResponse);
-      agent.setBridge(bridge);
+      });
+      agent.setExecutionAdapter(adapter);
 
       const workOrder = createWorkOrder();
       const ctx = createExecutionContext(workOrder);
@@ -227,89 +179,62 @@ describe('WorkerAgent - generateCode with bridge delegation', () => {
       const changes = agent.getFileChanges();
       expect(changes.has('src/a.ts')).toBe(true);
       expect(changes.has('src/b.ts')).toBe(true);
-
-      const contentA = await readFile(join(testDir, 'src/a.ts'), 'utf-8');
-      expect(contentA).toBe('export const a = 1;');
-      const contentB = await readFile(join(testDir, 'src/b.ts'), 'utf-8');
-      expect(contentB).toBe('export const b = 2;');
     });
 
-    it('should handle delete action', async () => {
-      // Create a file first
-      await mkdir(join(testDir, 'src'), { recursive: true });
-      const { writeFile } = await import('node:fs/promises');
-      await writeFile(join(testDir, 'src/to-delete.ts'), 'old content');
-
-      const bridgeResponse: AgentResponse = {
-        output: JSON.stringify([
-          {
-            filePath: 'src/to-delete.ts',
-            action: 'delete',
-            description: 'Remove deprecated file',
-            linesAdded: 0,
-            linesRemoved: 5,
-          },
-        ]),
-        artifacts: [],
-        success: true,
-      };
-      const bridge = createStubBridge(bridgeResponse);
-      agent.setBridge(bridge);
-
-      const workOrder = createWorkOrder();
-      const ctx = createExecutionContext(workOrder);
-      await agent.generateCode(ctx);
-
-      expect(existsSync(join(testDir, 'src/to-delete.ts'))).toBe(false);
-      const changes = agent.getFileChanges();
-      expect(changes.get('src/to-delete.ts')?.changeType).toBe('delete');
-    });
-
-    it('should pass work order and code context in bridge request', async () => {
-      const bridgeResponse: AgentResponse = {
-        output: '[]',
-        artifacts: [],
-        success: true,
-      };
-      const bridge = createStubBridge(bridgeResponse);
-      agent.setBridge(bridge);
+    it('should pass work order and code context in prior outputs', async () => {
+      const adapter = new MockExecutionAdapter({
+        defaultResult: successResult([]),
+      });
+      agent.setExecutionAdapter(adapter);
 
       const workOrder = createWorkOrder('ISS-042', 'WO-042');
       const ctx = createExecutionContext(workOrder);
       await agent.generateCode(ctx);
 
-      const request = (bridge.execute as ReturnType<typeof vi.fn>).mock.calls[0][0] as AgentRequest;
-      expect(request.priorStageOutputs.issue).toContain('ISS-042');
-      expect(request.priorStageOutputs.codeContext).toBeDefined();
+      const request = adapter.calls[0] as StageExecutionRequest;
+      expect(request.priorOutputs.issue).toContain('ISS-042');
+      expect(request.priorOutputs.codeContext).toBeDefined();
     });
 
-    it('should reject path traversal attempts', async () => {
-      const bridgeResponse: AgentResponse = {
-        output: JSON.stringify([
-          {
-            filePath: '../../../etc/passwd',
-            action: 'create',
-            content: 'malicious',
-            description: 'Attempt path traversal',
-            linesAdded: 1,
-            linesRemoved: 0,
-          },
+    it('should skip artifacts that escape project root', async () => {
+      const adapter = new MockExecutionAdapter({
+        defaultResult: successResult([
+          { path: '../../../etc/passwd', description: 'Escape attempt' },
+          { path: 'src/legit.ts', description: 'Legitimate file' },
         ]),
-        artifacts: [],
-        success: true,
-      };
-      const bridge = createStubBridge(bridgeResponse);
-      agent.setBridge(bridge);
+      });
+      agent.setExecutionAdapter(adapter);
 
       const workOrder = createWorkOrder();
       const ctx = createExecutionContext(workOrder);
+      await agent.generateCode(ctx);
 
-      await expect(agent.generateCode(ctx)).rejects.toThrow(CodeGenerationError);
+      const changes = agent.getFileChanges();
+      // Out-of-project artifact must be silently skipped
+      expect(changes.has('../../../etc/passwd')).toBe(false);
+      // Legitimate artifact is recorded
+      expect(changes.has('src/legit.ts')).toBe(true);
+    });
+
+    it('should normalize absolute artifact paths to project-relative', async () => {
+      const absoluteArtifact = join(testDir, 'src/abs.ts');
+      const adapter = new MockExecutionAdapter({
+        defaultResult: successResult([{ path: absoluteArtifact }]),
+      });
+      agent.setExecutionAdapter(adapter);
+
+      const workOrder = createWorkOrder();
+      const ctx = createExecutionContext(workOrder);
+      await agent.generateCode(ctx);
+
+      const changes = agent.getFileChanges();
+      // Stored as project-relative
+      expect(changes.has(join('src', 'abs.ts'))).toBe(true);
     });
   });
 
-  describe('generateCode without bridge (fallback)', () => {
-    it('should use stub behavior when no bridge is set', async () => {
+  describe('generateCode without adapter (fallback)', () => {
+    it('should use stub behavior when no adapter is set', async () => {
       const workOrder = createWorkOrder();
       const ctx = createExecutionContext(workOrder);
       await agent.generateCode(ctx);
@@ -412,77 +337,65 @@ describe('WorkerAgent - generateCode with bridge delegation', () => {
     });
   });
 
-  describe('buildCodeGenPrompt (via bridge request)', () => {
+  describe('buildCodeGenPrompt (via adapter request)', () => {
     it('should include issue ID and acceptance criteria in prompt', async () => {
-      const bridgeResponse: AgentResponse = {
-        output: '[]',
-        artifacts: [],
-        success: true,
-      };
-      const bridge = createStubBridge(bridgeResponse);
-      agent.setBridge(bridge);
+      const adapter = new MockExecutionAdapter({
+        defaultResult: successResult([]),
+      });
+      agent.setExecutionAdapter(adapter);
 
       const workOrder = createWorkOrder('ISS-099', 'WO-099');
       const ctx = createExecutionContext(workOrder);
       await agent.generateCode(ctx);
 
-      const request = (bridge.execute as ReturnType<typeof vi.fn>).mock.calls[0][0] as AgentRequest;
-      expect(request.input).toContain('ISS-099');
-      expect(request.input).toContain('Implement feature');
-      expect(request.input).toContain('Add tests');
+      const request = adapter.calls[0] as StageExecutionRequest;
+      expect(request.workOrder).toContain('ISS-099');
+      expect(request.workOrder).toContain('Implement feature');
+      expect(request.workOrder).toContain('Add tests');
     });
 
     it('should include code style information in prompt', async () => {
-      const bridgeResponse: AgentResponse = {
-        output: '[]',
-        artifacts: [],
-        success: true,
-      };
-      const bridge = createStubBridge(bridgeResponse);
-      agent.setBridge(bridge);
+      const adapter = new MockExecutionAdapter({
+        defaultResult: successResult([]),
+      });
+      agent.setExecutionAdapter(adapter);
 
       const workOrder = createWorkOrder();
       const ctx = createExecutionContext(workOrder);
       await agent.generateCode(ctx);
 
-      const request = (bridge.execute as ReturnType<typeof vi.fn>).mock.calls[0][0] as AgentRequest;
-      expect(request.input).toContain('single');
-      expect(request.input).toContain('spaces');
+      const request = adapter.calls[0] as StageExecutionRequest;
+      expect(request.workOrder).toContain('single');
+      expect(request.workOrder).toContain('spaces');
     });
 
     it('should include related file content in prompt', async () => {
-      const bridgeResponse: AgentResponse = {
-        output: '[]',
-        artifacts: [],
-        success: true,
-      };
-      const bridge = createStubBridge(bridgeResponse);
-      agent.setBridge(bridge);
+      const adapter = new MockExecutionAdapter({
+        defaultResult: successResult([]),
+      });
+      agent.setExecutionAdapter(adapter);
 
       const workOrder = createWorkOrder();
       const ctx = createExecutionContext(workOrder);
       await agent.generateCode(ctx);
 
-      const request = (bridge.execute as ReturnType<typeof vi.fn>).mock.calls[0][0] as AgentRequest;
-      expect(request.input).toContain('export const foo = 42;');
+      const request = adapter.calls[0] as StageExecutionRequest;
+      expect(request.workOrder).toContain('export const foo = 42;');
     });
 
     it('should include output format instructions', async () => {
-      const bridgeResponse: AgentResponse = {
-        output: '[]',
-        artifacts: [],
-        success: true,
-      };
-      const bridge = createStubBridge(bridgeResponse);
-      agent.setBridge(bridge);
+      const adapter = new MockExecutionAdapter({
+        defaultResult: successResult([]),
+      });
+      agent.setExecutionAdapter(adapter);
 
       const workOrder = createWorkOrder();
       const ctx = createExecutionContext(workOrder);
       await agent.generateCode(ctx);
 
-      const request = (bridge.execute as ReturnType<typeof vi.fn>).mock.calls[0][0] as AgentRequest;
-      expect(request.input).toContain('Output Format');
-      expect(request.input).toContain('JSON array');
+      const request = adapter.calls[0] as StageExecutionRequest;
+      expect(request.workOrder).toContain('Output Format');
+      expect(request.workOrder).toContain('JSON array');
     });
   });
 });


### PR DESCRIPTION
Closes #835

## Summary
- WorkerAgent now uses ExecutionAdapter for AI-backed code generation instead of AgentBridge.
- Public API: setBridge replaced with setExecutionAdapter (no in-tree callers; only tests used setBridge).
- Internal delegation path replaced: the SDK writes files directly via Edit/Write tools, captured as artifacts; the worker records each artifact as a file change.
- Now-unused applyFileChange helper removed; replaced by toProjectRelativePath for artifact path normalization.
- Tests use MockExecutionAdapter.

## Test Plan
- npm run build (clean).
- npm test for tests/worker (270/270 pass).
- grep -n 'AgentBridge' src/worker/WorkerAgent.ts shows 0 hits.

Two pre-existing failures in tests/doc-audit/audit-docs.cli.test.ts reproduce on develop without these changes and are unrelated.

Prerequisite for #798.