### PR TITLE
fix(regression-tester): stop reporting passed without running tests

### DIFF
--- a/src/regression-tester/RegressionTesterAgent.ts
+++ b/src/regression-tester/RegressionTesterAgent.ts
@@ -594,9 +594,10 @@ export class RegressionTesterAgent implements IAgent {
   ): TestExecutionSummary {
     const results: TestResult[] = [];
     const startTime = Date.now();
-    let passed = 0;
+    const passed = 0;
     const failed = 0;
     let skipped = 0;
+    let notRun = 0;
 
     for (const test of affectedTests) {
       if (this.config.maxTests > 0 && results.length >= this.config.maxTests) {
@@ -604,7 +605,7 @@ export class RegressionTesterAgent implements IAgent {
       }
 
       const testStartTime = Date.now();
-      let status: 'passed' | 'failed' | 'skipped' | 'error' = 'passed';
+      let status: 'passed' | 'failed' | 'skipped' | 'error' | 'not-run';
       const errorMessage: string | null = null;
 
       // Check if test file exists in discovered tests
@@ -613,9 +614,11 @@ export class RegressionTesterAgent implements IAgent {
         status = 'skipped';
         skipped++;
       } else {
-        // In real implementation, this would run the actual test
-        // For now, we mark as passed (test framework integration needed)
-        passed++;
+        // No test framework is wired yet. Mark as 'not-run' so callers never
+        // mistake this for a passing result. Real execution will replace this
+        // path once test-framework integration is implemented.
+        status = 'not-run';
+        notRun++;
       }
 
       const durationMs = Date.now() - testStartTime;
@@ -635,6 +638,7 @@ export class RegressionTesterAgent implements IAgent {
       passed,
       failed,
       skipped,
+      notRun,
       durationSeconds: (Date.now() - startTime) / 1000,
       results,
     };
@@ -727,8 +731,25 @@ export class RegressionTesterAgent implements IAgent {
       });
     }
 
-    // All passed
-    if (testExecution.failed === 0 && compatibilityIssues.length === 0) {
+    // Not-run tests: surface explicitly so the outcome is never mistaken for a pass
+    if (testExecution.notRun > 0) {
+      const notRunTests = testExecution.results
+        .filter((r) => r.status === 'not-run')
+        .map((r) => r.testFile);
+      recommendations.push({
+        type: 'review_suggested',
+        priority: 'high',
+        message: `${String(testExecution.notRun)} test(s) were not executed — no test framework is wired. Integrate a test runner to get real regression results.`,
+        relatedTests: notRunTests,
+      });
+    }
+
+    // All passed (only when none are not-run)
+    if (
+      testExecution.failed === 0 &&
+      testExecution.notRun === 0 &&
+      compatibilityIssues.length === 0
+    ) {
       recommendations.push({
         type: 'acceptable',
         priority: 'low',
@@ -790,19 +811,29 @@ export class RegressionTesterAgent implements IAgent {
       compatibilityIssues.filter((i) => i.severity === 'critical' || i.severity === 'high').length +
       testExecution.failed;
 
+    // Tests with 'not-run' status have an unknown outcome and must never produce
+    // an overall 'passed' verdict — surface them as at least 'warning'.
     const status: RegressionSummary['status'] =
-      blockingIssues > 0 ? 'failed' : testExecution.failed > 0 ? 'warning' : 'passed';
+      blockingIssues > 0
+        ? 'failed'
+        : testExecution.failed > 0 || testExecution.notRun > 0
+          ? 'warning'
+          : 'passed';
+
+    const summaryMessage =
+      status === 'passed'
+        ? 'All regression tests passed'
+        : status === 'warning' && testExecution.notRun > 0
+          ? `${String(testExecution.notRun)} test(s) not executed — no test framework wired`
+          : status === 'warning'
+            ? 'Some tests failed but no blocking issues'
+            : `${String(blockingIssues)} blocking issue(s) found`;
 
     const summary: RegressionSummary = {
       status,
       totalIssues: compatibilityIssues.length,
       blockingIssues,
-      message:
-        status === 'passed'
-          ? 'All regression tests passed'
-          : status === 'warning'
-            ? 'Some tests failed but no blocking issues'
-            : `${String(blockingIssues)} blocking issue(s) found`,
+      message: summaryMessage,
     };
 
     return {
@@ -1135,6 +1166,7 @@ export class RegressionTesterAgent implements IAgent {
       passed: 0,
       failed: 0,
       skipped: 0,
+      notRun: 0,
       durationSeconds: 0,
       results: [],
     };

--- a/src/regression-tester/types.ts
+++ b/src/regression-tester/types.ts
@@ -7,8 +7,15 @@
 
 /**
  * Test execution status
+ *
+ * - 'passed'  — test ran and succeeded
+ * - 'failed'  — test ran and failed
+ * - 'skipped' — test was intentionally skipped (e.g. file not found)
+ * - 'error'   — test runner encountered an unexpected error
+ * - 'not-run' — no test framework is wired; the test was NOT executed and
+ *               its outcome is unknown. Never treat this as a pass.
  */
-export type TestStatus = 'passed' | 'failed' | 'skipped' | 'error';
+export type TestStatus = 'passed' | 'failed' | 'skipped' | 'error' | 'not-run';
 
 /**
  * Priority levels for affected tests
@@ -195,6 +202,12 @@ export interface TestExecutionSummary {
   readonly failed: number;
   /** Number of skipped tests */
   readonly skipped: number;
+  /**
+   * Number of tests that were NOT executed because no test framework is wired.
+   * These are distinct from skipped: their outcome is unknown and they must
+   * never be counted as passed.
+   */
+  readonly notRun: number;
   /** Total duration in seconds */
   readonly durationSeconds: number;
   /** Individual test results */

--- a/tests/regression-tester/RegressionTesterAgent.test.ts
+++ b/tests/regression-tester/RegressionTesterAgent.test.ts
@@ -19,6 +19,8 @@ import {
   type ChangedFile,
 } from '../../src/regression-tester/index.js';
 
+import { ENHANCEMENT_STAGES } from '../../src/ad-sdlc-orchestrator/index.js';
+
 describe('RegressionTesterAgent', () => {
   let tempDir: string;
   let agent: RegressionTesterAgent;
@@ -487,5 +489,121 @@ describe('UserController', () => {
         'Dependency graph not found. Using naming-based mapping only.'
       );
     });
+  });
+
+  describe('executeTests — no test framework wired', () => {
+    // These tests use an agent with runTests: true to verify that executeTests
+    // itself never silently returns 'passed' when no real test framework is wired.
+    let runTestsAgent: RegressionTesterAgent;
+
+    beforeEach(() => {
+      runTestsAgent = new RegressionTesterAgent({
+        scratchpadBasePath: '.ad-sdlc/scratchpad',
+        runTests: true, // explicitly enable so executeTests is called
+        collectCoverage: false,
+      });
+    });
+
+    afterEach(() => {
+      resetRegressionTesterAgent();
+    });
+
+    it('should never emit "passed" status when no test framework is wired', async () => {
+      const changedFiles: ChangedFile[] = [
+        { path: 'src/services/userService.ts', changeType: 'modified', linesChanged: 10 },
+      ];
+
+      await runTestsAgent.startSession('test-project', tempDir, changedFiles);
+      const result = await runTestsAgent.analyze();
+
+      // Every result whose test file exists must be 'not-run', never 'passed'
+      for (const r of result.report.testExecution.results) {
+        expect(r.status).not.toBe('passed');
+      }
+    });
+
+    it('should set status to "not-run" for tests whose files exist but have not been executed', async () => {
+      const changedFiles: ChangedFile[] = [
+        { path: 'src/services/userService.ts', changeType: 'modified', linesChanged: 10 },
+      ];
+
+      await runTestsAgent.startSession('test-project', tempDir, changedFiles);
+      const result = await runTestsAgent.analyze();
+
+      // At least one test file exists in tempDir (userService.test.ts) so at
+      // least one result should carry 'not-run'
+      const notRunResults = result.report.testExecution.results.filter(
+        (r) => r.status === 'not-run'
+      );
+      expect(notRunResults.length).toBeGreaterThan(0);
+    });
+
+    it('should count not-run tests in notRun, not in passed', async () => {
+      const changedFiles: ChangedFile[] = [
+        { path: 'src/services/userService.ts', changeType: 'modified', linesChanged: 10 },
+      ];
+
+      await runTestsAgent.startSession('test-project', tempDir, changedFiles);
+      const result = await runTestsAgent.analyze();
+
+      const exec = result.report.testExecution;
+      expect(exec.passed).toBe(0);
+      expect(exec.notRun).toBeGreaterThan(0);
+    });
+
+    it('should produce a "warning" (not "passed") overall status when tests are not-run', async () => {
+      const changedFiles: ChangedFile[] = [
+        { path: 'src/services/userService.ts', changeType: 'modified', linesChanged: 10 },
+      ];
+
+      await runTestsAgent.startSession('test-project', tempDir, changedFiles);
+      const result = await runTestsAgent.analyze();
+
+      // When there are not-run tests the gate must be at least 'warning'
+      expect(result.report.summary.status).not.toBe('passed');
+    });
+
+    it('should include a recommendation explaining that tests were not executed', async () => {
+      const changedFiles: ChangedFile[] = [
+        { path: 'src/services/userService.ts', changeType: 'modified', linesChanged: 10 },
+      ];
+
+      await runTestsAgent.startSession('test-project', tempDir, changedFiles);
+      const result = await runTestsAgent.analyze();
+
+      const notRunRec = result.report.recommendations.find((r) =>
+        r.message.includes('not executed')
+      );
+      expect(notRunRec).toBeDefined();
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ENHANCEMENT pipeline stage-graph: regression_testing → validation-agent order
+// ---------------------------------------------------------------------------
+describe('ENHANCEMENT_STAGES — regression_testing → validation-agent ordering', () => {
+  it('should include regression_testing in ENHANCEMENT_STAGES', () => {
+    const names = ENHANCEMENT_STAGES.map((s) => s.name);
+    expect(names).toContain('regression_testing');
+  });
+
+  it('should include validation-agent in ENHANCEMENT_STAGES', () => {
+    const names = ENHANCEMENT_STAGES.map((s) => s.name);
+    expect(names).toContain('validation-agent');
+  });
+
+  it('should have validation-agent depend on regression_testing', () => {
+    const validationStage = ENHANCEMENT_STAGES.find((s) => s.name === 'validation-agent');
+    expect(validationStage).toBeDefined();
+    expect(validationStage?.dependsOn).toContain('regression_testing');
+  });
+
+  it('should have regression_testing come before validation-agent in stage order', () => {
+    const regressionIdx = ENHANCEMENT_STAGES.findIndex((s) => s.name === 'regression_testing');
+    const validationIdx = ENHANCEMENT_STAGES.findIndex((s) => s.name === 'validation-agent');
+    expect(regressionIdx).toBeGreaterThanOrEqual(0);
+    expect(validationIdx).toBeGreaterThanOrEqual(0);
+    expect(regressionIdx).toBeLessThan(validationIdx);
   });
 });


### PR DESCRIPTION
## What

Fixes the silent false-green in `RegressionTesterAgent.executeTests` where every test was unconditionally marked `'passed'` even though no test framework was actually wired.

### Change Type
- [x] Bugfix (fixes an issue)

### Affected Components
- `src/regression-tester/types.ts` — new `'not-run'` variant on `TestStatus`, new `notRun` field on `TestExecutionSummary`
- `src/regression-tester/RegressionTesterAgent.ts` — `executeTests`, `generateRecommendations`, `createReport`, `createEmptyTestExecution`
- `tests/regression-tester/RegressionTesterAgent.test.ts` — 5 new unit tests + 4 stage-graph assertions

## Why

### Problem Solved
`executeTests` marked every existing test as `'passed'` with the comment "test framework integration needed", giving the Enhancement pipeline a false sense of safety. Any regression would be silently ignored.

### Related Issues
Closes #869

## How

### Implementation Details
1. Added `'not-run'` to the `TestStatus` union with an explanatory JSDoc.
2. Added `notRun: number` to `TestExecutionSummary` (with JSDoc clarifying it is never a pass).
3. In `executeTests`: when a test file exists but no framework executes it, status is now `'not-run'` and the counter goes into `notRun`, not `passed`.
4. In `createReport`: `notRun > 0` forces the overall status to at least `'warning'`.
5. In `generateRecommendations`: emits a high-priority `'review_suggested'` entry listing the not-run tests; the "All passed" entry is only emitted when `notRun === 0`.
6. `createEmptyTestExecution` initialises `notRun: 0`.

### What was NOT changed (scope guard)
- The orchestrator's `regression_testing` pipeline stage definition and its `dependsOn` relationship to `validation-agent` are untouched.
- No real test-framework execution was added (separate future work).

### Testing Done
- [x] 5 new unit tests asserting `'not-run'` is used and never `'passed'`
- [x] 4 stage-graph tests asserting `regression_testing → validation-agent` ordering in `ENHANCEMENT_STAGES`
- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run tests/regression-tester/` — 59/59 passed

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Tests added
- [x] No sensitive data exposed
- [x] Related issue linked with closing keyword