### PR TITLE
feat(orchestrator): add skills/mcpServers/maxTurns/permissionMode to stage definition

### DIFF
--- a/docs/architecture/dual-layer-design.md
+++ b/docs/architecture/dual-layer-design.md
@@ -10,17 +10,17 @@
 
 AD-SDLC uses a **dual-layer architecture** where each specialized agent exists in two complementary forms. This separation isolates deterministic infrastructure concerns from non-deterministic AI reasoning, making each layer independently testable and maintainable.
 
-| Layer | Location | Responsibility |
-|-------|----------|----------------|
-| **Infrastructure** | `src/<agent>/` | State management, file I/O, validation, security, error handling |
-| **Intelligence** | `.claude/agents/<agent>.md` | AI reasoning, content generation, decision making, prompt definitions |
+| Layer              | Location                    | Responsibility                                                        |
+| ------------------ | --------------------------- | --------------------------------------------------------------------- |
+| **Infrastructure** | `src/<agent>/`              | State management, file I/O, validation, security, error handling      |
+| **Intelligence**   | `.claude/agents/<agent>.md` | AI reasoning, content generation, decision making, prompt definitions |
 
 ### Why Two Layers?
 
 The dual-layer design addresses a fundamental tension in AI-augmented systems:
 
 - **Infrastructure code** must be deterministic, testable, and type-safe. It handles file operations, schema validation, state persistence, and error recovery -- concerns that benefit from TypeScript's type system and conventional unit testing.
-- **Intelligence definitions** must be flexible, declarative, and model-aware. They define what an agent *should do* (its role, reasoning strategy, output format) rather than *how* the underlying system executes it.
+- **Intelligence definitions** must be flexible, declarative, and model-aware. They define what an agent _should do_ (its role, reasoning strategy, output format) rather than _how_ the underlying system executes it.
 
 By separating these concerns, a developer can modify AI behavior (adjusting prompts, changing reasoning strategies) without touching infrastructure code, and vice versa.
 
@@ -135,24 +135,24 @@ flowchart LR
 
 This matrix clarifies which layer owns each concern. When deciding where to make a change, consult this table.
 
-| Concern | Infrastructure Layer | Intelligence Layer |
-|---------|:-------------------:|:-----------------:|
-| State management / persistence | X | |
-| File I/O (read/write scratchpad) | X | |
-| Input validation / schema enforcement | X | |
-| Error handling / retry logic | X | |
-| Security (path traversal, secrets) | X | |
-| Agent lifecycle (init/dispose) | X | |
-| Singleton caching | X | |
-| Pipeline stage coordination | X | |
-| AI reasoning strategy | | X |
-| Content generation prompts | | X |
-| Output format instructions | | X |
-| Decision-making heuristics | | X |
-| Tool selection (Read, Write, Bash, etc.) | | X |
-| Few-shot examples | | X |
-| Quality/acceptance criteria | | X |
-| Model preference (opus/sonnet/haiku) | | X |
+| Concern                                  | Infrastructure Layer | Intelligence Layer |
+| ---------------------------------------- | :------------------: | :----------------: |
+| State management / persistence           |          X           |                    |
+| File I/O (read/write scratchpad)         |          X           |                    |
+| Input validation / schema enforcement    |          X           |                    |
+| Error handling / retry logic             |          X           |                    |
+| Security (path traversal, secrets)       |          X           |                    |
+| Agent lifecycle (init/dispose)           |          X           |                    |
+| Singleton caching                        |          X           |                    |
+| Pipeline stage coordination              |          X           |                    |
+| AI reasoning strategy                    |                      |         X          |
+| Content generation prompts               |                      |         X          |
+| Output format instructions               |                      |         X          |
+| Decision-making heuristics               |                      |         X          |
+| Tool selection (Read, Write, Bash, etc.) |                      |         X          |
+| Few-shot examples                        |                      |         X          |
+| Quality/acceptance criteria              |                      |         X          |
+| Model preference (opus/sonnet/haiku)     |                      |         X          |
 
 ---
 
@@ -160,47 +160,47 @@ This matrix clarifies which layer owns each concern. When deciding where to make
 
 All 25 dual-layer agents with their file locations in both layers:
 
-| # | Agent | Infrastructure (`src/`) | Intelligence (`.claude/agents/`) |
-|---|-------|------------------------|----------------------------------|
-| 1 | ad-sdlc-orchestrator | `src/ad-sdlc-orchestrator/index.ts` | `.claude/agents/ad-sdlc-orchestrator.md` |
-| 2 | analysis-orchestrator | `src/analysis-orchestrator/index.ts` | `.claude/agents/analysis-orchestrator.md` |
-| 3 | ci-fixer | `src/ci-fixer/index.ts` | `.claude/agents/ci-fixer.md` |
-| 4 | code-reader | `src/code-reader/index.ts` | `.claude/agents/code-reader.md` |
-| 5 | codebase-analyzer | `src/codebase-analyzer/index.ts` | `.claude/agents/codebase-analyzer.md` |
-| 6 | collector | `src/collector/index.ts` | `.claude/agents/collector.md` |
-| 7 | controller | `src/controller/index.ts` | `.claude/agents/controller.md` |
-| 8 | doc-code-comparator | `src/doc-code-comparator/index.ts` | `.claude/agents/doc-code-comparator.md` |
-| 9 | document-reader | `src/document-reader/index.ts` | `.claude/agents/document-reader.md` |
-| 10 | github-repo-setup | `src/github-repo-setup/index.ts` | `.claude/agents/github-repo-setup.md` |
-| 11 | impact-analyzer | `src/impact-analyzer/index.ts` | `.claude/agents/impact-analyzer.md` |
-| 12 | issue-generator | `src/issue-generator/index.ts` | `.claude/agents/issue-generator.md` |
-| 13 | issue-reader | `src/issue-reader/index.ts` | `.claude/agents/issue-reader.md` |
-| 14 | mode-detector | `src/mode-detector/index.ts` | `.claude/agents/mode-detector.md` |
-| 15 | pr-reviewer | `src/pr-reviewer/index.ts` | `.claude/agents/pr-reviewer.md` |
-| 16 | prd-updater | `src/prd-updater/index.ts` | `.claude/agents/prd-updater.md` |
-| 17 | prd-writer | `src/prd-writer/index.ts` | `.claude/agents/prd-writer.md` |
-| 18 | project-initializer | `src/project-initializer/index.ts` | `.claude/agents/project-initializer.md` |
-| 19 | regression-tester | `src/regression-tester/index.ts` | `.claude/agents/regression-tester.md` |
-| 20 | repo-detector | `src/repo-detector/index.ts` | `.claude/agents/repo-detector.md` |
-| 21 | sds-updater | `src/sds-updater/index.ts` | `.claude/agents/sds-updater.md` |
-| 22 | sds-writer | `src/sds-writer/index.ts` | `.claude/agents/sds-writer.md` |
-| 23 | srs-updater | `src/srs-updater/index.ts` | `.claude/agents/srs-updater.md` |
-| 24 | srs-writer | `src/srs-writer/index.ts` | `.claude/agents/srs-writer.md` |
-| 25 | worker | `src/worker/index.ts` | `.claude/agents/worker.md` |
+| #   | Agent                 | Infrastructure (`src/`)              | Intelligence (`.claude/agents/`)          |
+| --- | --------------------- | ------------------------------------ | ----------------------------------------- |
+| 1   | ad-sdlc-orchestrator  | `src/ad-sdlc-orchestrator/index.ts`  | `.claude/agents/ad-sdlc-orchestrator.md`  |
+| 2   | analysis-orchestrator | `src/analysis-orchestrator/index.ts` | `.claude/agents/analysis-orchestrator.md` |
+| 3   | ci-fixer              | `src/ci-fixer/index.ts`              | `.claude/agents/ci-fixer.md`              |
+| 4   | code-reader           | `src/code-reader/index.ts`           | `.claude/agents/code-reader.md`           |
+| 5   | codebase-analyzer     | `src/codebase-analyzer/index.ts`     | `.claude/agents/codebase-analyzer.md`     |
+| 6   | collector             | `src/collector/index.ts`             | `.claude/agents/collector.md`             |
+| 7   | controller            | `src/controller/index.ts`            | `.claude/agents/controller.md`            |
+| 8   | doc-code-comparator   | `src/doc-code-comparator/index.ts`   | `.claude/agents/doc-code-comparator.md`   |
+| 9   | document-reader       | `src/document-reader/index.ts`       | `.claude/agents/document-reader.md`       |
+| 10  | github-repo-setup     | `src/github-repo-setup/index.ts`     | `.claude/agents/github-repo-setup.md`     |
+| 11  | impact-analyzer       | `src/impact-analyzer/index.ts`       | `.claude/agents/impact-analyzer.md`       |
+| 12  | issue-generator       | `src/issue-generator/index.ts`       | `.claude/agents/issue-generator.md`       |
+| 13  | issue-reader          | `src/issue-reader/index.ts`          | `.claude/agents/issue-reader.md`          |
+| 14  | mode-detector         | `src/mode-detector/index.ts`         | `.claude/agents/mode-detector.md`         |
+| 15  | pr-reviewer           | `src/pr-reviewer/index.ts`           | `.claude/agents/pr-reviewer.md`           |
+| 16  | prd-updater           | `src/prd-updater/index.ts`           | `.claude/agents/prd-updater.md`           |
+| 17  | prd-writer            | `src/prd-writer/index.ts`            | `.claude/agents/prd-writer.md`            |
+| 18  | project-initializer   | `src/project-initializer/index.ts`   | `.claude/agents/project-initializer.md`   |
+| 19  | regression-tester     | `src/regression-tester/index.ts`     | `.claude/agents/regression-tester.md`     |
+| 20  | repo-detector         | `src/repo-detector/index.ts`         | `.claude/agents/repo-detector.md`         |
+| 21  | sds-updater           | `src/sds-updater/index.ts`           | `.claude/agents/sds-updater.md`           |
+| 22  | sds-writer            | `src/sds-writer/index.ts`            | `.claude/agents/sds-writer.md`            |
+| 23  | srs-updater           | `src/srs-updater/index.ts`           | `.claude/agents/srs-updater.md`           |
+| 24  | srs-writer            | `src/srs-writer/index.ts`            | `.claude/agents/srs-writer.md`            |
+| 25  | worker                | `src/worker/index.ts`                | `.claude/agents/worker.md`                |
 
 ### Infrastructure-Only Modules
 
 These `src/` modules provide shared infrastructure without corresponding `.md` definitions:
 
-| Category | Modules |
-|----------|---------|
-| **Core dispatch** | `agents/` (Dispatcher, BridgeRegistry), `cli/`, `config/` |
-| **Pipeline control** | `control-plane/`, `data-plane/`, `state-manager/`, `status/`, `completion/` |
-| **Data and validation** | `schemas/`, `scratchpad/`, `agent-validator/` |
-| **Cross-cutting** | `security/`, `logging/`, `monitoring/`, `telemetry/` |
-| **Error handling** | `errors/`, `error-handler/` |
-| **Utilities** | `utilities/`, `utils/` |
-| **Generators** | `architecture-generator/`, `component-generator/` |
+| Category                | Modules                                                                     |
+| ----------------------- | --------------------------------------------------------------------------- |
+| **Core dispatch**       | `agents/` (Dispatcher, BridgeRegistry), `cli/`, `config/`                   |
+| **Pipeline control**    | `control-plane/`, `data-plane/`, `state-manager/`, `status/`, `completion/` |
+| **Data and validation** | `schemas/`, `scratchpad/`, `agent-validator/`                               |
+| **Cross-cutting**       | `security/`, `logging/`, `monitoring/`, `telemetry/`                        |
+| **Error handling**      | `errors/`, `error-handler/`                                                 |
+| **Utilities**           | `utilities/`, `utils/`                                                      |
+| **Generators**          | `architecture-generator/`, `component-generator/`                           |
 
 ---
 
@@ -231,15 +231,46 @@ flowchart TD
 
 ### Common Scenarios
 
-| Scenario | Layer to Modify | Example |
-|----------|----------------|---------|
-| Change how an agent reasons about input | Intelligence | Edit `.claude/agents/collector.md` to refine extraction instructions |
-| Change output file format or location | Infrastructure | Edit `src/collector/CollectorAgent.ts` to change YAML output path |
-| Add a new validation rule | Infrastructure | Add Zod schema check in `src/collector/InputParser.ts` |
-| Change which tools an agent can use | Intelligence | Update `tools:` list in the `.md` frontmatter |
-| Fix a file write bug | Infrastructure | Fix the write logic in `src/<agent>/` TypeScript code |
-| Improve content quality | Intelligence | Refine instructions and examples in the `.md` definition |
-| Add error recovery logic | Infrastructure | Add try/catch and retry in the TypeScript module |
-| Change model preference | Intelligence | Update `model:` in the `.md` frontmatter |
-| Add a new agent | Both | Create `src/<agent>/index.ts` AND `.claude/agents/<agent>.md` |
-| Change pipeline stage order | Infrastructure | Update stage definitions in `src/ad-sdlc-orchestrator/types.ts` |
+| Scenario                                | Layer to Modify | Example                                                              |
+| --------------------------------------- | --------------- | -------------------------------------------------------------------- |
+| Change how an agent reasons about input | Intelligence    | Edit `.claude/agents/collector.md` to refine extraction instructions |
+| Change output file format or location   | Infrastructure  | Edit `src/collector/CollectorAgent.ts` to change YAML output path    |
+| Add a new validation rule               | Infrastructure  | Add Zod schema check in `src/collector/InputParser.ts`               |
+| Change which tools an agent can use     | Intelligence    | Update `tools:` list in the `.md` frontmatter                        |
+| Fix a file write bug                    | Infrastructure  | Fix the write logic in `src/<agent>/` TypeScript code                |
+| Improve content quality                 | Intelligence    | Refine instructions and examples in the `.md` definition             |
+| Add error recovery logic                | Infrastructure  | Add try/catch and retry in the TypeScript module                     |
+| Change model preference                 | Intelligence    | Update `model:` in the `.md` frontmatter                             |
+| Add a new agent                         | Both            | Create `src/<agent>/index.ts` AND `.claude/agents/<agent>.md`        |
+| Change pipeline stage order             | Infrastructure  | Update stage definitions in `src/ad-sdlc-orchestrator/types.ts`      |
+
+---
+
+## Stage Knowledge-Layer Hints
+
+Each `PipelineStageDefinition` may carry optional Knowledge Layer hints that
+the orchestrator forwards verbatim through `ExecutionAdapter` to the Claude
+Agent SDK `query()` options. They are infrastructure-level configuration —
+they tell the SDK _how_ to run the stage, not _what_ to reason about — so
+they belong in `src/ad-sdlc-orchestrator/types.ts` rather than in any
+`.claude/agents/*.md` frontmatter.
+
+| Field            | Type                                   | SDK option               | Purpose                                                                         |
+| ---------------- | -------------------------------------- | ------------------------ | ------------------------------------------------------------------------------- |
+| `skills`         | `readonly string[]`                    | `options.skills`         | Plugin skills the SDK preloads for this stage (e.g. `['coding-guidelines']`)    |
+| `mcpServers`     | `Record<string, McpServerConfig>`      | `options.mcpServers`     | Inline MCP server definitions; override project-wide `.mcp.json` for this stage |
+| `maxTurns`       | `number`                               | `options.maxTurns`       | Cap the SDK tool-loop turns before the stage is forced to terminate             |
+| `permissionMode` | `'default' \| 'acceptEdits' \| 'plan'` | `options.permissionMode` | Permission posture: prompt (`default`), auto-approve edits, or planning-only    |
+
+All four fields are optional. When omitted (the current case for every
+shipped stage), the orchestrator builds the `StageExecutionRequest`
+without those keys and the SDK uses its built-in defaults — runtime
+behaviour is identical to the pre-AD-18 pipeline. Populating values is
+the scope of follow-up work (see issues AD-19 / AD-21).
+
+The wire is single-direction: `PipelineStageDefinition` →
+`AdsdlcOrchestratorAgent.buildStageExecutionRequest` →
+`StageExecutionRequest` → `SdkExecutionAdapter.execute` →
+`SdkQueryOptions.options`. Each step uses conditional spreads so that
+`undefined` values never appear as keys (required by tsconfig
+`exactOptionalPropertyTypes: true`).

--- a/src/ad-sdlc-orchestrator/AdsdlcOrchestratorAgent.ts
+++ b/src/ad-sdlc-orchestrator/AdsdlcOrchestratorAgent.ts
@@ -637,6 +637,10 @@ export class AdsdlcOrchestratorAgent implements IAgent {
       agentType: stage.agentType,
       workOrder: session.userRequest,
       priorOutputs,
+      ...(stage.skills !== undefined ? { skills: stage.skills } : {}),
+      ...(stage.mcpServers !== undefined ? { mcpServers: stage.mcpServers } : {}),
+      ...(stage.maxTurns !== undefined ? { maxTurns: stage.maxTurns } : {}),
+      ...(stage.permissionMode !== undefined ? { permissionMode: stage.permissionMode } : {}),
       ...(resumeId !== undefined ? { resume: resumeId } : {}),
       ...(this.abortController !== null ? { signal: this.abortController.signal } : {}),
     };

--- a/src/ad-sdlc-orchestrator/types.ts
+++ b/src/ad-sdlc-orchestrator/types.ts
@@ -5,6 +5,7 @@
  * Enhancement, and Import modes. Based on SDS-001 CMP-025 specification.
  */
 
+import type { McpServerConfig } from '../execution/types.js';
 import type { StageVerificationResult } from '../stage-verifier/types.js';
 
 /**
@@ -107,7 +108,13 @@ export type ExecutionStrategy = 'sequential' | 'parallel';
 export type ResumeMode = 'fresh' | 'resume' | 'start_from';
 
 /**
- * Pipeline stage definition
+ * Pipeline stage definition.
+ *
+ * The `skills`, `mcpServers`, `maxTurns`, and `permissionMode` fields are
+ * optional Knowledge Layer hints forwarded by `ExecutionAdapter` to the
+ * Claude Agent SDK `query()` options. Existing stage definitions do not
+ * need to populate them — runtime behaviour is unchanged when omitted
+ * (see ARCH-RFC-001 §4.2 and `docs/architecture/dual-layer-design.md`).
  */
 export interface PipelineStageDefinition {
   /** Stage name identifier */
@@ -122,6 +129,29 @@ export interface PipelineStageDefinition {
   readonly approvalRequired: boolean;
   /** Stages that must complete before this one */
   readonly dependsOn: readonly StageName[];
+  /**
+   * Plugin skills the SDK should preload for this stage (e.g.
+   * `['coding-guidelines']`). Forwarded as `options.skills`.
+   */
+  readonly skills?: readonly string[];
+  /**
+   * MCP servers to expose to the SDK during this stage. Forwarded as
+   * `options.mcpServers`. Inline definitions take precedence over
+   * project-wide `.mcp.json` entries.
+   */
+  readonly mcpServers?: Record<string, McpServerConfig>;
+  /**
+   * Maximum tool-loop turns the SDK may take before terminating the
+   * stage. Forwarded as `options.maxTurns`.
+   */
+  readonly maxTurns?: number;
+  /**
+   * Permission posture passed to the SDK. `'default'` honours the
+   * existing prompt flow, `'acceptEdits'` auto-approves edits, and
+   * `'plan'` enables planning-only mode. Forwarded as
+   * `options.permissionMode`.
+   */
+  readonly permissionMode?: 'default' | 'acceptEdits' | 'plan';
 }
 
 /**

--- a/src/execution/SdkExecutionAdapter.ts
+++ b/src/execution/SdkExecutionAdapter.ts
@@ -15,6 +15,7 @@
  * | `skills`        | options.skills   |                                                |
  * | `mcpServers`    | options.mcpServers |                                              |
  * | `maxTurns`      | options.maxTurns |                                                |
+ * | `permissionMode`| options.permissionMode | `'default' \| 'acceptEdits' \| 'plan'`   |
  * | `resume`        | options.resume   | Continue an earlier session                    |
  * | `signal`        | options.signal   |                                                |
  *
@@ -44,6 +45,7 @@ export interface SdkQueryOptions {
     skills?: readonly string[];
     mcpServers?: Record<string, McpServerConfig>;
     maxTurns?: number;
+    permissionMode?: 'default' | 'acceptEdits' | 'plan';
     resume?: string;
     signal?: AbortSignal;
     hooks?: HookPipeline;
@@ -102,6 +104,9 @@ export interface SdkExecutionAdapterOptions {
   readonly hooks?: HookPipeline;
 }
 
+/**
+ *
+ */
 export class SdkExecutionAdapter implements ExecutionAdapter {
   private readonly loader: SdkLoader;
   private readonly hooks: HookPipeline | undefined;
@@ -113,6 +118,10 @@ export class SdkExecutionAdapter implements ExecutionAdapter {
     this.hooks = options.hooks;
   }
 
+  /**
+   *
+   * @param req
+   */
   async execute(req: StageExecutionRequest): Promise<StageExecutionResult> {
     if (this.disposed) {
       throw new AppError('EXEC-002', 'SdkExecutionAdapter: execute called after dispose', {
@@ -131,6 +140,7 @@ export class SdkExecutionAdapter implements ExecutionAdapter {
       ...(req.skills !== undefined && { skills: req.skills }),
       ...(req.mcpServers !== undefined && { mcpServers: req.mcpServers }),
       ...(req.maxTurns !== undefined && { maxTurns: req.maxTurns }),
+      ...(req.permissionMode !== undefined && { permissionMode: req.permissionMode }),
       ...(req.resume !== undefined && { resume: req.resume }),
       ...(req.signal !== undefined && { signal: req.signal }),
       ...(this.hooks !== undefined && { hooks: this.hooks }),
@@ -178,10 +188,13 @@ export class SdkExecutionAdapter implements ExecutionAdapter {
     };
   }
 
-  // eslint-disable-next-line @typescript-eslint/require-await
+  /**
+   *
+   */
   async dispose(): Promise<void> {
     this.disposed = true;
     this.sdkPromise = null;
+    await Promise.resolve();
   }
 
   private getSdk(): Promise<SdkLike> {
@@ -194,6 +207,7 @@ export class SdkExecutionAdapter implements ExecutionAdapter {
  * Render a prompt that includes the work order and every prior output verbatim.
  * The format is intentionally simple — downstream agents parse the section
  * headers to retrieve specific upstream outputs.
+ * @param req
  */
 export function renderPrompt(req: StageExecutionRequest): string {
   const blocks: string[] = [`# Stage: ${req.agentType}`, '', '## Work order', '', req.workOrder];
@@ -220,6 +234,7 @@ function mapUsage(usage: NonNullable<SdkMessage['usage']>): TokenUsage {
  * Lift any `path:` annotations the agent emitted into ArtifactRefs. The agent
  * convention is one per line as `<path>: <description>`. Lines without that
  * shape are ignored.
+ * @param resultText
  */
 function extractArtifacts(resultText: string): ArtifactRef[] {
   const out: ArtifactRef[] = [];

--- a/src/execution/types.ts
+++ b/src/execution/types.ts
@@ -68,6 +68,7 @@ export interface StageExecutionRequest {
   readonly skills?: readonly string[];
   readonly mcpServers?: Record<string, McpServerConfig>;
   readonly maxTurns?: number;
+  readonly permissionMode?: 'default' | 'acceptEdits' | 'plan';
   readonly resume?: string;
   readonly signal?: AbortSignal;
 }

--- a/tests/execution/SdkExecutionAdapter.test.ts
+++ b/tests/execution/SdkExecutionAdapter.test.ts
@@ -8,7 +8,10 @@ import {
 } from '../../src/execution/SdkExecutionAdapter.js';
 import type { StageExecutionRequest } from '../../src/execution/types.js';
 
-function fakeSdk(messages: readonly SdkMessage[], opts: { onCall?: (q: SdkQueryOptions) => void } = {}): SdkLike {
+function fakeSdk(
+  messages: readonly SdkMessage[],
+  opts: { onCall?: (q: SdkQueryOptions) => void } = {}
+): SdkLike {
   return {
     query(q) {
       opts.onCall?.(q);
@@ -91,6 +94,80 @@ describe('SdkExecutionAdapter', () => {
       expect(captured?.options?.maxTurns).toBe(7);
       expect(captured?.options?.resume).toBe('prior-session');
       expect(captured?.options?.signal).toBe(controller.signal);
+    });
+
+    it('forwards skills only when provided and omits the option otherwise', async () => {
+      let withCaptured: SdkQueryOptions | undefined;
+      let withoutCaptured: SdkQueryOptions | undefined;
+
+      const adapterWith = new SdkExecutionAdapter({
+        loader: async () => fakeSdk(successMessages, { onCall: (q) => (withCaptured = q) }),
+      });
+      await adapterWith.execute({ ...baseRequest, skills: ['coding-guidelines'] });
+      expect(withCaptured?.options?.skills).toEqual(['coding-guidelines']);
+
+      const adapterWithout = new SdkExecutionAdapter({
+        loader: async () => fakeSdk(successMessages, { onCall: (q) => (withoutCaptured = q) }),
+      });
+      await adapterWithout.execute(baseRequest);
+      expect(withoutCaptured?.options).toBeDefined();
+      expect(withoutCaptured?.options).not.toHaveProperty('skills');
+    });
+
+    it('forwards mcpServers only when provided and omits the option otherwise', async () => {
+      let withCaptured: SdkQueryOptions | undefined;
+      let withoutCaptured: SdkQueryOptions | undefined;
+
+      const adapterWith = new SdkExecutionAdapter({
+        loader: async () => fakeSdk(successMessages, { onCall: (q) => (withCaptured = q) }),
+      });
+      await adapterWith.execute({
+        ...baseRequest,
+        mcpServers: { docs: { type: 'http', url: 'https://example.com/mcp' } },
+      });
+      expect(withCaptured?.options?.mcpServers).toEqual({
+        docs: { type: 'http', url: 'https://example.com/mcp' },
+      });
+
+      const adapterWithout = new SdkExecutionAdapter({
+        loader: async () => fakeSdk(successMessages, { onCall: (q) => (withoutCaptured = q) }),
+      });
+      await adapterWithout.execute(baseRequest);
+      expect(withoutCaptured?.options).not.toHaveProperty('mcpServers');
+    });
+
+    it('forwards maxTurns only when provided and omits the option otherwise', async () => {
+      let withCaptured: SdkQueryOptions | undefined;
+      let withoutCaptured: SdkQueryOptions | undefined;
+
+      const adapterWith = new SdkExecutionAdapter({
+        loader: async () => fakeSdk(successMessages, { onCall: (q) => (withCaptured = q) }),
+      });
+      await adapterWith.execute({ ...baseRequest, maxTurns: 12 });
+      expect(withCaptured?.options?.maxTurns).toBe(12);
+
+      const adapterWithout = new SdkExecutionAdapter({
+        loader: async () => fakeSdk(successMessages, { onCall: (q) => (withoutCaptured = q) }),
+      });
+      await adapterWithout.execute(baseRequest);
+      expect(withoutCaptured?.options).not.toHaveProperty('maxTurns');
+    });
+
+    it('forwards permissionMode only when provided and omits the option otherwise', async () => {
+      let withCaptured: SdkQueryOptions | undefined;
+      let withoutCaptured: SdkQueryOptions | undefined;
+
+      const adapterWith = new SdkExecutionAdapter({
+        loader: async () => fakeSdk(successMessages, { onCall: (q) => (withCaptured = q) }),
+      });
+      await adapterWith.execute({ ...baseRequest, permissionMode: 'acceptEdits' });
+      expect(withCaptured?.options?.permissionMode).toBe('acceptEdits');
+
+      const adapterWithout = new SdkExecutionAdapter({
+        loader: async () => fakeSdk(successMessages, { onCall: (q) => (withoutCaptured = q) }),
+      });
+      await adapterWithout.execute(baseRequest);
+      expect(withoutCaptured?.options).not.toHaveProperty('permissionMode');
     });
 
     it('embeds priorOutputs in the prompt forwarded to the SDK (priorOutputs contract)', async () => {


### PR DESCRIPTION
Closes #802

## What

Extend `PipelineStageDefinition` with four optional Knowledge Layer hint
fields and propagate them through the execution layer:

- `skills?: readonly string[]`
- `mcpServers?: Record<string, McpServerConfig>`
- `maxTurns?: number`
- `permissionMode?: 'default' | 'acceptEdits' | 'plan'`

The wire is single-direction:

```
PipelineStageDefinition
  → AdsdlcOrchestratorAgent.buildStageExecutionRequest
  → StageExecutionRequest
  → SdkExecutionAdapter.execute
  → SdkQueryOptions.options
```

## Why

ARCH-RFC-001 §4.2 requires that stages be able to declare claude-config
plugin skills, inline MCP servers, turn caps, and permission posture
declaratively. This is a prerequisite for AD-19 / AD-21 which will
populate concrete values; this PR provides the infrastructure only.

## How

- `src/ad-sdlc-orchestrator/types.ts`: extend interface with four optional
  fields and import `McpServerConfig` from the execution module.
- `src/execution/types.ts`: add `permissionMode` to
  `StageExecutionRequest` (the other three were already present).
- `src/execution/SdkExecutionAdapter.ts`: forward `permissionMode` to
  `options.permissionMode` via the existing conditional-spread pattern
  so undefined values never appear as keys (required by
  `exactOptionalPropertyTypes`).
- `src/ad-sdlc-orchestrator/AdsdlcOrchestratorAgent.ts`:
  `buildStageExecutionRequest` now spreads the four stage fields into
  the `StageExecutionRequest` only when defined.
- `tests/execution/SdkExecutionAdapter.test.ts`: four new scenarios
  assert each field is forwarded when present and omitted otherwise.
- `docs/architecture/dual-layer-design.md`: new "Stage Knowledge-Layer
  Hints" section documenting the wire and field semantics.

## Backward compatibility

All four fields are optional. No shipped stage definition populates
them. Runtime behaviour is unchanged for every existing pipeline.

## Acceptance Criteria

- [x] 4 fields added, all optional
- [x] ExecutionAdapter forwards each field to the SDK without loss
- [x] Existing stage behaviour unchanged (optional fields unfilled)
- [x] Unit tests cover the option mapping (4 scenarios)
- [x] `docs/architecture/dual-layer-design.md` describes the new fields

## Test plan

- `npm run build` — clean
- `npx vitest run tests/execution/ tests/ad-sdlc-orchestrator/` — 215 / 215 pass
- Pre-existing failures in `tests/doc-audit/audit-docs.cli.test.ts` are
  unrelated to this change (verified with `git stash` on develop).

## Out of scope

- Populating real skill / MCP / turn / permission values on shipped
  stage definitions (AD-19, AD-21).
