### PR TITLE
refactor(collector): migrate Collector subsystem to ExecutionAdapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Migrate `CollectorAgent`, `LLMExtractor`, and `InvestigationEngine` off `AgentBridge` to `ExecutionAdapter`. All three classes now accept an `ExecutionAdapter` (instead of `AgentBridge`) for AI-backed extraction and investigation question generation. The legacy `isStubBridge` helper is removed; an absent adapter simply disables LLM-backed paths in favor of keyword extraction and template-based questions. LLM JSON payloads are read from the first artifact's `description` (preferred for stubs/tests) or by reading the artifact `path` from disk, matching how the production SDK surfaces output. Collector tests use `MockExecutionAdapter`. Prerequisite for #798 (#836)
 - Migrate `WorkerAgent` off `AgentBridge` to `ExecutionAdapter`. The `setBridge`/`AgentBridge` typed API on `WorkerAgent` is replaced by `setExecutionAdapter`/`ExecutionAdapter`; code generation now records artifacts returned by the adapter (the SDK writes files directly via Edit/Write tools) instead of parsing JSON output from a bridge response. Worker tests use `MockExecutionAdapter` (#835)
 - Separate Database Schema Specification (DBS) from SDS into standalone document (#760)
 - Cut over the eight Doc Writers stages (PRD, SRS, SDP, SDS, UI Spec, Threat Model, Tech Decision, SVP) from `AgentDispatcher` to the SDK `ExecutionAdapter`; routing for these stages no longer consults the `AD_SDLC_USE_SDK_FOR_WORKER` feature flag (#823, AD-13-A, part of #797)

--- a/src/collector/CollectorAgent.ts
+++ b/src/collector/CollectorAgent.ts
@@ -15,7 +15,7 @@
 
 import { randomUUID } from 'node:crypto';
 import type { IAgent } from '../agents/types.js';
-import type { AgentBridge } from '../agents/AgentBridge.js';
+import type { ExecutionAdapter } from '../execution/index.js';
 import { getScratchpad, type CollectedInfo } from '../scratchpad/index.js';
 import { InputParser, type InputParserOptions } from './InputParser.js';
 import { InformationExtractor, type InformationExtractorOptions } from './InformationExtractor.js';
@@ -77,7 +77,7 @@ export class CollectorAgent implements IAgent {
   private session: CollectionSession | null = null;
   private initialized = false;
 
-  constructor(config: CollectorAgentConfig = {}, bridge?: AgentBridge) {
+  constructor(config: CollectorAgentConfig = {}, adapter?: ExecutionAdapter) {
     this.config = { ...DEFAULT_CONFIG, ...config };
 
     const parserOptions: InputParserOptions = {};
@@ -90,11 +90,11 @@ export class CollectorAgent implements IAgent {
     this.inputParser = new InputParser(parserOptions);
     this.extractor = new InformationExtractor(extractorOptions);
 
-    const effectiveBridge = bridge !== undefined && !this.isStubBridge(bridge) ? bridge : null;
+    const effectiveAdapter = adapter ?? null;
 
-    if (effectiveBridge !== null) {
+    if (effectiveAdapter !== null) {
       this.llmExtractor = new LLMExtractor(
-        effectiveBridge,
+        effectiveAdapter,
         this.extractor,
         this.config.scratchpadBasePath
       );
@@ -106,20 +106,10 @@ export class CollectorAgent implements IAgent {
       {
         depth: this.config.investigationDepth,
         maxQuestionsPerRound: this.config.maxQuestionsPerRound,
-        enableLLMQuestions: effectiveBridge !== null,
+        enableLLMQuestions: effectiveAdapter !== null,
       },
-      effectiveBridge
+      effectiveAdapter
     );
-  }
-
-  /**
-   * Check if a bridge is a StubBridge (no-op fallback).
-   * StubBridge always returns `true` from supports() and outputs start with "Stub execution".
-   * We detect it by constructor name to avoid a hard import dependency.
-   * @param bridge
-   */
-  private isStubBridge(bridge: AgentBridge): boolean {
-    return bridge.constructor.name === 'StubBridge';
   }
 
   /**

--- a/src/collector/InvestigationEngine.ts
+++ b/src/collector/InvestigationEngine.ts
@@ -7,8 +7,9 @@
  * @module collector/InvestigationEngine
  */
 
+import { promises as fs } from 'node:fs';
 import { z } from 'zod';
-import type { AgentBridge } from '../agents/AgentBridge.js';
+import type { ExecutionAdapter, StageExecutionResult } from '../execution/index.js';
 import { getLogger } from '../logging/index.js';
 import type {
   InvestigationDepth,
@@ -65,7 +66,7 @@ const LLMQuestionsArraySchema = z.array(LLMQuestionResponseSchema);
  */
 export class InvestigationEngine {
   private readonly config: Required<InvestigationEngineConfig>;
-  private readonly bridge: AgentBridge | null;
+  private readonly adapter: ExecutionAdapter | null;
   private readonly templates: InvestigationTemplates;
   private state: InvestigationState;
   private questionCounter: number;
@@ -74,7 +75,7 @@ export class InvestigationEngine {
 
   constructor(
     config: Partial<InvestigationEngineConfig>,
-    bridge: AgentBridge | null,
+    adapter: ExecutionAdapter | null,
     templates?: InvestigationTemplates
   ) {
     const parsed = InvestigationEngineConfigSchema.parse(config);
@@ -85,7 +86,7 @@ export class InvestigationEngine {
       earlyExitOnHighConfidence: parsed.earlyExitOnHighConfidence,
       enableLLMQuestions: parsed.enableLLMQuestions,
     };
-    this.bridge = bridge;
+    this.adapter = adapter;
     this.templates = templates ?? new InvestigationTemplates();
     this.questionCounter = 0;
     this.totalQuestionsAsked = 0;
@@ -191,7 +192,7 @@ export class InvestigationEngine {
 
     // Generate questions
     let questions: InvestigationQuestion[];
-    if (this.config.enableLLMQuestions && this.bridge !== null) {
+    if (this.config.enableLLMQuestions && this.adapter !== null) {
       questions = await this.generateLLMQuestions(
         phase,
         currentExtraction,
@@ -316,7 +317,7 @@ export class InvestigationEngine {
     try {
       const prompt = this.buildLLMPrompt(phase, extraction, priorAnswers, maxQuestions);
 
-      if (this.bridge === null) {
+      if (this.adapter === null) {
         return this.generateTemplateQuestions(
           phase,
           extraction,
@@ -326,15 +327,13 @@ export class InvestigationEngine {
         );
       }
 
-      const response = await this.bridge.execute({
+      const result = await this.adapter.execute({
         agentType: 'collector',
-        input: prompt,
-        scratchpadDir: '',
-        projectDir: '',
-        priorStageOutputs: {},
+        workOrder: prompt,
+        priorOutputs: {},
       });
 
-      if (!response.success) {
+      if (result.status !== 'success') {
         getLogger().warn('LLM question generation unsuccessful, falling back to templates', {
           agent: 'InvestigationEngine',
           phase,
@@ -348,7 +347,18 @@ export class InvestigationEngine {
         );
       }
 
-      return this.parseLLMQuestions(response.output, phase, roundNumber);
+      const payload = await this.readQuestionsPayload(result);
+      if (payload === null) {
+        return this.generateTemplateQuestions(
+          phase,
+          extraction,
+          priorAnswers,
+          maxQuestions,
+          roundNumber
+        );
+      }
+
+      return this.parseLLMQuestions(payload, phase, roundNumber);
     } catch (error) {
       getLogger().warn('LLM question generation failed, falling back to templates', {
         agent: 'InvestigationEngine',
@@ -464,6 +474,36 @@ Rules:
             : 'requirement',
       };
     });
+  }
+
+  /**
+   * Resolve the JSON questions payload from the adapter result.
+   *
+   * Mirrors the contract used by {@link LLMExtractor.readExtractionPayload}:
+   * the first artifact's `description` (preferred for tests/stubs) holds the
+   * payload inline, otherwise the artifact `path` points to a file written
+   * by the SDK that we read from disk. Returns null when neither channel
+   * produced a payload.
+   * @param result
+   */
+  private async readQuestionsPayload(result: StageExecutionResult): Promise<string | null> {
+    const first = result.artifacts[0];
+    if (first === undefined) {
+      return null;
+    }
+    if (first.description !== undefined && first.description.length > 0) {
+      return first.description;
+    }
+    try {
+      return await fs.readFile(first.path, 'utf8');
+    } catch (error) {
+      getLogger().warn('Failed to read investigation questions artifact from disk', {
+        agent: 'InvestigationEngine',
+        path: first.path,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return null;
+    }
   }
 
   // ===========================================================================

--- a/src/collector/LLMExtractor.ts
+++ b/src/collector/LLMExtractor.ts
@@ -2,13 +2,20 @@
  * LLMExtractor - LLM-backed information extraction with keyword fallback
  *
  * Replaces the keyword-based InformationExtractor with LLM analysis
- * via AgentBridge. Falls back to the keyword-based extractor on failure.
+ * via ExecutionAdapter. Falls back to the keyword-based extractor on failure.
+ *
+ * The adapter is expected to drive an SDK that writes the JSON extraction
+ * result either as the first artifact's `description` (preferred for tests
+ * and stub adapters) or to disk at the artifact `path`. The extractor reads
+ * the result and parses it through the same Zod schema used by the legacy
+ * bridge code path.
  *
  * @packageDocumentation
  */
 
+import { promises as fs } from 'node:fs';
 import { z } from 'zod';
-import type { AgentBridge } from '../agents/AgentBridge.js';
+import type { ExecutionAdapter, StageExecutionResult } from '../execution/index.js';
 import type { InformationExtractor } from './InformationExtractor.js';
 import type { ParsedInput, ExtractionResult } from './types.js';
 import { getLogger } from '../logging/index.js';
@@ -38,12 +45,13 @@ const LLMExtractionResultSchema = z.object({
 type LLMExtractionResult = z.infer<typeof LLMExtractionResultSchema>;
 
 /**
- * LLMExtractor delegates information extraction to an LLM via AgentBridge,
- * with graceful fallback to keyword-based InformationExtractor.
+ * LLMExtractor delegates information extraction to an LLM via
+ * {@link ExecutionAdapter}, with graceful fallback to keyword-based
+ * {@link InformationExtractor}.
  */
 export class LLMExtractor {
   constructor(
-    private readonly bridge: AgentBridge,
+    private readonly adapter: ExecutionAdapter,
     private readonly fallback: InformationExtractor,
     private readonly scratchpadDir: string = '',
     private readonly projectDir: string = ''
@@ -59,19 +67,22 @@ export class LLMExtractor {
    */
   async extract(input: ParsedInput, projectContext?: string): Promise<ExtractionResult> {
     try {
-      const response = await this.bridge.execute({
+      const result = await this.adapter.execute({
         agentType: 'collector',
-        input: this.buildExtractionPrompt(input.combinedContent, projectContext),
-        scratchpadDir: this.scratchpadDir,
-        projectDir: this.projectDir,
-        priorStageOutputs: {},
+        workOrder: this.buildExtractionPrompt(input.combinedContent, projectContext),
+        priorOutputs: this.buildPriorOutputs(projectContext),
       });
 
-      if (!response.success) {
+      if (result.status !== 'success') {
         return this.fallback.extract(input);
       }
 
-      return this.parseExtraction(response.output);
+      const extractionJson = await this.readExtractionPayload(result);
+      if (extractionJson === null) {
+        return this.fallback.extract(input);
+      }
+
+      return this.parseExtraction(extractionJson);
     } catch (error) {
       getLogger().warn('LLM extraction failed, falling back to keyword extractor', {
         agent: 'LLMExtractor',
@@ -79,6 +90,60 @@ export class LLMExtractor {
       });
       return this.fallback.extract(input);
     }
+  }
+
+  /**
+   * Resolve the JSON extraction payload from the adapter result.
+   *
+   * The adapter contract does not return free-form text. Implementations
+   * (production SDK, mocks) communicate the extraction JSON via artifacts:
+   *
+   * 1. Preferred for tests and stubs: the first artifact's `description`
+   *    contains the JSON document inline.
+   * 2. Production SDK: the artifact `path` points to a JSON file written by
+   *    the model via Edit/Write tools — read that file from disk.
+   *
+   * Returns null when neither channel produced a payload.
+   * @param result
+   */
+  private async readExtractionPayload(result: StageExecutionResult): Promise<string | null> {
+    const first = result.artifacts[0];
+    if (first === undefined) {
+      return null;
+    }
+    if (first.description !== undefined && first.description.length > 0) {
+      return first.description;
+    }
+    try {
+      return await fs.readFile(first.path, 'utf8');
+    } catch (error) {
+      getLogger().warn('Failed to read extraction artifact from disk', {
+        agent: 'LLMExtractor',
+        path: first.path,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return null;
+    }
+  }
+
+  /**
+   * Build the `priorOutputs` map forwarded to the adapter so downstream
+   * configuration (scratchpad / project paths, project context) is visible
+   * to the SDK without changing the request shape.
+   * @param projectContext
+   */
+  private buildPriorOutputs(projectContext?: string): Record<string, string> {
+    const out: Record<string, string> = {};
+    if (this.scratchpadDir.length > 0) {
+      out['scratchpadDir'] = this.scratchpadDir;
+    }
+    if (this.projectDir.length > 0) {
+      out['projectDir'] = this.projectDir;
+    }
+    if (projectContext !== undefined && projectContext.length > 0) {
+      out['projectContext'] = projectContext;
+    }
+    return out;
   }
 
   /**

--- a/tests/collector/LLMExtractor.test.ts
+++ b/tests/collector/LLMExtractor.test.ts
@@ -1,17 +1,49 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach } from 'vitest';
 import { LLMExtractor } from '../../src/collector/LLMExtractor.js';
 import { InformationExtractor, InputParser } from '../../src/collector/index.js';
-import type { AgentBridge, AgentRequest, AgentResponse } from '../../src/agents/AgentBridge.js';
+import { MockExecutionAdapter } from '../../src/execution/MockExecutionAdapter.js';
+import type { StageExecutionResult } from '../../src/execution/types.js';
+import { ErrorSeverity } from '../../src/errors/types.js';
 
 /**
- * Create a mock AgentBridge that returns a configurable response.
+ * Build a successful StageExecutionResult whose first artifact carries the
+ * extraction JSON inline via its `description` field.
  */
-function createMockBridge(response: AgentResponse): AgentBridge {
+function successResult(jsonPayload: string): StageExecutionResult {
   return {
-    execute: vi.fn().mockResolvedValue(response),
-    supports: vi.fn().mockReturnValue(true),
-    dispose: vi.fn().mockResolvedValue(undefined),
+    status: 'success',
+    artifacts: [{ path: 'mock://collector/extraction.json', description: jsonPayload }],
+    sessionId: 'mock-session',
+    toolCallCount: 0,
+    tokenUsage: { input: 0, output: 0, cache: 0 },
   };
+}
+
+/**
+ * Build a failed StageExecutionResult.
+ */
+function failedResult(): StageExecutionResult {
+  return {
+    status: 'failed',
+    artifacts: [],
+    sessionId: 'mock-session',
+    toolCallCount: 0,
+    tokenUsage: { input: 0, output: 0, cache: 0 },
+    error: {
+      code: 'EXEC-099',
+      message: 'API error',
+      severity: ErrorSeverity.HIGH,
+      context: {},
+      timestamp: new Date().toISOString(),
+    },
+  };
+}
+
+/**
+ * Build a MockExecutionAdapter whose default response carries the given JSON.
+ */
+function adapterReturning(jsonPayload: string): MockExecutionAdapter {
+  return new MockExecutionAdapter({ defaultResult: successResult(jsonPayload) });
 }
 
 /**
@@ -62,13 +94,8 @@ describe('LLMExtractor', () => {
 
   describe('extract', () => {
     it('should return structured extraction from LLM response', async () => {
-      const bridge = createMockBridge({
-        output: validLLMResponse(),
-        artifacts: [],
-        success: true,
-      });
-
-      const extractor = new LLMExtractor(bridge, fallback);
+      const adapter = adapterReturning(validLLMResponse());
+      const extractor = new LLMExtractor(adapter, fallback);
       const input = parser.combineInputs([
         parser.parseText('Build a task management app with user login'),
       ]);
@@ -89,13 +116,8 @@ describe('LLMExtractor', () => {
     });
 
     it('should convert ambiguities to clarification questions', async () => {
-      const bridge = createMockBridge({
-        output: validLLMResponse(),
-        artifacts: [],
-        success: true,
-      });
-
-      const extractor = new LLMExtractor(bridge, fallback);
+      const adapter = adapterReturning(validLLMResponse());
+      const extractor = new LLMExtractor(adapter, fallback);
       const input = parser.combineInputs([parser.parseText('Some text')]);
 
       const result = await extractor.extract(input);
@@ -108,13 +130,8 @@ describe('LLMExtractor', () => {
     });
 
     it('should calculate overall confidence from requirements', async () => {
-      const bridge = createMockBridge({
-        output: validLLMResponse(),
-        artifacts: [],
-        success: true,
-      });
-
-      const extractor = new LLMExtractor(bridge, fallback);
+      const adapter = adapterReturning(validLLMResponse());
+      const extractor = new LLMExtractor(adapter, fallback);
       const input = parser.combineInputs([parser.parseText('Text')]);
 
       const result = await extractor.extract(input);
@@ -123,51 +140,38 @@ describe('LLMExtractor', () => {
       expect(result.overallConfidence).toBe(0.9);
     });
 
-    it('should pass project context to the prompt', async () => {
-      const bridge = createMockBridge({
-        output: validLLMResponse(),
-        artifacts: [],
-        success: true,
-      });
-
-      const extractor = new LLMExtractor(bridge, fallback);
+    it('should pass project context to the prompt and forward it via priorOutputs', async () => {
+      const adapter = adapterReturning(validLLMResponse());
+      const extractor = new LLMExtractor(adapter, fallback);
       const input = parser.combineInputs([parser.parseText('Build a task app')]);
 
       await extractor.extract(input, 'Enterprise environment');
 
-      const call = (bridge.execute as ReturnType<typeof vi.fn>).mock.calls[0] as [AgentRequest];
-      expect(call[0].input).toContain('Enterprise environment');
-      expect(call[0].agentType).toBe('collector');
+      expect(adapter.calls).toHaveLength(1);
+      const request = adapter.calls[0]!;
+      expect(request.agentType).toBe('collector');
+      expect(request.workOrder).toContain('Enterprise environment');
+      expect(request.priorOutputs['projectContext']).toBe('Enterprise environment');
     });
 
-    it('should set scratchpadDir and projectDir on bridge request', async () => {
-      const bridge = createMockBridge({
-        output: validLLMResponse(),
-        artifacts: [],
-        success: true,
-      });
-
-      const extractor = new LLMExtractor(bridge, fallback, '/scratch', '/project');
+    it('should set scratchpadDir and projectDir on adapter request priorOutputs', async () => {
+      const adapter = adapterReturning(validLLMResponse());
+      const extractor = new LLMExtractor(adapter, fallback, '/scratch', '/project');
       const input = parser.combineInputs([parser.parseText('Text')]);
 
       await extractor.extract(input);
 
-      const call = (bridge.execute as ReturnType<typeof vi.fn>).mock.calls[0] as [AgentRequest];
-      expect(call[0].scratchpadDir).toBe('/scratch');
-      expect(call[0].projectDir).toBe('/project');
+      expect(adapter.calls).toHaveLength(1);
+      const request = adapter.calls[0]!;
+      expect(request.priorOutputs['scratchpadDir']).toBe('/scratch');
+      expect(request.priorOutputs['projectDir']).toBe('/project');
     });
   });
 
   describe('fallback behavior', () => {
-    it('should fall back to keyword extractor when bridge returns failure', async () => {
-      const bridge = createMockBridge({
-        output: '',
-        artifacts: [],
-        success: false,
-        error: 'API error',
-      });
-
-      const extractor = new LLMExtractor(bridge, fallback);
+    it('should fall back to keyword extractor when adapter returns failure', async () => {
+      const adapter = new MockExecutionAdapter({ defaultResult: failedResult() });
+      const extractor = new LLMExtractor(adapter, fallback);
       const input = parser.combineInputs([
         parser.parseText('The system must support user authentication.'),
       ]);
@@ -180,14 +184,19 @@ describe('LLMExtractor', () => {
       expect(result.overallConfidence).toBeLessThanOrEqual(1);
     });
 
-    it('should fall back to keyword extractor when bridge throws', async () => {
-      const bridge: AgentBridge = {
-        execute: vi.fn().mockRejectedValue(new Error('Network error')),
-        supports: vi.fn().mockReturnValue(true),
-        dispose: vi.fn().mockResolvedValue(undefined),
-      };
+    it('should fall back to keyword extractor when adapter throws', async () => {
+      const adapter = new MockExecutionAdapter({
+        handlers: [
+          {
+            match: () => true,
+            respond: () => {
+              throw new Error('Network error');
+            },
+          },
+        ],
+      });
 
-      const extractor = new LLMExtractor(bridge, fallback);
+      const extractor = new LLMExtractor(adapter, fallback);
       const input = parser.combineInputs([parser.parseText('The system must support login.')]);
 
       const result = await extractor.extract(input);
@@ -197,13 +206,8 @@ describe('LLMExtractor', () => {
     });
 
     it('should fall back when LLM output is not valid JSON', async () => {
-      const bridge = createMockBridge({
-        output: 'This is not JSON at all',
-        artifacts: [],
-        success: true,
-      });
-
-      const extractor = new LLMExtractor(bridge, fallback);
+      const adapter = adapterReturning('This is not JSON at all');
+      const extractor = new LLMExtractor(adapter, fallback);
       const input = parser.combineInputs([
         parser.parseText('The system must handle user requests.'),
       ]);
@@ -221,18 +225,32 @@ describe('LLMExtractor', () => {
         requirements: [{ id: 'R-1', text: 'Req', type: 'invalid_type' }],
       });
 
-      const bridge = createMockBridge({
-        output: invalidJson,
-        artifacts: [],
-        success: true,
-      });
-
-      const extractor = new LLMExtractor(bridge, fallback);
+      const adapter = adapterReturning(invalidJson);
+      const extractor = new LLMExtractor(adapter, fallback);
       const input = parser.combineInputs([parser.parseText('The system should process data.')]);
 
       const result = await extractor.extract(input);
 
       expect(result).toBeDefined();
+    });
+
+    it('should fall back when adapter result has no artifacts', async () => {
+      const adapter = new MockExecutionAdapter({
+        defaultResult: {
+          status: 'success',
+          artifacts: [],
+          sessionId: 'mock-session',
+          toolCallCount: 0,
+          tokenUsage: { input: 0, output: 0, cache: 0 },
+        },
+      });
+      const extractor = new LLMExtractor(adapter, fallback);
+      const input = parser.combineInputs([parser.parseText('Some content for analysis.')]);
+
+      const result = await extractor.extract(input);
+
+      expect(result).toBeDefined();
+      expect(result.overallConfidence).toBeGreaterThanOrEqual(0);
     });
   });
 
@@ -241,13 +259,8 @@ describe('LLMExtractor', () => {
       const jsonContent = validLLMResponse();
       const wrappedOutput = `Here is the analysis:\n\n\`\`\`json\n${jsonContent}\n\`\`\`\n\nLet me know if you need more details.`;
 
-      const bridge = createMockBridge({
-        output: wrappedOutput,
-        artifacts: [],
-        success: true,
-      });
-
-      const extractor = new LLMExtractor(bridge, fallback);
+      const adapter = adapterReturning(wrappedOutput);
+      const extractor = new LLMExtractor(adapter, fallback);
       const input = parser.combineInputs([parser.parseText('Build a task app')]);
 
       const result = await extractor.extract(input);
@@ -260,13 +273,8 @@ describe('LLMExtractor', () => {
       const jsonContent = validLLMResponse();
       const wrappedOutput = `Based on my analysis:\n${jsonContent}\nEnd of analysis.`;
 
-      const bridge = createMockBridge({
-        output: wrappedOutput,
-        artifacts: [],
-        success: true,
-      });
-
-      const extractor = new LLMExtractor(bridge, fallback);
+      const adapter = adapterReturning(wrappedOutput);
+      const extractor = new LLMExtractor(adapter, fallback);
       const input = parser.combineInputs([parser.parseText('Build a task app')]);
 
       const result = await extractor.extract(input);
@@ -292,8 +300,8 @@ describe('LLMExtractor', () => {
         ],
       });
 
-      const bridge = createMockBridge({ output: response, artifacts: [], success: true });
-      const extractor = new LLMExtractor(bridge, fallback);
+      const adapter = adapterReturning(response);
+      const extractor = new LLMExtractor(adapter, fallback);
       const input = parser.combineInputs([parser.parseText('Secure app')]);
 
       const result = await extractor.extract(input);
@@ -317,8 +325,8 @@ describe('LLMExtractor', () => {
         ],
       });
 
-      const bridge = createMockBridge({ output: response, artifacts: [], success: true });
-      const extractor = new LLMExtractor(bridge, fallback);
+      const adapter = adapterReturning(response);
+      const extractor = new LLMExtractor(adapter, fallback);
       const input = parser.combineInputs([parser.parseText('Budget app')]);
 
       const result = await extractor.extract(input);
@@ -342,8 +350,8 @@ describe('LLMExtractor', () => {
         ],
       });
 
-      const bridge = createMockBridge({ output: response, artifacts: [], success: true });
-      const extractor = new LLMExtractor(bridge, fallback);
+      const adapter = adapterReturning(response);
+      const extractor = new LLMExtractor(adapter, fallback);
       const input = parser.combineInputs([parser.parseText('App')]);
 
       const result = await extractor.extract(input);
@@ -367,8 +375,8 @@ describe('LLMExtractor', () => {
         ],
       });
 
-      const bridge = createMockBridge({ output: response, artifacts: [], success: true });
-      const extractor = new LLMExtractor(bridge, fallback);
+      const adapter = adapterReturning(response);
+      const extractor = new LLMExtractor(adapter, fallback);
       const input = parser.combineInputs([parser.parseText('App')]);
 
       const result = await extractor.extract(input);
@@ -385,8 +393,8 @@ describe('LLMExtractor', () => {
         requirements: [],
       });
 
-      const bridge = createMockBridge({ output: response, artifacts: [], success: true });
-      const extractor = new LLMExtractor(bridge, fallback);
+      const adapter = adapterReturning(response);
+      const extractor = new LLMExtractor(adapter, fallback);
       const input = parser.combineInputs([parser.parseText('Empty')]);
 
       const result = await extractor.extract(input);
@@ -418,8 +426,8 @@ describe('LLMExtractor', () => {
         ],
       });
 
-      const bridge = createMockBridge({ output: response, artifacts: [], success: true });
-      const extractor = new LLMExtractor(bridge, fallback);
+      const adapter = adapterReturning(response);
+      const extractor = new LLMExtractor(adapter, fallback);
       const input = parser.combineInputs([parser.parseText('App')]);
 
       const result = await extractor.extract(input);
@@ -431,13 +439,8 @@ describe('LLMExtractor', () => {
     });
 
     it('should return empty assumptions and dependencies arrays', async () => {
-      const bridge = createMockBridge({
-        output: validLLMResponse(),
-        artifacts: [],
-        success: true,
-      });
-
-      const extractor = new LLMExtractor(bridge, fallback);
+      const adapter = adapterReturning(validLLMResponse());
+      const extractor = new LLMExtractor(adapter, fallback);
       const input = parser.combineInputs([parser.parseText('App')]);
 
       const result = await extractor.extract(input);
@@ -462,8 +465,8 @@ describe('LLMExtractor', () => {
         ],
       });
 
-      const bridge = createMockBridge({ output: response, artifacts: [], success: true });
-      const extractor = new LLMExtractor(bridge, fallback);
+      const adapter = adapterReturning(response);
+      const extractor = new LLMExtractor(adapter, fallback);
       const input = parser.combineInputs([parser.parseText('Clear app')]);
 
       const result = await extractor.extract(input);


### PR DESCRIPTION
Closes #836

## Summary
- CollectorAgent / LLMExtractor / InvestigationEngine now accept ExecutionAdapter instead of AgentBridge.
- Internal AI delegation switched to adapter.execute() pattern.
- isStubBridge helper replaced with ExecutionAdapter-based check (an absent adapter disables LLM paths).
- Tests use MockExecutionAdapter.

## Test Plan
- npm run build / npm test (no regressions).
- grep -n 'AgentBridge' src/collector/ shows 0 hits in production code.

Prerequisite for #798. Sibling of #835 (Worker).