### PR TITLE
fix(scratchpad): honor configured backend via BackendFactory

### DIFF
--- a/src/scratchpad/Scratchpad.ts
+++ b/src/scratchpad/Scratchpad.ts
@@ -79,7 +79,7 @@ import { randomUUID } from 'node:crypto';
 import * as yaml from 'js-yaml';
 import { InputValidator } from '../security/index.js';
 import { tryGetProjectRoot } from '../utils/index.js';
-import { FileBackend } from './backends/FileBackend.js';
+import { BackendFactory } from './backends/BackendFactory.js';
 import type { IScratchpadBackend } from './backends/IScratchpadBackend.js';
 import type {
   ScratchpadOptions,
@@ -95,6 +95,7 @@ import type {
   LockReleaseRequest,
   SerializationFormat,
 } from './types.js';
+import type { ScratchpadBackendConfig } from './backends/types.js';
 import { EXTENSION_TO_FORMAT } from './types.js';
 import { LockContentionError } from './errors.js';
 import { DEFAULT_PATHS } from '../config/paths.js';
@@ -215,8 +216,10 @@ export class Scratchpad {
   private readonly projectRoot: string;
   /** Pending release requests created by this instance */
   private readonly pendingReleaseRequests: Set<string> = new Set();
-  /** File backend for storage operations */
-  private readonly backend: IScratchpadBackend;
+  /** Backend config for lazy initialization (used when backend !== 'file') */
+  private readonly backendConfig: ScratchpadBackendConfig;
+  /** Storage backend instance (null until first use; set during ensureBackendInitialized) */
+  private backend: IScratchpadBackend | null = null;
   /** Whether the backend has been initialized */
   private backendInitialized = false;
 
@@ -249,13 +252,33 @@ export class Scratchpad {
       : path.resolve(this.projectRoot, this.basePath);
     this.validator = new InputValidator({ basePath: resolvedBasePath });
 
-    // Initialize file backend with raw format (no extension manipulation)
-    this.backend = new FileBackend({
-      basePath: resolvedBasePath,
-      fileMode: this.fileMode,
-      dirMode: this.dirMode,
-      format: 'raw',
-    });
+    // Build the backend config to use during lazy initialization.
+    // FileBackend is always available (no optional deps); SQLite/Redis are loaded
+    // lazily via dynamic import() in BackendFactory.create() so that consumers who
+    // never select those backends are not forced to install better-sqlite3 / ioredis.
+    const backendType = options.backend ?? 'file';
+    if (backendType === 'file') {
+      this.backendConfig = {
+        backend: 'file',
+        file: {
+          basePath: resolvedBasePath,
+          fileMode: this.fileMode,
+          dirMode: this.dirMode,
+          format: 'raw',
+        },
+      };
+    } else if (backendType === 'sqlite') {
+      this.backendConfig = {
+        backend: 'sqlite',
+        ...(options.sqlite !== undefined ? { sqlite: options.sqlite } : {}),
+      };
+    } else {
+      // redis
+      this.backendConfig = {
+        backend: 'redis',
+        ...(options.redis !== undefined ? { redis: options.redis } : {}),
+      };
+    }
   }
 
   // ============================================================
@@ -278,13 +301,32 @@ export class Scratchpad {
   // ============================================================
 
   /**
-   * Ensure the backend is initialized
+   * Ensure the backend is created and initialized.
+   *
+   * For the file backend the instance is created synchronously the first time
+   * this is called. For sqlite/redis backends BackendFactory.create() is awaited,
+   * which triggers a lazy dynamic import() of the optional-dependency module.
+   * Subsequent calls are no-ops.
    */
   private async ensureBackendInitialized(): Promise<void> {
     if (!this.backendInitialized) {
+      if (this.backend === null) {
+        this.backend = await BackendFactory.create(this.backendConfig);
+      }
       await this.backend.initialize();
       this.backendInitialized = true;
     }
+  }
+
+  /**
+   * Return the initialized backend instance.
+   * Must only be called after ensureBackendInitialized().
+   */
+  private getBackend(): IScratchpadBackend {
+    if (this.backend === null) {
+      throw new Error('Backend not yet initialized. Call ensureBackendInitialized() first.');
+    }
+    return this.backend;
   }
 
   /**
@@ -575,7 +617,7 @@ export class Scratchpad {
     // Use backend for atomic write
     await this.ensureBackendInitialized();
     const { section, key } = this.pathToSectionKey(validatedPath);
-    await this.backend.write(section, key, content);
+    await this.getBackend().write(section, key, content);
   }
 
   /**
@@ -1459,7 +1501,7 @@ export class Scratchpad {
     try {
       await this.ensureBackendInitialized();
       const { section, key } = this.pathToSectionKey(validatedPath);
-      const content = await this.backend.read<string>(section, key);
+      const content = await this.getBackend().read<string>(section, key);
 
       if (content === null) {
         if (allowMissing) {
@@ -1544,7 +1586,7 @@ export class Scratchpad {
     const content = this.serialize(data, format);
     await this.ensureBackendInitialized();
     const { section, key } = this.pathToSectionKey(validatedPath);
-    await this.backend.write(section, key, content);
+    await this.getBackend().write(section, key, content);
   }
 
   /**
@@ -1611,7 +1653,7 @@ export class Scratchpad {
     try {
       await this.ensureBackendInitialized();
       const { section, key } = this.pathToSectionKey(validatedPath);
-      const content = await this.backend.read<string>(section, key);
+      const content = await this.getBackend().read<string>(section, key);
 
       if (content === null) {
         if (allowMissing) {
@@ -1709,7 +1751,7 @@ export class Scratchpad {
     try {
       await this.ensureBackendInitialized();
       const { section, key } = this.pathToSectionKey(validatedPath);
-      const content = await this.backend.read<string>(section, key);
+      const content = await this.getBackend().read<string>(section, key);
 
       if (content === null) {
         if (allowMissing) {
@@ -1801,7 +1843,7 @@ export class Scratchpad {
     try {
       await this.ensureBackendInitialized();
       const { section, key } = this.pathToSectionKey(validatedPath);
-      const content = await this.backend.read<string>(section, key);
+      const content = await this.getBackend().read<string>(section, key);
 
       if (content === null) {
         if (allowMissing) {
@@ -1888,7 +1930,7 @@ export class Scratchpad {
     const validatedPath = this.validatePath(filePath);
     await this.ensureBackendInitialized();
     const { section, key } = this.pathToSectionKey(validatedPath);
-    return this.backend.exists(section, key);
+    return this.getBackend().exists(section, key);
   }
 
   /**
@@ -1918,7 +1960,7 @@ export class Scratchpad {
     const validatedPath = this.validatePath(filePath);
     await this.ensureBackendInitialized();
     const { section, key } = this.pathToSectionKey(validatedPath);
-    const deleted = await this.backend.delete(section, key);
+    const deleted = await this.getBackend().delete(section, key);
     if (!deleted) {
       const error = new Error(`ENOENT: no such file or directory, unlink '${validatedPath}'`);
       (error as NodeJS.ErrnoException).code = 'ENOENT';
@@ -1973,7 +2015,7 @@ export class Scratchpad {
 
     // Close backend
     if (this.backendInitialized) {
-      await this.backend.close();
+      await this.backend?.close();
       this.backendInitialized = false;
     }
   }

--- a/src/scratchpad/backends/BackendFactory.ts
+++ b/src/scratchpad/backends/BackendFactory.ts
@@ -13,8 +13,6 @@
 import type { IScratchpadBackend } from './IScratchpadBackend.js';
 import type { ScratchpadBackendConfig, BackendType } from './types.js';
 import { FileBackend } from './FileBackend.js';
-import { SQLiteBackend } from './SQLiteBackend.js';
-import { RedisBackend } from './RedisBackend.js';
 import { loadScratchpadConfig } from './configLoader.js';
 import { getLogger } from '../../logging/index.js';
 
@@ -38,37 +36,48 @@ export class BackendCreationError extends Error {
  *
  * @example
  * ```typescript
- * const backend = BackendFactory.create({ backend: 'sqlite' });
+ * const backend = await BackendFactory.create({ backend: 'sqlite' });
  * await backend.initialize();
  * ```
  */
 // eslint-disable-next-line @typescript-eslint/no-extraneous-class
 export class BackendFactory {
   /**
-   * Create a backend instance based on configuration
+   * Create a backend instance based on configuration.
+   *
+   * SQLite and Redis backends are loaded via dynamic import() so that their
+   * optional peer dependencies (better-sqlite3, ioredis) are never required by
+   * consumers who only use the default file backend.
+   * FileBackend is imported eagerly because it is the default and has no optional deps.
    *
    * @param config - Backend configuration
    * @returns Uninitialized backend instance
    * @throws BackendCreationError if backend type is unknown
    */
-  static create(config: ScratchpadBackendConfig = {}): IScratchpadBackend {
+  static async create(config: ScratchpadBackendConfig = {}): Promise<IScratchpadBackend> {
     const backendType = config.backend ?? 'file';
 
     switch (backendType) {
       case 'file':
         return new FileBackend(config.file);
 
-      case 'sqlite':
+      case 'sqlite': {
+        // Lazy-load: better-sqlite3 is only required when SQLite backend is selected
+        const { SQLiteBackend } = await import('./SQLiteBackend.js');
         return new SQLiteBackend(config.sqlite);
+      }
 
-      case 'redis':
+      case 'redis': {
         if (!config.redis) {
           throw new BackendCreationError(
             'redis',
             'Redis configuration is required. Provide host, port, etc.'
           );
         }
+        // Lazy-load: ioredis is only required when Redis backend is selected
+        const { RedisBackend } = await import('./RedisBackend.js');
         return new RedisBackend(config.redis);
+      }
 
       default:
         throw new BackendCreationError(
@@ -90,7 +99,7 @@ export class BackendFactory {
     config: ScratchpadBackendConfig = {}
   ): Promise<IScratchpadBackend> {
     const backendType = config.backend ?? 'file';
-    const backend = BackendFactory.create(config);
+    const backend = await BackendFactory.create(config);
 
     try {
       await backend.initialize();

--- a/src/scratchpad/types.ts
+++ b/src/scratchpad/types.ts
@@ -95,6 +95,47 @@ export interface ScratchpadOptions {
    * within this duration.
    */
   readonly heartbeatTimeoutMs?: number;
+  /**
+   * Storage backend type to use (default: 'file').
+   * - 'file': File-based storage (default, no optional dependencies)
+   * - 'sqlite': SQLite-based storage (requires better-sqlite3)
+   * - 'redis': Redis-based storage (requires ioredis)
+   */
+  readonly backend?: 'file' | 'sqlite' | 'redis';
+  /**
+   * SQLite backend specific options.
+   * Only used when backend is 'sqlite'.
+   */
+  readonly sqlite?: {
+    /** Path to SQLite database file (default: '.ad-sdlc/scratchpad.db') */
+    readonly dbPath?: string;
+    /** Enable WAL mode for better concurrency (default: true) */
+    readonly walMode?: boolean;
+    /** Busy timeout in milliseconds (default: 5000) */
+    readonly busyTimeout?: number;
+  };
+  /**
+   * Redis backend specific options.
+   * Required when backend is 'redis'.
+   */
+  readonly redis?: {
+    /** Redis host (default: 'localhost') */
+    readonly host?: string;
+    /** Redis port (default: 6379) */
+    readonly port?: number;
+    /** Redis password (optional) */
+    readonly password?: string;
+    /** Redis database number (default: 0) */
+    readonly db?: number;
+    /** Key prefix (default: 'ad-sdlc:scratchpad:') */
+    readonly prefix?: string;
+    /** TTL in seconds for entries (optional, no expiry if not set) */
+    readonly ttl?: number;
+    /** Connection timeout in milliseconds (default: 5000) */
+    readonly connectTimeout?: number;
+    /** Maximum retry attempts on connection failure (default: 3) */
+    readonly maxRetries?: number;
+  };
 }
 
 /**

--- a/tests/scratchpad/ScratchpadBackendWiring.test.ts
+++ b/tests/scratchpad/ScratchpadBackendWiring.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Tests for Scratchpad backend wiring via BackendFactory (#873)
+ *
+ * Verifies that:
+ *  (a) When backend: 'sqlite' is configured, Scratchpad routes through SQLiteBackend.
+ *  (b) When no backend (or backend: 'file') is configured, Scratchpad uses FileBackend
+ *      and does not eagerly pull optional dependencies.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import * as fs from 'node:fs';
+import { Scratchpad, resetScratchpad } from '../../src/scratchpad/index.js';
+import { BackendFactory } from '../../src/scratchpad/backends/BackendFactory.js';
+import { FileBackend } from '../../src/scratchpad/backends/FileBackend.js';
+import { SQLiteBackend } from '../../src/scratchpad/backends/SQLiteBackend.js';
+
+describe('Scratchpad backend wiring (issue #873)', () => {
+  let testBasePath: string;
+
+  beforeEach(() => {
+    resetScratchpad();
+    testBasePath = path.join(os.tmpdir(), `scratchpad-wiring-test-${Date.now()}`);
+  });
+
+  afterEach(async () => {
+    resetScratchpad();
+    try {
+      fs.rmSync(testBasePath, { recursive: true, force: true });
+    } catch {
+      // ignore cleanup errors
+    }
+  });
+
+  describe('(a) SQLite backend wiring', () => {
+    it('should use SQLiteBackend when backend: sqlite is configured', async () => {
+      // Spy on BackendFactory.create to capture what backend type is created
+      const createSpy = vi.spyOn(BackendFactory, 'create');
+
+      const scratchpad = new Scratchpad({
+        basePath: testBasePath,
+        backend: 'sqlite',
+        sqlite: {
+          dbPath: path.join(testBasePath, 'test.db'),
+        },
+      });
+
+      // Trigger lazy initialization
+      const writeTarget = path.join(testBasePath, 'test.txt');
+      await scratchpad.atomicWrite(writeTarget, 'hello');
+      await scratchpad.cleanup();
+
+      // BackendFactory.create must have been called with backend: 'sqlite'
+      expect(createSpy).toHaveBeenCalledWith(expect.objectContaining({ backend: 'sqlite' }));
+
+      // The returned backend instance must be a SQLiteBackend
+      const createdBackend = await createSpy.mock.results[0]?.value;
+      expect(createdBackend).toBeInstanceOf(SQLiteBackend);
+
+      createSpy.mockRestore();
+    });
+
+    it('should be able to write and read data through SQLite backend', async () => {
+      const dbPath = path.join(testBasePath, 'sqlite-rw.db');
+      const scratchpad = new Scratchpad({
+        basePath: testBasePath,
+        backend: 'sqlite',
+        sqlite: { dbPath },
+      });
+
+      const filePath = path.join(testBasePath, 'data.json');
+      const payload = { key: 'value', num: 42 };
+
+      await scratchpad.writeJson(filePath, payload);
+      const result = await scratchpad.readJson<typeof payload>(filePath);
+
+      expect(result).toEqual(payload);
+
+      await scratchpad.cleanup();
+    });
+  });
+
+  describe('(b) Default file backend — no optional dep eager-load', () => {
+    it('should use FileBackend when no backend option is provided', async () => {
+      const createSpy = vi.spyOn(BackendFactory, 'create');
+
+      const scratchpad = new Scratchpad({ basePath: testBasePath });
+
+      const writeTarget = path.join(testBasePath, 'default.txt');
+      await scratchpad.atomicWrite(writeTarget, 'default');
+      await scratchpad.cleanup();
+
+      // BackendFactory.create must have been called with backend: 'file'
+      expect(createSpy).toHaveBeenCalledWith(expect.objectContaining({ backend: 'file' }));
+
+      const createdBackend = await createSpy.mock.results[0]?.value;
+      expect(createdBackend).toBeInstanceOf(FileBackend);
+
+      createSpy.mockRestore();
+    });
+
+    it('should use FileBackend when backend: file is explicitly configured', async () => {
+      const createSpy = vi.spyOn(BackendFactory, 'create');
+
+      const scratchpad = new Scratchpad({
+        basePath: testBasePath,
+        backend: 'file',
+      });
+
+      const writeTarget = path.join(testBasePath, 'explicit-file.txt');
+      await scratchpad.atomicWrite(writeTarget, 'explicit');
+      await scratchpad.cleanup();
+
+      const createdBackend = await createSpy.mock.results[0]?.value;
+      expect(createdBackend).toBeInstanceOf(FileBackend);
+      expect(createdBackend).not.toBeInstanceOf(SQLiteBackend);
+
+      createSpy.mockRestore();
+    });
+  });
+});

--- a/tests/scratchpad/backends/BackendFactory.test.ts
+++ b/tests/scratchpad/backends/BackendFactory.test.ts
@@ -12,25 +12,25 @@ import { RedisBackend } from '../../../src/scratchpad/backends/RedisBackend.js';
 
 describe('BackendFactory', () => {
   describe('create', () => {
-    it('should create file backend by default', () => {
-      const backend = BackendFactory.create();
+    it('should create file backend by default', async () => {
+      const backend = await BackendFactory.create();
       expect(backend).toBeInstanceOf(FileBackend);
       expect(backend.name).toBe('file');
     });
 
-    it('should create file backend when specified', () => {
-      const backend = BackendFactory.create({ backend: 'file' });
+    it('should create file backend when specified', async () => {
+      const backend = await BackendFactory.create({ backend: 'file' });
       expect(backend).toBeInstanceOf(FileBackend);
     });
 
-    it('should create sqlite backend when specified', () => {
-      const backend = BackendFactory.create({ backend: 'sqlite' });
+    it('should create sqlite backend when specified', async () => {
+      const backend = await BackendFactory.create({ backend: 'sqlite' });
       expect(backend).toBeInstanceOf(SQLiteBackend);
       expect(backend.name).toBe('sqlite');
     });
 
-    it('should create redis backend when specified with config', () => {
-      const backend = BackendFactory.create({
+    it('should create redis backend when specified with config', async () => {
+      const backend = await BackendFactory.create({
         backend: 'redis',
         redis: {
           host: 'localhost',
@@ -41,36 +41,38 @@ describe('BackendFactory', () => {
       expect(backend.name).toBe('redis');
     });
 
-    it('should throw error for redis without config', () => {
-      expect(() => BackendFactory.create({ backend: 'redis' })).toThrow(BackendCreationError);
-    });
-
-    it('should throw error for unknown backend type', () => {
-      expect(() => BackendFactory.create({ backend: 'unknown' as 'file' })).toThrow(
+    it('should throw error for redis without config', async () => {
+      await expect(BackendFactory.create({ backend: 'redis' })).rejects.toThrow(
         BackendCreationError
       );
     });
 
-    it('should pass file config to FileBackend', () => {
-      const backend = BackendFactory.create({
+    it('should throw error for unknown backend type', async () => {
+      await expect(BackendFactory.create({ backend: 'unknown' as 'file' })).rejects.toThrow(
+        BackendCreationError
+      );
+    });
+
+    it('should pass file config to FileBackend', async () => {
+      const backend = (await BackendFactory.create({
         backend: 'file',
         file: {
           basePath: '/custom/path',
           format: 'json',
         },
-      }) as FileBackend;
+      })) as FileBackend;
 
       expect(backend).toBeInstanceOf(FileBackend);
     });
 
-    it('should pass sqlite config to SQLiteBackend', () => {
-      const backend = BackendFactory.create({
+    it('should pass sqlite config to SQLiteBackend', async () => {
+      const backend = (await BackendFactory.create({
         backend: 'sqlite',
         sqlite: {
           dbPath: '/custom/db.sqlite',
           walMode: false,
         },
-      }) as SQLiteBackend;
+      })) as SQLiteBackend;
 
       expect(backend).toBeInstanceOf(SQLiteBackend);
     });


### PR DESCRIPTION
## What

Routes `Scratchpad` backend selection through `BackendFactory` instead of hardcoding `FileBackend`.

### Summary
- `Scratchpad` previously hardcoded `new FileBackend(...)` at line 253, bypassing the live `BackendFactory` and ignoring the publicly-supported `backend: 'sqlite' | 'redis'` config options.
- `BackendFactory.create()` is now `async` and uses dynamic `import()` for `SQLiteBackend`/`RedisBackend` so optional peer dependencies (`better-sqlite3`, `ioredis`) are never loaded for consumers that only use the default file backend.
- `FileBackend` remains eagerly imported (no optional deps, is the default).
- The backend is constructed lazily inside the existing `ensureBackendInitialized()` method so the `Scratchpad` constructor stays synchronous.

### Change Type
- [x] Bugfix / wiring gap (existing config option had no effect)

### Affected Components
- `src/scratchpad/Scratchpad.ts` — replaced hardcoded `FileBackend` with `BackendFactory.create()` in lazy-init
- `src/scratchpad/backends/BackendFactory.ts` — `create()` is now `async`, SQLite/Redis use `await import()`
- `src/scratchpad/types.ts` — added `backend`, `sqlite`, `redis` fields to `ScratchpadOptions`

## Why

Closes #873

The `backend` config field in `ScratchpadOptions` was accepted but silently ignored; every `Scratchpad` instance always used `FileBackend` regardless of config.

## Who

### Reviewers
- Please verify the async ripple: `BackendFactory.create()` is now `async`; `createAndInitialize()` already awaited it internally so no external callers break.
- `BackendFactory.test.ts` was updated to `await` the now-async `create()` calls.

## How

### Implementation Details
1. Added `backend / sqlite / redis` options to `ScratchpadOptions` (mirrors `ScratchpadBackendConfig` shape)
2. `Scratchpad` constructor stores a `backendConfig` snapshot instead of constructing the backend eagerly
3. First call to `ensureBackendInitialized()` invokes `await BackendFactory.create(backendConfig)`
4. `BackendFactory.create()` uses `await import('./SQLiteBackend.js')` / `await import('./RedisBackend.js')` so the modules (and their optional native deps) are only loaded when actually needed
5. For `backend: 'file'` the factory still constructs `new FileBackend(...)` synchronously inside the already-async method — no behavioral change

### Testing Done
- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run tests/scratchpad/` — 322 passed, 25 skipped (0 failures)
- [x] New test file `tests/scratchpad/ScratchpadBackendWiring.test.ts` with 4 cases:
  - `backend:'sqlite'` routes through `SQLiteBackend` (spy on `BackendFactory.create`)
  - SQLite backend can write and read data (end-to-end with `better-sqlite3`)
  - Default (no option) uses `FileBackend`
  - `backend:'file'` explicit uses `FileBackend`, not `SQLiteBackend`

### Breaking Changes
- `BackendFactory.create()` return type changed from `IScratchpadBackend` to `Promise<IScratchpadBackend>`. Callers of the static method must now `await` it. `createAndInitialize()` / `createFromConfig()` / `createAndInitializeFromConfig()` are unaffected (already async).