### PR TITLE
feat(stages): preload claude-config plugin skills on worker/pr-reviewer/ci-fixer

### DIFF
--- a/src/ad-sdlc-orchestrator/AdsdlcOrchestratorAgent.ts
+++ b/src/ad-sdlc-orchestrator/AdsdlcOrchestratorAgent.ts
@@ -10,6 +10,7 @@
 
 import { randomUUID } from 'node:crypto';
 import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
 import * as path from 'node:path';
 
 import type { IAgent } from '../agents/types.js';
@@ -124,7 +125,54 @@ export class AdsdlcOrchestratorAgent implements IAgent {
   async initialize(): Promise<void> {
     if (this.initialized) return;
     await loadYaml();
+    await this.warnIfClaudeConfigPluginMissing();
     this.initialized = true;
+  }
+
+  /**
+   * Emit a one-time warning when the `claude-config` plugin directory is not
+   * found in the user's Claude home. Stage definitions preload skills from
+   * that plugin (see `WORKER_SKILLS`, `PR_REVIEWER_SKILLS`); without it, the
+   * SDK silently skips the unknown skill names and pipelines run without
+   * the coding-standards / review heuristics that would otherwise be
+   * injected. The warning surfaces this gap so operators can install the
+   * plugin if they want the full behaviour.
+   *
+   * Failures to stat the directory are themselves logged at debug level
+   * and do not block initialization.
+   */
+  private async warnIfClaudeConfigPluginMissing(): Promise<void> {
+    const pluginDir = path.join(os.homedir(), '.claude', 'plugins', 'claude-config');
+    try {
+      const stat = await fs.stat(pluginDir);
+      if (!stat.isDirectory()) {
+        getLogger().warn('claude-config plugin path exists but is not a directory', {
+          agent: 'AdsdlcOrchestratorAgent',
+          pluginDir,
+        });
+      }
+    } catch (err: unknown) {
+      const code =
+        typeof err === 'object' && err !== null && 'code' in err
+          ? (err as { code?: string }).code
+          : undefined;
+      if (code === 'ENOENT') {
+        getLogger().warn(
+          'claude-config plugin not found; preload skills will be skipped by the SDK',
+          {
+            agent: 'AdsdlcOrchestratorAgent',
+            pluginDir,
+            hint: 'Install via: /plugins install claude-config',
+          }
+        );
+      } else {
+        getLogger().debug('claude-config plugin probe failed', {
+          agent: 'AdsdlcOrchestratorAgent',
+          pluginDir,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
   }
 
   /**

--- a/src/ad-sdlc-orchestrator/index.ts
+++ b/src/ad-sdlc-orchestrator/index.ts
@@ -73,6 +73,9 @@ export {
   GREENFIELD_STAGES,
   ENHANCEMENT_STAGES,
   IMPORT_STAGES,
+  WORKER_SKILLS,
+  PR_REVIEWER_SKILLS,
+  CI_FIXER_SKILLS,
 } from './types.js';
 
 // Error exports

--- a/src/ad-sdlc-orchestrator/types.ts
+++ b/src/ad-sdlc-orchestrator/types.ts
@@ -380,6 +380,41 @@ export const DEFAULT_ORCHESTRATOR_CONFIG: Required<OrchestratorConfig> = {
 };
 
 /**
+ * Plugin skills the SDK should preload for the `worker` stage agent.
+ *
+ * These names resolve to skills published by the
+ * [`claude-config`](https://github.com/kcenon/claude-config) plugin and are
+ * forwarded to the SDK as `options.skills`. When the plugin is not enabled,
+ * the SDK skips the unknown skill names (graceful degradation) — see
+ * `AdsdlcOrchestratorAgent.warnIfClaudeConfigPluginMissing`.
+ */
+export const WORKER_SKILLS: readonly string[] = ['coding-guidelines', 'security-audit'];
+
+/**
+ * Plugin skills the SDK should preload for the `pr-reviewer` stage agent.
+ *
+ * Provides reviewer-side coverage for code quality, PR review heuristics, and
+ * security scanning. Forwarded to the SDK as `options.skills`. See
+ * {@link WORKER_SKILLS} for graceful-degradation behaviour when the plugin
+ * is not installed.
+ */
+export const PR_REVIEWER_SKILLS: readonly string[] = [
+  'pr-review',
+  'security-audit',
+  'code-quality',
+];
+
+/**
+ * Plugin skills the SDK should preload for the `ci-fixer` agent. The
+ * `ci-fixer` agent is invoked outside the pipeline stage flow (delegated by
+ * `pr-reviewer` on persistent CI failures) and therefore has no
+ * `PipelineStageDefinition` entry. Consumers that drive `ci-fixer` through
+ * the SDK adapter directly should wire this constant into their stage
+ * execution request as `skills`.
+ */
+export const CI_FIXER_SKILLS: readonly string[] = ['ci-debugging'];
+
+/**
  * Greenfield pipeline stage definitions
  */
 export const GREENFIELD_STAGES: readonly PipelineStageDefinition[] = [
@@ -511,6 +546,7 @@ export const GREENFIELD_STAGES: readonly PipelineStageDefinition[] = [
     parallel: true,
     approvalRequired: false,
     dependsOn: ['orchestration'],
+    skills: WORKER_SKILLS,
   },
   {
     name: 'validation-agent',
@@ -527,6 +563,7 @@ export const GREENFIELD_STAGES: readonly PipelineStageDefinition[] = [
     parallel: false,
     approvalRequired: false,
     dependsOn: ['validation-agent'],
+    skills: PR_REVIEWER_SKILLS,
   },
   {
     name: 'doc_indexing',
@@ -633,6 +670,7 @@ export const ENHANCEMENT_STAGES: readonly PipelineStageDefinition[] = [
     parallel: true,
     approvalRequired: false,
     dependsOn: ['orchestration'],
+    skills: WORKER_SKILLS,
   },
   {
     name: 'regression_testing',
@@ -657,6 +695,7 @@ export const ENHANCEMENT_STAGES: readonly PipelineStageDefinition[] = [
     parallel: false,
     approvalRequired: false,
     dependsOn: ['validation-agent'],
+    skills: PR_REVIEWER_SKILLS,
   },
   {
     name: 'doc_indexing',
@@ -698,6 +737,7 @@ export const IMPORT_STAGES: readonly PipelineStageDefinition[] = [
     parallel: true,
     approvalRequired: false,
     dependsOn: ['orchestration'],
+    skills: WORKER_SKILLS,
   },
   {
     name: 'validation-agent',
@@ -714,6 +754,7 @@ export const IMPORT_STAGES: readonly PipelineStageDefinition[] = [
     parallel: false,
     approvalRequired: false,
     dependsOn: ['validation-agent'],
+    skills: PR_REVIEWER_SKILLS,
   },
 ];
 

--- a/tests/ad-sdlc-orchestrator/AdsdlcOrchestratorAgent.test.ts
+++ b/tests/ad-sdlc-orchestrator/AdsdlcOrchestratorAgent.test.ts
@@ -39,6 +39,9 @@ import {
   GREENFIELD_STAGES,
   ENHANCEMENT_STAGES,
   IMPORT_STAGES,
+  WORKER_SKILLS,
+  PR_REVIEWER_SKILLS,
+  CI_FIXER_SKILLS,
 } from '../../src/ad-sdlc-orchestrator/types.js';
 import type {
   ApprovalDecision,
@@ -1316,6 +1319,87 @@ describe('IMPORT_STAGES', () => {
     expect(stageMap.get('orchestration')).toBe('controller');
     expect(stageMap.get('implementation')).toBe('worker');
     expect(stageMap.get('review')).toBe('pr-reviewer');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Plugin skill preload (Issue #803)
+// ---------------------------------------------------------------------------
+
+describe('claude-config plugin skills preload', () => {
+  it('exposes the expected skill name constants', () => {
+    expect(WORKER_SKILLS).toEqual(['coding-guidelines', 'security-audit']);
+    expect(PR_REVIEWER_SKILLS).toEqual(['pr-review', 'security-audit', 'code-quality']);
+    expect(CI_FIXER_SKILLS).toEqual(['ci-debugging']);
+  });
+
+  it.each([
+    ['GREENFIELD_STAGES', GREENFIELD_STAGES],
+    ['ENHANCEMENT_STAGES', ENHANCEMENT_STAGES],
+    ['IMPORT_STAGES', IMPORT_STAGES],
+  ])('declares worker skills on the implementation stage of %s', (_label, stages) => {
+    const worker = stages.find((s) => s.agentType === 'worker');
+    expect(worker).toBeDefined();
+    expect(worker?.skills).toEqual(WORKER_SKILLS);
+  });
+
+  it.each([
+    ['GREENFIELD_STAGES', GREENFIELD_STAGES],
+    ['ENHANCEMENT_STAGES', ENHANCEMENT_STAGES],
+    ['IMPORT_STAGES', IMPORT_STAGES],
+  ])('declares pr-reviewer skills on the review stage of %s', (_label, stages) => {
+    const reviewer = stages.find((s) => s.agentType === 'pr-reviewer');
+    expect(reviewer).toBeDefined();
+    expect(reviewer?.skills).toEqual(PR_REVIEWER_SKILLS);
+  });
+
+  it('keeps the skills field readonly so callers cannot mutate the shared constant', () => {
+    // Compile-time invariant: PipelineStageDefinition.skills is `readonly
+    // string[]`. Verify at runtime that the constants are also frozen-like
+    // (each entry is a string, mutation would surface in TS via `readonly`).
+    for (const skill of WORKER_SKILLS) expect(typeof skill).toBe('string');
+    for (const skill of PR_REVIEWER_SKILLS) expect(typeof skill).toBe('string');
+  });
+
+  it('forwards stage.skills through buildStageExecutionRequest', () => {
+    class ProbeOrchestrator extends AdsdlcOrchestratorAgent {
+      probe(
+        stage: PipelineStageDefinition,
+        session: OrchestratorSession
+      ): ReturnType<AdsdlcOrchestratorAgent['buildStageExecutionRequest']> {
+        return this.buildStageExecutionRequest(stage, session);
+      }
+    }
+
+    const orchestrator = new ProbeOrchestrator();
+    const session: OrchestratorSession = {
+      sessionId: 'probe-session',
+      projectDir: '/tmp/probe',
+      userRequest: 'probe',
+      mode: 'greenfield',
+      startedAt: new Date().toISOString(),
+      status: 'running',
+      stageResults: [],
+      scratchpadDir: '/tmp/probe/.ad-sdlc/scratchpad',
+      localMode: false,
+    };
+
+    const workerStage = GREENFIELD_STAGES.find((s) => s.agentType === 'worker');
+    const reviewerStage = GREENFIELD_STAGES.find((s) => s.agentType === 'pr-reviewer');
+    expect(workerStage).toBeDefined();
+    expect(reviewerStage).toBeDefined();
+
+    const workerReq = orchestrator.probe(workerStage as PipelineStageDefinition, session);
+    expect(workerReq.skills).toEqual(WORKER_SKILLS);
+
+    const reviewerReq = orchestrator.probe(reviewerStage as PipelineStageDefinition, session);
+    expect(reviewerReq.skills).toEqual(PR_REVIEWER_SKILLS);
+
+    // Stages without skills should still produce a request with no skills key.
+    const initStage = GREENFIELD_STAGES.find((s) => s.name === 'initialization');
+    expect(initStage).toBeDefined();
+    const initReq = orchestrator.probe(initStage as PipelineStageDefinition, session);
+    expect(initReq.skills).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
Closes #803

## What

Populate the optional `skills` field on the `worker` and `pr-reviewer`
stages of the three pipeline stage definitions (`GREENFIELD_STAGES`,
`ENHANCEMENT_STAGES`, `IMPORT_STAGES`) so the SDK auto-injects
claude-config plugin skill content into the corresponding subagent
contexts.

| Stage agent | Preloaded skills |
|---|---|
| `worker` | `coding-guidelines`, `security-audit` |
| `pr-reviewer` | `pr-review`, `security-audit`, `code-quality` |
| `ci-fixer` | `ci-debugging` (exposed as `CI_FIXER_SKILLS` constant — see scope note below) |

## Why

ARCH-RFC-001 §3 T3 requires that the Knowledge Layer be coupled to
agents from outside the code path. The `PipelineStageDefinition.skills`
field added in #802 is the wiring; this PR is the declarative
activation that lets `worker` apply coding standards and security
heuristics consistently and lets `pr-reviewer` apply review-time
quality gates without those rules being baked into the agent prompt
files.

## How

- Added `WORKER_SKILLS`, `PR_REVIEWER_SKILLS`, and `CI_FIXER_SKILLS`
  exported constants in `src/ad-sdlc-orchestrator/types.ts`.
- Set `skills: WORKER_SKILLS` on the `implementation` stage and
  `skills: PR_REVIEWER_SKILLS` on the `review` stage in all three
  pipeline definitions.
- Re-exported the three constants from
  `src/ad-sdlc-orchestrator/index.ts` for downstream consumers.
- Added a one-time `warnIfClaudeConfigPluginMissing` probe in
  `AdsdlcOrchestratorAgent.initialize()` that logs a warning if
  `~/.claude/plugins/claude-config/` is absent. Failures to stat the
  directory degrade to debug-level logging.
- Added 9 assertions covering: constant values, skill-array presence
  on every pipeline's worker/reviewer stage, and end-to-end
  propagation through `buildStageExecutionRequest` (stages without
  `skills` continue to produce a request with no `skills` key,
  preserving the `exactOptionalPropertyTypes` contract).

## Where

- `src/ad-sdlc-orchestrator/types.ts` — stage definitions + constants
- `src/ad-sdlc-orchestrator/index.ts` — public exports
- `src/ad-sdlc-orchestrator/AdsdlcOrchestratorAgent.ts` — plugin probe
- `tests/ad-sdlc-orchestrator/AdsdlcOrchestratorAgent.test.ts` — tests

## Out of scope (acceptance-criteria gaps explicitly noted)

1. **"≥10% ESLint improvement on worker artifacts"** AC — this is a
   longitudinal quality target measured across many pipelines, not a
   single-PR deliverable. This PR enables future measurement by
   getting the skills into the SDK option flow; the metrics harness
   itself is out of scope.
2. **CI workflow `/plugins install claude-config@<version>` step** —
   no existing pattern for installing claude-config inside GitHub
   Actions, and the plugin install mechanism is interactive. Skipped
   per the scope-reduction guidance; if the plugin is missing in CI,
   the SDK silently skips the unknown skill names and tests still pass
   (verified locally).
3. **`ci-fixer` stage `skills` field** — `ci-fixer` is invoked outside
   the pipeline stage definitions (delegated by `pr-reviewer` on
   persistent CI failures via `CIFixHandoff`) and therefore has no
   `PipelineStageDefinition` entry to populate. The `CI_FIXER_SKILLS`
   constant is exported so callers that drive `ci-fixer` through the
   SDK adapter directly can wire it into their stage execution
   request as `skills`.
4. **claude-config plugin changes** — out of scope per issue body
   (different repo).
5. **Skills on stages other than worker/pr-reviewer/ci-fixer** —
   reserved for separate issues per the issue body.

## Verification

- `npm run build` — clean.
- `npm test` — 6447 passed, 2 pre-existing failures in
  `tests/doc-audit/audit-docs.cli.test.ts` that reproduce on `develop`
  unchanged (verified by checking out `develop` and running the same
  test file).
- Targeted run of new assertions:
  `vitest run tests/ad-sdlc-orchestrator/AdsdlcOrchestratorAgent.test.ts -t "skills preload"`
  — 9 passed.
