### PR TITLE
docs(readme): align built-with claim and add v0.1.0 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,35 +7,47 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Removed
+## [0.1.0] - 2026-05-09
 
-- **Breaking**: Delete the dead Bridge / Dispatcher / Registry stack now that all consumer subsystems have migrated to `ExecutionAdapter`. Removed source modules: `src/agents/AgentBridge.ts`, `src/agents/AgentDispatcher.ts`, `src/agents/AgentRegistry.ts`, `src/agents/AgentTypeMapping.ts`, `src/agents/AgentFactory.ts`, `src/agents/bootstrapAgents.ts`, `src/agents/BridgeRegistry.ts`, `src/agents/ExecutionScaffoldGenerator.ts`, and the entire `src/agents/bridges/` directory (`AnthropicApiBridge`, `ClaudeCliSubprocessBridge`, `ClaudeCodeBridge`, `StubBridge`, `agentDefinition`, `index`, `tools`). External consumers importing `AgentBridge`, `AgentDispatcher`, `AgentRegistry`, `AgentFactory`, `BridgeRegistry`, `bootstrapAgents`, `ExecutionScaffoldGenerator`, or any of the four concrete bridge classes from `@ad-sdlc/agents` must migrate to the `ExecutionAdapter` API in `src/execution/`. The `IAgent` interface and per-agent module re-exports remain available. Also removed the `@anthropic-ai/sdk` runtime dependency now that `AnthropicApiBridge` is gone (#798)
+The v0.1.0 release completes the AD-13 cutover: every pipeline stage now routes through the official Claude Agent SDK via a single `ExecutionAdapter`, and the in-tree `AgentBridge` / `AgentDispatcher` / `AgentRegistry` stack has been removed. The 35-stage SDLC pipeline, V&V gates, and traceability matrix are unchanged; tool use, sub-agent delegation, and session management are now handled by the SDK itself. See [`docs/architecture/v0.1-hybrid-pipeline-rfc.md`](docs/architecture/v0.1-hybrid-pipeline-rfc.md) for the architecture rationale and [`docs/architecture/v0.1-migration-guide.md`](docs/architecture/v0.1-migration-guide.md) for migration steps.
 
 ### Added
 
-- `PipelineCheckpointManager` records the SDK `session_id` per stage so a mid-stage crash can resume via the SDK's `resume: sessionId` and recover its tool-loop context. Checkpoint schema is bumped from v1 to v2 with backward-compatible auto-migration (v1 fixtures load as v2 with `sdkSessionId` undefined); adapters that do not surface a session id (e.g. Bedrock/Vertex) gracefully fall back to a clean stage restart (#800)
-- UI Specification Writer agent for generating screen specifications, user flow documents, and design system references from SRS use cases (#770)
-- Document Audit CLI for generated output integrity verification with frontmatter, cross-reference, and traceability checks (#769)
-- Technology Decision Writer agent with parallel pipeline stage for comparative analysis (#762)
-- SVP Writer agent with automated test case derivation from SRS requirements (#761)
-- Threat Model Writer agent for STRIDE/DREAD analysis from SDS (#759)
-- SDP Writer agent for Software Development Plan generation from PRD and SRS (#758)
-- YAML frontmatter metadata on all generated documents with doc_id, version, status, and change history (#756)
-- Doc Index Generator as post-pipeline stage for structured documentation indexing (#742)
+- `ExecutionAdapter` as the single Claude Agent SDK entry point for every pipeline stage; all 35 stages route through it (#797, #798, #799)
+- Hook pipeline for scratchpad auto-capture and telemetry forwarding from SDK tool calls
+- `PipelineStageDefinition` extension with `skills`, `mcpServers`, `maxTurns`, and `permissionMode` fields so each stage can declare its knowledge-layer needs declaratively
+- Pre-load of `claude-config` plugin skills for the `worker` and `pr-reviewer` stages, enabling shared coding-style and review guidelines across consumer projects
+- `.claude/commands/` entries for ad-sdlc operator workflows (pipeline run, stage retry, session inspection)
+- `.mcp.json` with the GitHub MCP server registered out of the box for issue/PR-handling stages
+- `PipelineCheckpointManager` records the SDK `session_id` per stage so a mid-stage crash can resume via the SDK's `resume: sessionId` and recover its tool-loop context. Checkpoint schema is bumped from v1 to v2 with backward-compatible auto-migration; adapters that do not surface a session id (Bedrock/Vertex) gracefully fall back to a clean stage restart (#800)
+- README "Built with Claude Agent SDK" badge, 3-tier architecture mermaid diagram, and Dependencies section that name the single Agent SDK runtime dependency (#801)
 
 ### Changed
 
-- Migrate `src/cli.ts` off `createDefaultBridgeRegistry`/`isClaudeCodeSession` to the standalone execution-environment helpers in `src/execution/env.ts`. The CLI now uses `hasRealExecutionEnvironment()` and `describeExecutionEnvironment()` for its `doctor`, `pipeline --dry-run`, and pipeline pre-check diagnostics, and no longer imports from `src/agents/BridgeRegistry.ts`. With this change, the CLI is no longer a `BridgeRegistry` consumer — the bridge stack has no live consumers in `src/`, unblocking removal of `AgentBridge`/`BridgeRegistry`/bridges in #798 (#838)
-- Migrate `WorkerPoolManager` (controller subsystem) off `BridgeRegistry`/`AgentBridge` to `ExecutionAdapter`. The `setBridgeRegistry`/`executeWithBridge` public surface is replaced by `setExecutionAdapter`/`executeWithAdapter`; worker resolution now goes through `executionAdapter.execute({ agentType: 'worker', ... })` instead of `bridgeRegistry.resolve('worker').execute(req)`. The controller no longer imports `AgentBridge`, `AgentRequest`, `AgentResponse`, or `BridgeRegistry`; it consumes `ExecutionAdapter`, `StageExecutionRequest`, and `StageExecutionResult` from `src/execution/`. WorkerPoolManager tests use `MockExecutionAdapter`. Prerequisite for #798 (#837)
-- Migrate `CollectorAgent`, `LLMExtractor`, and `InvestigationEngine` off `AgentBridge` to `ExecutionAdapter`. All three classes now accept an `ExecutionAdapter` (instead of `AgentBridge`) for AI-backed extraction and investigation question generation. The legacy `isStubBridge` helper is removed; an absent adapter simply disables LLM-backed paths in favor of keyword extraction and template-based questions. LLM JSON payloads are read from the first artifact's `description` (preferred for stubs/tests) or by reading the artifact `path` from disk, matching how the production SDK surfaces output. Collector tests use `MockExecutionAdapter`. Prerequisite for #798 (#836)
-- Migrate `WorkerAgent` off `AgentBridge` to `ExecutionAdapter`. The `setBridge`/`AgentBridge` typed API on `WorkerAgent` is replaced by `setExecutionAdapter`/`ExecutionAdapter`; code generation now records artifacts returned by the adapter (the SDK writes files directly via Edit/Write tools) instead of parsing JSON output from a bridge response. Worker tests use `MockExecutionAdapter` (#835)
-- Separate Database Schema Specification (DBS) from SDS into standalone document (#760)
-- Cut over the eight Doc Writers stages (PRD, SRS, SDP, SDS, UI Spec, Threat Model, Tech Decision, SVP) from `AgentDispatcher` to the SDK `ExecutionAdapter`; routing for these stages no longer consults the `AD_SDLC_USE_SDK_FOR_WORKER` feature flag (#823, AD-13-A, part of #797)
-- Cut over the four Doc Updater + Reader stages (PRD Updater, SRS Updater, SDS Updater, Document Reader) from `AgentDispatcher` to the SDK `ExecutionAdapter`; routing is independent of the `AD_SDLC_USE_SDK_FOR_WORKER` feature flag and disjoint from the AD-13-A Doc Writers cutover set (#824, AD-13-B, part of #797)
-- Cut over the four Analyzer stages (Code Reader, Codebase Analyzer, Doc-Code Comparator, Impact Analyzer) from `AgentDispatcher` to the SDK `ExecutionAdapter`; routing is independent of the `AD_SDLC_USE_SDK_FOR_WORKER` feature flag and disjoint from the AD-13-A and AD-13-B cutover sets (#825, AD-13-C, part of #797)
-- Cut over the six Setup + Collection stages (Project Initializer, Mode Detector, Repo Detector, GitHub Setup, Collector, Issue Reader) from `AgentDispatcher` to the SDK `ExecutionAdapter`; routing is independent of the `AD_SDLC_USE_SDK_FOR_WORKER` feature flag and disjoint from the AD-13-A, AD-13-B, and AD-13-C cutover sets (#826, AD-13-D, part of #797)
-- Cut over the final nine Execution + QA + V&V stages (Controller, Issue Generator, PR Reviewer, CI Fixer, Regression Tester, Stage Verifier, RTM Builder, Validation Agent, Doc Index Generator) from `AgentDispatcher` to the SDK `ExecutionAdapter`; routing is independent of the `AD_SDLC_USE_SDK_FOR_WORKER` feature flag and disjoint from the AD-13-A, AD-13-B, AD-13-C, and AD-13-D cutover sets. With this PR, all 33 cutover-target stages route through `ExecutionAdapter` and the AD-13 cutover (#797) is complete; only the feature-flag-gated `worker` pilot retains a conditional bridge fallback (#827, AD-13-E, completes #797)
-- Slim `AdsdlcOrchestratorAgent` from ~1,443 lines to <=950 by removing the dead dispatcher / bridge plumbing left over after the AD-13 cutover (`_dispatcher` / `_bridgeRegistry` fields, `getDispatcher()` / `getBridgeRegistry()` methods, `executeViaBridge()` branch, `coordinateAgents` / `executeParallel` / `executeSequential` `BridgeRegistry`-backed helpers). Stage-scheduling and approval-gate logic split out into `StageScheduler.ts` and `ApprovalGate.ts`. Public API (`startSession`, `executePipeline`, `loadPriorSession`, `findLatestSession`) signatures are unchanged; the worker stage now routes through the adapter unconditionally and the orchestrator no longer reads `AD_SDLC_USE_SDK_FOR_WORKER` (the env flag plumbing remains in `FeatureFlagsResolver` for other consumers) (#799)
+- `AdsdlcOrchestratorAgent` slimmed from ~1,443 lines to <=950 by removing the dispatcher / bridge plumbing left over after the AD-13 cutover; stage-scheduling and approval-gate logic split out into `StageScheduler.ts` and `ApprovalGate.ts`. Public API (`startSession`, `executePipeline`, `loadPriorSession`, `findLatestSession`) signatures are unchanged (#799)
+- `WorkerPoolManager`, `WorkerAgent`, `CollectorAgent`, `LLMExtractor`, and `InvestigationEngine` migrated off `AgentBridge`/`BridgeRegistry` to `ExecutionAdapter`; their public surfaces now accept an `ExecutionAdapter` and tests use `MockExecutionAdapter` (#835, #836, #837)
+- `src/cli.ts` migrated off `createDefaultBridgeRegistry`/`isClaudeCodeSession` to `hasRealExecutionEnvironment()` and `describeExecutionEnvironment()` from `src/execution/env.ts` for `doctor`, `pipeline --dry-run`, and pipeline pre-check diagnostics (#838)
+- All 33 cutover-target stages (Doc Writers, Doc Updaters, Document Reader, Analyzers, Setup, Collection, Execution, QA, V&V, Doc Index Generator) routed through `ExecutionAdapter` independent of the `AD_SDLC_USE_SDK_FOR_WORKER` feature flag (#823, #824, #825, #826, #827)
+- README architecture section now matches the actual SDK dependency rather than the v0.0.1 wording that pre-dated AD-13 (#801)
+- Database Schema Specification (DBS) emitted as a standalone document alongside the SDS (#760)
+
+### Removed
+
+- **Breaking**: Bridge / Dispatcher / Registry stack removed now that all consumers route through `ExecutionAdapter`. Removed source modules: `src/agents/AgentBridge.ts`, `src/agents/AgentDispatcher.ts`, `src/agents/AgentRegistry.ts`, `src/agents/AgentTypeMapping.ts`, `src/agents/AgentFactory.ts`, `src/agents/bootstrapAgents.ts`, `src/agents/BridgeRegistry.ts`, `src/agents/ExecutionScaffoldGenerator.ts`, and the entire `src/agents/bridges/` directory (`AnthropicApiBridge`, `ClaudeCliSubprocessBridge`, `ClaudeCodeBridge`, `StubBridge`, `agentDefinition`, `index`, `tools`). External consumers importing any of these symbols from `@ad-sdlc/agents` must migrate to the `ExecutionAdapter` API in `src/execution/`. The `IAgent` interface and per-agent module re-exports remain available (#798)
+- **Breaking**: `@anthropic-ai/sdk` runtime dependency removed; replaced by `@anthropic-ai/claude-agent-sdk@^0.2.132` as the only AI runtime dependency (#798)
+
+### Fixed
+
+- Missing YAML frontmatter on `.claude/agents/doc-code-comparator.md` so the agent registry can resolve the doc-code-comparator stage (#AD-04)
+- Naming alignment between the `validation` agent definition and `src/validation-agent/` so V&V stage routing matches the agent registry id (#AD-05)
+
+### Breaking Changes
+
+- Internal: `AgentBridge`, `AgentDispatcher`, `AgentRegistry`, `AgentFactory`, `BridgeRegistry`, `bootstrapAgents`, and `ExecutionScaffoldGenerator` exports are gone. Migrate to `ExecutionAdapter` in `src/execution/`.
+- Pipeline checkpoint schema migrates from v1 to v2 (auto-migrated on load; v1 fixtures load with `sdkSessionId` undefined).
+- Runtime dependency switch: install Claude Agent SDK >= 0.2.132 (now the only `@anthropic-ai/*` package shipped). Consumers depending on `@anthropic-ai/sdk` directly must remove that dependency.
+
+[Migration Guide](docs/architecture/v0.1-migration-guide.md)
 
 ## [0.0.1] - 2025-12-27
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,12 @@
 # AD-SDLC: Agent-Driven Software Development Lifecycle
 
-> **Automate your software development from requirements to deployment using Claude-powered agents.**
+> **Automate your software development from requirements to deployment, built on the [Claude Agent SDK](https://www.npmjs.com/package/@anthropic-ai/claude-agent-sdk).**
 
 [![License: BSD-3-Clause](https://img.shields.io/badge/License-BSD_3--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause)
 [![Node.js](https://img.shields.io/badge/Node.js-18%2B-green.svg)](https://nodejs.org/)
+[![Built with Claude Agent SDK](https://img.shields.io/badge/Built%20with-Claude%20Agent%20SDK-blueviolet)](https://www.npmjs.com/package/@anthropic-ai/claude-agent-sdk)
+
+Every agent stage runs through a single Claude Agent SDK entry point (`ExecutionAdapter`). The 35-stage pipeline, V&V gates, and traceability matrix are AD-SDLC's domain layer on top of the SDK; tool use, sub-agent delegation, and session management are handled by the SDK itself.
 
 ## Quick Start
 
@@ -109,6 +112,30 @@ GitHub Issues → Issue Reader → Controller → Worker → Validation → PR R
 
 ## How it Works
 
+### 3-Tier Architecture
+
+AD-SDLC is structured as three cooperating tiers. The orchestrator owns the pipeline DAG and V&V gates, the execution layer is a single Claude Agent SDK entry point, and the knowledge layer (`.claude/`, MCP servers, claude-config plugin) is consumed by the SDK rather than wired through custom bridges.
+
+```mermaid
+flowchart TB
+    Orch[T1 Orchestrator] -->|stage 단위| Adapter[T2 ExecutionAdapter]
+    Adapter --> SDK[Agent SDK query]
+    Adapter --> Hooks[Hook Pipeline]
+    SDK -.reads.-> Knowledge[T3 .claude/ + plugin]
+    Hooks --> Scratchpad
+    Hooks --> Telemetry
+```
+
+| Tier                          | Responsibility                                    | Implementation                                   |
+| ----------------------------- | ------------------------------------------------- | ------------------------------------------------ |
+| **T1 Pipeline Control Plane** | Stage DAG, checkpoints, V&V gates, domain writers | `src/ad-sdlc-orchestrator/`, `*-writer/`, `vnv/` |
+| **T2 Agent Execution Layer**  | Single SDK entry point, hooks, telemetry bridge   | `src/execution/`                                 |
+| **T3 Knowledge Layer**        | Agent definitions, skills, commands, MCP servers  | `.claude/`, `.mcp.json`, claude-config plugin    |
+
+See [`docs/architecture/v0.1-hybrid-pipeline-rfc.md`](docs/architecture/v0.1-hybrid-pipeline-rfc.md) for the full architecture RFC and [`docs/architecture/v0.1-migration-guide.md`](docs/architecture/v0.1-migration-guide.md) for the v0.0.1 → v0.1.0 migration steps.
+
+### Pipeline Flow
+
 AD-SDLC automates the full software development lifecycle through a coordinated agent pipeline:
 
 1. **Mode Detection**: The system analyzes your project to determine the appropriate pipeline -- Greenfield (new project), Enhancement (existing project), or Import (existing GitHub issues).
@@ -177,6 +204,22 @@ gh auth login
 ```
 
 See [Installation Guide](docs/installation.md) for detailed setup instructions.
+
+### Dependencies
+
+AD-SDLC v0.1 standardizes on the official Claude Agent SDK as the only AI runtime dependency. The legacy raw `@anthropic-ai/sdk` client and the in-tree `AgentBridge`/`AgentDispatcher`/`AgentRegistry` stack were removed in v0.1.0 (#798).
+
+| Package                          | Version    | Role                                                                         |
+| -------------------------------- | ---------- | ---------------------------------------------------------------------------- |
+| `@anthropic-ai/claude-agent-sdk` | `^0.2.132` | Single Agent SDK entry point used by `ExecutionAdapter` for every stage      |
+| `commander`                      | `^14.0.3`  | `ad-sdlc` CLI argument parsing                                               |
+| `inquirer`                       | `^13.4.2`  | Interactive prompts for `ad-sdlc init`                                       |
+| `js-yaml`                        | `^4.1.1`   | Pipeline config and document frontmatter parsing                             |
+| `zod`                            | `^4.4.2`   | Runtime schema validation for agent registry, configs, and checkpoint schema |
+| `ts-morph`                       | `^28.0.0`  | TypeScript AST analysis for the Code Reader / Codebase Analyzer agents       |
+| `chalk`, `dotenv`                | latest     | CLI output and environment loading                                           |
+
+Optional integrations (logging backends, OpenTelemetry exporters, `better-sqlite3`, `ioredis`, `mammoth`, `pdf-parse`) are declared as **optional peer dependencies** so the runtime install stays lean; consumers pull them in only when the matching scratchpad backend or document parser is enabled.
 
 ## Usage
 
@@ -372,6 +415,8 @@ your-project/
 ### Reference
 
 - [System Architecture](docs/system-architecture.md)
+- [v0.1 Hybrid Pipeline RFC](docs/architecture/v0.1-hybrid-pipeline-rfc.md) — 3-tier architecture and Claude Agent SDK adoption rationale
+- [v0.1 Migration Guide](docs/architecture/v0.1-migration-guide.md) — v0.0.1 → v0.1.0 contributor and consumer migration steps
 - [Document Status Definitions](docs/DOCUMENT_STATUS_DEFINITIONS.md)
 - [Document Audit CLI](docs/doc-audit.md) — validate generated PRD/SRS/SDS/... documents for integrity and traceability
 - [PRD-001: Agent-Driven SDLC](docs/PRD-001-agent-driven-sdlc.md)


### PR DESCRIPTION
Closes #801

## Summary

- README "built with" statement reconciled with actual `@anthropic-ai/claude-agent-sdk` dependency (badge + opening sentence + Dependencies section)
- 3-tier architecture mermaid diagram added under "How it Works" (from RFC §3) with the T1/T2/T3 responsibility table
- CHANGELOG `[0.1.0]` section completed (Added / Changed / Removed / Fixed / Breaking Changes); orphan `[Unreleased]` entries promoted into the dated release
- Migration Guide and v0.1 Hybrid Pipeline RFC linked from the Reference section
- `README.ko.md` does not exist in this repo, so the optional Korean sync AC is N/A

## Test Plan

- `npm run build` clean (no TypeScript regressions from the docs touch)
- `npx prettier --write README.md CHANGELOG.md` clean (no further changes)
- mermaid block uses standard `flowchart TB` syntax that renders in GitHub preview
- All added internal links (`docs/architecture/v0.1-hybrid-pipeline-rfc.md`, `docs/architecture/v0.1-migration-guide.md`) resolve to existing files on `develop`

## Acceptance Criteria

- [x] README "built with" statement matches the actual dependency
- [x] 3-tier architecture mermaid diagram added (RFC §3)
- [x] CHANGELOG v0.1.0 section complete (all 5 categories filled)
- [x] Migration Guide link added
- [x] 0 AI/Claude attribution lines
- [x] README.ko.md sync — N/A (file does not exist)