### PR TITLE
infra(schemas): unify tool/model allowlist into one SSOT with conformance enforcement

### DIFF
--- a/schemas/agents.schema.json
+++ b/schemas/agents.schema.json
@@ -138,15 +138,15 @@
               },
               "model_preference": {
                 "type": "string",
-                "enum": ["sonnet", "opus", "haiku"],
-                "description": "Preferred model for this agent"
+                "enum": ["sonnet", "opus", "haiku", "inherit"],
+                "description": "Preferred model for this agent (inherit = use parent agent model)"
               }
             }
           },
           "model_preference": {
             "type": "string",
-            "enum": ["sonnet", "opus", "haiku"],
-            "description": "Preferred Claude model for this agent"
+            "enum": ["sonnet", "opus", "haiku", "inherit"],
+            "description": "Preferred Claude model for this agent (inherit = use parent agent model)"
           }
         }
       }
@@ -238,10 +238,7 @@
                 "description": "Target agent ID"
               },
               "data": {
-                "oneOf": [
-                  { "type": "string" },
-                  { "type": "array", "items": { "type": "string" } }
-                ],
+                "oneOf": [{ "type": "string" }, { "type": "array", "items": { "type": "string" } }],
                 "description": "Data files passed between agents"
               },
               "mode": {

--- a/schemas/workflow.schema.json
+++ b/schemas/workflow.schema.json
@@ -16,28 +16,57 @@
         "inputs": {
           "type": "array",
           "items": {
-            "oneOf": [
-              { "type": "string" },
-              { "type": "object" }
-            ]
+            "oneOf": [{ "type": "string" }, { "type": "object" }]
           },
           "description": "Input files/patterns (strings or typed objects)"
         },
-        "outputs": { "type": "array", "items": { "type": "string" }, "description": "Output files/patterns" },
+        "outputs": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Output files/patterns"
+        },
         "next": { "type": ["string", "null"], "description": "Next stage name" },
-        "approval_required": { "type": "boolean", "default": false, "description": "Whether approval is required" },
-        "parallel": { "type": "boolean", "default": false, "description": "Whether stage runs in parallel" },
-        "max_parallel": { "type": "integer", "minimum": 1, "maximum": 10, "description": "Max parallel workers" },
-        "conditional": { "type": "boolean", "description": "Whether this stage is conditionally executed" },
+        "approval_required": {
+          "type": "boolean",
+          "default": false,
+          "description": "Whether approval is required"
+        },
+        "parallel": {
+          "type": "boolean",
+          "default": false,
+          "description": "Whether stage runs in parallel"
+        },
+        "max_parallel": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 10,
+          "description": "Max parallel workers"
+        },
+        "conditional": {
+          "type": "boolean",
+          "description": "Whether this stage is conditionally executed"
+        },
         "on_ci_failure": {
           "type": "object",
           "description": "CI failure handling configuration",
           "properties": {
             "agent": { "type": "string", "description": "Agent to handle CI failure" },
             "description": { "type": "string", "description": "Description of failure handler" },
-            "max_attempts": { "type": "integer", "minimum": 1, "description": "Max retry attempts on CI failure" },
-            "inputs": { "type": "array", "items": { "type": "string" }, "description": "Inputs for failure handler" },
-            "outputs": { "type": "array", "items": { "type": "string" }, "description": "Outputs from failure handler" }
+            "max_attempts": {
+              "type": "integer",
+              "minimum": 1,
+              "description": "Max retry attempts on CI failure"
+            },
+            "inputs": {
+              "type": "array",
+              "items": { "type": "string" },
+              "description": "Inputs for failure handler"
+            },
+            "outputs": {
+              "type": "array",
+              "items": { "type": "string" },
+              "description": "Outputs from failure handler"
+            }
           }
         },
         "substages": {
@@ -99,7 +128,11 @@
           "description": "Retry policy for agents",
           "properties": {
             "max_attempts": { "type": "integer", "minimum": 1, "maximum": 10, "default": 3 },
-            "backoff": { "type": "string", "enum": ["linear", "exponential"], "default": "exponential" },
+            "backoff": {
+              "type": "string",
+              "enum": ["linear", "exponential"],
+              "default": "exponential"
+            },
             "base_delay_seconds": { "type": "integer", "minimum": 1, "default": 5 },
             "max_delay_seconds": { "type": "integer", "minimum": 1, "default": 60 }
           }
@@ -182,20 +215,37 @@
         "properties": {
           "model": {
             "type": "string",
-            "enum": ["sonnet", "opus", "haiku"],
+            "enum": ["sonnet", "opus", "haiku", "inherit"],
             "default": "sonnet",
-            "description": "Claude model to use"
+            "description": "Claude model to use (inherit = use parent agent model)"
           },
           "tools": {
             "type": "array",
             "items": {
               "type": "string",
-              "enum": ["Read", "Write", "Edit", "Bash", "Glob", "Grep", "WebFetch", "WebSearch"]
+              "enum": [
+                "Read",
+                "Write",
+                "Edit",
+                "Bash",
+                "Glob",
+                "Grep",
+                "WebFetch",
+                "WebSearch",
+                "Task",
+                "LSP",
+                "TodoWrite",
+                "NotebookEdit"
+              ]
             },
             "description": "Tools available to the agent"
           },
           "template": { "type": "string", "description": "Template file path" },
-          "max_questions": { "type": "integer", "minimum": 1, "description": "Max clarifying questions" },
+          "max_questions": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "Max clarifying questions"
+          },
           "github": {
             "type": "object",
             "properties": {
@@ -208,7 +258,10 @@
           "scheduling": {
             "type": "object",
             "properties": {
-              "algorithm": { "type": "string", "enum": ["priority_only", "dependency_only", "priority_dependency"] },
+              "algorithm": {
+                "type": "string",
+                "enum": ["priority_only", "dependency_only", "priority_dependency"]
+              },
               "max_workers": { "type": "integer", "minimum": 1, "maximum": 10 },
               "check_interval_seconds": { "type": "integer", "minimum": 10 }
             }
@@ -229,7 +282,12 @@
               "run_tests": { "type": "boolean", "default": true },
               "run_lint": { "type": "boolean", "default": true },
               "run_build": { "type": "boolean", "default": true },
-              "coverage_threshold": { "type": "number", "minimum": 0, "maximum": 100, "default": 80 }
+              "coverage_threshold": {
+                "type": "number",
+                "minimum": 0,
+                "maximum": 100,
+                "default": 80
+              }
             }
           },
           "review": {
@@ -237,7 +295,12 @@
             "properties": {
               "auto_merge": { "type": "boolean", "default": false },
               "require_all_checks": { "type": "boolean", "default": true },
-              "coverage_threshold": { "type": "number", "minimum": 0, "maximum": 100, "default": 80 },
+              "coverage_threshold": {
+                "type": "number",
+                "minimum": 0,
+                "maximum": 100,
+                "default": 80
+              },
               "max_complexity": { "type": "integer", "minimum": 1, "default": 10 }
             }
           }
@@ -340,7 +403,11 @@
       "type": "object",
       "description": "Logging configuration",
       "properties": {
-        "level": { "type": "string", "enum": ["DEBUG", "INFO", "WARN", "ERROR"], "default": "INFO" },
+        "level": {
+          "type": "string",
+          "enum": ["DEBUG", "INFO", "WARN", "ERROR"],
+          "default": "INFO"
+        },
         "format": { "type": "string", "enum": ["json", "text"], "default": "json" },
         "output": {
           "type": "array",
@@ -452,16 +519,27 @@
       "properties": {
         "default_model": {
           "type": "string",
-          "enum": ["sonnet", "opus", "haiku"],
-          "description": "Default model for budget calculations"
+          "enum": ["sonnet", "opus", "haiku", "inherit"],
+          "description": "Default model for budget calculations (inherit = use parent agent model)"
         },
         "pipeline": {
           "type": "object",
           "description": "Pipeline-level token budget",
           "properties": {
-            "max_tokens": { "type": "integer", "description": "Maximum tokens for the entire pipeline" },
-            "max_cost_usd": { "type": "number", "description": "Maximum cost in USD for the pipeline" },
-            "warning_threshold": { "type": "number", "minimum": 0, "maximum": 1, "description": "Threshold (0-1) to trigger budget warning" }
+            "max_tokens": {
+              "type": "integer",
+              "description": "Maximum tokens for the entire pipeline"
+            },
+            "max_cost_usd": {
+              "type": "number",
+              "description": "Maximum cost in USD for the pipeline"
+            },
+            "warning_threshold": {
+              "type": "number",
+              "minimum": 0,
+              "maximum": 1,
+              "description": "Threshold (0-1) to trigger budget warning"
+            }
           }
         },
         "defaults": {

--- a/src/agent-validator/schemas.ts
+++ b/src/agent-validator/schemas.ts
@@ -5,6 +5,7 @@
  */
 
 import { z } from 'zod';
+import { CANONICAL_TOOLS, CANONICAL_MODELS } from '../config/allowlist.js';
 
 /**
  * Schema version for agent definitions
@@ -12,27 +13,16 @@ import { z } from 'zod';
 export const AGENT_SCHEMA_VERSION = '1.0.0';
 
 /**
- * Valid tool names
+ * Valid tool names — derived from the canonical allowlist (src/config/allowlist.ts).
+ * Do not add tools here; add them to the canonical module instead.
  */
-export const VALID_TOOLS = [
-  'Read',
-  'Write',
-  'Edit',
-  'Bash',
-  'Glob',
-  'Grep',
-  'WebFetch',
-  'WebSearch',
-  'LSP',
-  'Task',
-  'TodoWrite',
-  'NotebookEdit',
-] as const;
+export const VALID_TOOLS = CANONICAL_TOOLS;
 
 /**
- * Valid model names
+ * Valid model names — derived from the canonical allowlist (src/config/allowlist.ts).
+ * Do not add models here; add them to the canonical module instead.
  */
-export const VALID_MODELS = ['sonnet', 'opus', 'haiku'] as const;
+export const VALID_MODELS = CANONICAL_MODELS;
 
 /**
  * Schema for agent tool

--- a/src/agent-validator/types.ts
+++ b/src/agent-validator/types.ts
@@ -4,27 +4,19 @@
  * @module agent-validator/types
  */
 
-/**
- * Valid tool names that can be used by agents
- */
-export type AgentTool =
-  | 'Read'
-  | 'Write'
-  | 'Edit'
-  | 'Bash'
-  | 'Glob'
-  | 'Grep'
-  | 'WebFetch'
-  | 'WebSearch'
-  | 'LSP'
-  | 'Task'
-  | 'TodoWrite'
-  | 'NotebookEdit';
+import type { CanonicalTool, CanonicalModel } from '../config/allowlist.js';
 
 /**
- * Valid model names
+ * Valid tool names that can be used by agents.
+ * Aliased from the canonical allowlist (src/config/allowlist.ts).
  */
-export type AgentModel = 'sonnet' | 'opus' | 'haiku';
+export type AgentTool = CanonicalTool;
+
+/**
+ * Valid model names.
+ * Aliased from the canonical allowlist (src/config/allowlist.ts).
+ */
+export type AgentModel = CanonicalModel;
 
 /**
  * Agent definition frontmatter structure

--- a/src/agent-validator/validator.ts
+++ b/src/agent-validator/validator.ts
@@ -29,6 +29,8 @@ import type {
 
 const DEFAULT_AGENTS_DIR = '.claude/agents';
 const DEFAULT_REGISTRY_PATH = `${DEFAULT_PATHS.CONFIG_SUBDIR}/agents.yaml`;
+// Matches YAML frontmatter delimited by --- lines.
+// Normalise CRLF to LF before applying so files edited on Windows pass too.
 const FRONTMATTER_REGEX = /^---\n([\s\S]*?)\n---\n([\s\S]*)$/;
 
 // ============================================================
@@ -45,7 +47,9 @@ function parseFrontmatter(
   content: string,
   filePath: string
 ): { frontmatter: unknown; body: string } {
-  const match = content.match(FRONTMATTER_REGEX);
+  // Normalise CRLF line endings so files edited on Windows are handled correctly
+  const normalised = content.replace(/\r\n/g, '\n');
+  const match = normalised.match(FRONTMATTER_REGEX);
   if (!match) {
     throw new FrontmatterParseError(
       filePath,
@@ -56,7 +60,7 @@ function parseFrontmatter(
   const frontmatterYaml = match[1] ?? '';
   const body = match[2] ?? '';
   try {
-    const frontmatter = yaml.load(frontmatterYaml);
+    const frontmatter = yaml.load(frontmatterYaml) as Record<string, unknown>;
     return { frontmatter, body };
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Unknown YAML parse error';

--- a/src/config/ConfigManager.ts
+++ b/src/config/ConfigManager.ts
@@ -11,6 +11,7 @@
 
 import { loadWorkflowConfig, loadAgentsConfig } from './loader.js';
 import type { WorkflowConfig, AgentsConfig, LoadConfigOptions } from './types.js';
+import type { CanonicalModel } from './allowlist.js';
 
 // ============================================================
 // Types
@@ -70,7 +71,7 @@ export interface PipelineStage {
  * Agent configuration in workflow
  */
 export interface AgentWorkflowConfig {
-  readonly model: 'sonnet' | 'opus' | 'haiku';
+  readonly model: CanonicalModel;
   readonly tools: readonly string[] | undefined;
   readonly template: string | undefined;
   readonly maxQuestions: number | undefined;

--- a/src/config/allowlist.ts
+++ b/src/config/allowlist.ts
@@ -1,0 +1,104 @@
+/**
+ * Canonical tool and model allowlists for the AD-SDLC agent system.
+ *
+ * This is the SINGLE SOURCE OF TRUTH for:
+ *   - The set of tools agents may declare in their frontmatter
+ *   - The set of model names agents may declare in their frontmatter
+ *
+ * All other modules that need these lists MUST import from here.
+ * JSON schema files (schemas/*.schema.json) cannot import TypeScript,
+ * so a conformance test (tests/schemas/allowlist-conformance.test.ts)
+ * asserts that those JSON enums match these canonical arrays.
+ *
+ * @module config/allowlist
+ */
+
+// ============================================================
+// Tool allowlist
+// ============================================================
+
+/**
+ * Canonical list of tools that agents may use.
+ *
+ * Reconciliation notes (issue #871):
+ *   - src/agent-validator/schemas.ts had: Read, Write, Edit, Bash, Glob, Grep,
+ *     WebFetch, WebSearch, LSP, Task, TodoWrite, NotebookEdit  (12 tools)
+ *   - src/config/schemas.ts had:          Read, Write, Edit, Bash, Glob, Grep,
+ *     WebFetch, WebSearch                                       (8 tools)
+ *   - JSON schemas matched src/config/schemas.ts               (8 tools)
+ *
+ * Agents in .claude/agents/ actually declare:
+ *   Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch, Task
+ *
+ * Superset decision:
+ *   - Task: used by orchestrator agents (ad-sdlc-orchestrator, analysis-orchestrator,
+ *     collector). Legitimate — keep.
+ *   - LSP: declared in agent-validator allowlist but not used by any current agent.
+ *     Retained for forward compatibility; does not affect current agent files.
+ *   - TodoWrite: declared in agent-validator allowlist but not used by any current agent.
+ *     Retained for forward compatibility.
+ *   - NotebookEdit: declared in agent-validator allowlist but not used by any current agent.
+ *     Retained for forward compatibility.
+ *   - All 8 tools from src/config/schemas.ts are included.
+ */
+export const CANONICAL_TOOLS = [
+  'Read',
+  'Write',
+  'Edit',
+  'Bash',
+  'Glob',
+  'Grep',
+  'WebFetch',
+  'WebSearch',
+  'Task',
+  'LSP',
+  'TodoWrite',
+  'NotebookEdit',
+] as const;
+
+/**
+ * Type derived from the canonical tool list.
+ */
+export type CanonicalTool = (typeof CANONICAL_TOOLS)[number];
+
+// ============================================================
+// Model allowlist
+// ============================================================
+
+/**
+ * Canonical list of model values that agents may declare.
+ *
+ * Reconciliation notes (issue #871):
+ *   - src/agent-validator/schemas.ts had: sonnet, opus, haiku      (no inherit)
+ *   - src/config/schemas.ts had:          sonnet, opus, haiku      (no inherit)
+ *   - schemas/workflow.schema.json had:   sonnet, opus, haiku      (no inherit)
+ *   - schemas/agents.schema.json had:     sonnet, opus, haiku      (no inherit)
+ *
+ *   35 of 36 agents in .claude/agents/ declare `model: inherit`.
+ *   1 agent (project-initializer) declares `model: haiku`.
+ *
+ *   `inherit` means "use the model the parent agent is running with"
+ *   and is a valid Claude Code frontmatter value.  All four prior
+ *   sources omitted it, causing every real agent to fail validation.
+ *   Added here to fix the contract.
+ */
+export const CANONICAL_MODELS = ['sonnet', 'opus', 'haiku', 'inherit'] as const;
+
+/**
+ * Type derived from the canonical model list.
+ */
+export type CanonicalModel = (typeof CANONICAL_MODELS)[number];
+
+// ============================================================
+// Derived sets for fast membership tests
+// ============================================================
+
+/**
+ * Set of canonical tool names for O(1) membership tests.
+ */
+export const CANONICAL_TOOLS_SET: ReadonlySet<string> = new Set(CANONICAL_TOOLS);
+
+/**
+ * Set of canonical model names for O(1) membership tests.
+ */
+export const CANONICAL_MODELS_SET: ReadonlySet<string> = new Set(CANONICAL_MODELS);

--- a/src/config/schemas.ts
+++ b/src/config/schemas.ts
@@ -8,6 +8,7 @@
  */
 
 import { z } from 'zod';
+import { CANONICAL_TOOLS, CANONICAL_MODELS } from './allowlist.js';
 
 // ============================================================
 // Schema Version
@@ -33,23 +34,16 @@ const VersionSchema = z.string().regex(/^\d+\.\d+\.\d+$/, 'Must be in semver for
 const LogLevelSchema = z.enum(['DEBUG', 'INFO', 'WARN', 'ERROR']);
 
 /**
- * Model selection options
+ * Model selection options — derived from the canonical allowlist (allowlist.ts).
+ * Do not add models here; add them to the canonical module instead.
  */
-const ModelSchema = z.enum(['sonnet', 'opus', 'haiku']);
+const ModelSchema = z.enum(CANONICAL_MODELS);
 
 /**
- * Available tools for agents
+ * Available tools for agents — derived from the canonical allowlist (allowlist.ts).
+ * Do not add tools here; add them to the canonical module instead.
  */
-const ToolSchema = z.enum([
-  'Read',
-  'Write',
-  'Edit',
-  'Bash',
-  'Glob',
-  'Grep',
-  'WebFetch',
-  'WebSearch',
-]);
+const ToolSchema = z.enum(CANONICAL_TOOLS);
 
 // ============================================================
 // Workflow Config Schemas

--- a/tests/schemas/allowlist-conformance.test.ts
+++ b/tests/schemas/allowlist-conformance.test.ts
@@ -1,0 +1,414 @@
+/**
+ * Allowlist conformance tests (issue #871)
+ *
+ * Asserts that:
+ *  1. Every .claude/agents/*.md file validates against the canonical allowlist
+ *     with ZERO rejections (round-trip conformance).
+ *  2. The JSON schema files (schemas/workflow.schema.json,
+ *     schemas/agents.schema.json) carry the same tool/model enums as the
+ *     canonical TS allowlist — this is the anti-divergence enforcement that
+ *     replaces manual synchronisation.
+ *  3. Out-of-allowlist tool/model values are rejected by the validator.
+ *
+ * The test file is the authoritative enforcement gate.  Any edit that changes
+ * a JSON schema enum or the canonical TS allowlist without also updating the
+ * other will break these tests and be caught before merge.
+ */
+
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import * as yaml from 'js-yaml';
+
+import { CANONICAL_TOOLS, CANONICAL_MODELS } from '../../src/config/allowlist.js';
+import { validateAgentFile, validateAllAgents } from '../../src/agent-validator/index.js';
+
+// ============================================================
+// Helpers
+// ============================================================
+
+const PROJECT_ROOT = path.resolve(new URL('../../', import.meta.url).pathname);
+const AGENTS_DIR = path.join(PROJECT_ROOT, '.claude', 'agents');
+const WORKFLOW_SCHEMA = path.join(PROJECT_ROOT, 'schemas', 'workflow.schema.json');
+const AGENTS_SCHEMA = path.join(PROJECT_ROOT, 'schemas', 'agents.schema.json');
+
+/** Enumerate every .md file in .claude/agents/ (excludes .kr.md) */
+function listAgentFiles(): string[] {
+  if (!fs.existsSync(AGENTS_DIR)) return [];
+  return fs
+    .readdirSync(AGENTS_DIR)
+    .filter((f) => f.endsWith('.md') && !f.endsWith('.kr.md'))
+    .map((f) => path.join(AGENTS_DIR, f));
+}
+
+/** Load a JSON schema from disk */
+function loadJsonSchema(schemaPath: string): Record<string, unknown> {
+  const raw = fs.readFileSync(schemaPath, 'utf-8');
+  return JSON.parse(raw) as Record<string, unknown>;
+}
+
+// ============================================================
+// 1. Round-trip conformance — every real agent must validate to zero errors
+// ============================================================
+
+describe('Allowlist round-trip conformance', () => {
+  const agentFiles = listAgentFiles();
+
+  it('should find at least one agent file to validate', () => {
+    expect(agentFiles.length).toBeGreaterThan(0);
+  });
+
+  it(`should validate all ${agentFiles.length} agent files with zero errors`, () => {
+    const report = validateAllAgents({
+      agentsDir: AGENTS_DIR,
+      checkRegistry: false,
+      includeWarnings: false,
+    });
+
+    const failures = report.results.filter((r) => !r.valid);
+
+    if (failures.length > 0) {
+      const details = failures
+        .map(
+          (f) =>
+            `  ${path.basename(f.filePath)}:\n${f.errors.map((e) => `    [${e.field}] ${e.message}`).join('\n')}`
+        )
+        .join('\n');
+      expect.fail(
+        `${failures.length} of ${report.totalFiles} agent files failed validation:\n${details}`
+      );
+    }
+
+    expect(report.invalidCount).toBe(0);
+    expect(report.totalFiles).toBe(agentFiles.length);
+    expect(report.validCount).toBe(agentFiles.length);
+  });
+
+  // One test per agent file for granular CI failure reporting
+  for (const filePath of agentFiles) {
+    const name = path.basename(filePath);
+    it(`${name} passes validation`, () => {
+      const result = validateAgentFile(filePath, {
+        checkRegistry: false,
+        includeWarnings: false,
+      });
+      if (!result.valid) {
+        const msgs = result.errors.map((e) => `[${e.field}] ${e.message}`).join('; ');
+        expect.fail(`${name} failed: ${msgs}`);
+      }
+      expect(result.valid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+    });
+  }
+});
+
+// ============================================================
+// 2. JSON schema parity — JSON enum arrays must equal canonical TS lists
+// ============================================================
+
+describe('JSON schema parity with canonical allowlist', () => {
+  describe('schemas/workflow.schema.json', () => {
+    const schema = loadJsonSchema(WORKFLOW_SCHEMA);
+
+    it('agents.*.model enum equals CANONICAL_MODELS', () => {
+      // Path: properties.agents.additionalProperties.properties.model.enum
+      const agentsSection = (schema as Record<string, unknown>)['properties'] as
+        | Record<string, unknown>
+        | undefined;
+      const agentsAdditional = (agentsSection?.['agents'] as Record<string, unknown> | undefined)?.[
+        'additionalProperties'
+      ] as Record<string, unknown> | undefined;
+      const modelEnum = (
+        (agentsAdditional?.['properties'] as Record<string, unknown> | undefined)?.['model'] as
+          | Record<string, unknown>
+          | undefined
+      )?.['enum'] as string[] | undefined;
+
+      expect(modelEnum).toBeDefined();
+      expect([...modelEnum!].sort()).toEqual([...CANONICAL_MODELS].sort());
+    });
+
+    it('agents.*.tools.items.enum equals CANONICAL_TOOLS', () => {
+      const agentsSection = (schema as Record<string, unknown>)['properties'] as
+        | Record<string, unknown>
+        | undefined;
+      const agentsAdditional = (agentsSection?.['agents'] as Record<string, unknown> | undefined)?.[
+        'additionalProperties'
+      ] as Record<string, unknown> | undefined;
+      const toolsItems = (
+        (agentsAdditional?.['properties'] as Record<string, unknown> | undefined)?.['tools'] as
+          | Record<string, unknown>
+          | undefined
+      )?.['items'] as Record<string, unknown> | undefined;
+      const toolsEnum = toolsItems?.['enum'] as string[] | undefined;
+
+      expect(toolsEnum).toBeDefined();
+      expect([...toolsEnum!].sort()).toEqual([...CANONICAL_TOOLS].sort());
+    });
+
+    it('token_budgets.default_model enum equals CANONICAL_MODELS', () => {
+      const properties = (schema as Record<string, unknown>)['properties'] as
+        | Record<string, unknown>
+        | undefined;
+      const tokenBudgets = properties?.['token_budgets'] as Record<string, unknown> | undefined;
+      const defaultModel = (tokenBudgets?.['properties'] as Record<string, unknown> | undefined)?.[
+        'default_model'
+      ] as Record<string, unknown> | undefined;
+      const modelEnum = defaultModel?.['enum'] as string[] | undefined;
+
+      expect(modelEnum).toBeDefined();
+      expect([...modelEnum!].sort()).toEqual([...CANONICAL_MODELS].sort());
+    });
+  });
+
+  describe('schemas/agents.schema.json', () => {
+    const schema = loadJsonSchema(AGENTS_SCHEMA);
+
+    it('agents.*.model_preference enum equals CANONICAL_MODELS', () => {
+      const properties = (schema as Record<string, unknown>)['properties'] as
+        | Record<string, unknown>
+        | undefined;
+      const agents = properties?.['agents'] as Record<string, unknown> | undefined;
+      const additionalProperties = agents?.['additionalProperties'] as
+        | Record<string, unknown>
+        | undefined;
+      const agentProperties = additionalProperties?.['properties'] as
+        | Record<string, unknown>
+        | undefined;
+      const modelPreference = agentProperties?.['model_preference'] as
+        | Record<string, unknown>
+        | undefined;
+      const modelEnum = modelPreference?.['enum'] as string[] | undefined;
+
+      expect(modelEnum).toBeDefined();
+      expect([...modelEnum!].sort()).toEqual([...CANONICAL_MODELS].sort());
+    });
+
+    it('agents.*.token_budget.model_preference enum equals CANONICAL_MODELS', () => {
+      const properties = (schema as Record<string, unknown>)['properties'] as
+        | Record<string, unknown>
+        | undefined;
+      const agents = properties?.['agents'] as Record<string, unknown> | undefined;
+      const additionalProperties = agents?.['additionalProperties'] as
+        | Record<string, unknown>
+        | undefined;
+      const agentProperties = additionalProperties?.['properties'] as
+        | Record<string, unknown>
+        | undefined;
+      const tokenBudget = agentProperties?.['token_budget'] as Record<string, unknown> | undefined;
+      const tbProperties = tokenBudget?.['properties'] as Record<string, unknown> | undefined;
+      const modelPreference = tbProperties?.['model_preference'] as
+        | Record<string, unknown>
+        | undefined;
+      const modelEnum = modelPreference?.['enum'] as string[] | undefined;
+
+      expect(modelEnum).toBeDefined();
+      expect([...modelEnum!].sort()).toEqual([...CANONICAL_MODELS].sort());
+    });
+  });
+});
+
+// ============================================================
+// 3. Negative tests — out-of-allowlist values are rejected
+// ============================================================
+
+describe('Negative: out-of-allowlist values are rejected', () => {
+  let tempDir: string;
+
+  // Create a fresh temp dir for each test group
+  function setup(): { agentsDir: string } {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'allowlist-neg-'));
+    const agentsDir = path.join(tempDir, '.claude', 'agents');
+    fs.mkdirSync(agentsDir, { recursive: true });
+    return { agentsDir };
+  }
+
+  function teardown() {
+    if (tempDir) fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+
+  it('rejects an agent declaring an unknown tool', () => {
+    const { agentsDir } = setup();
+    try {
+      const content = `---
+name: bad-tool-agent
+description: Agent with an unknown tool for negative testing
+tools:
+  - Read
+  - UnknownTool
+model: inherit
+---
+
+# Bad Tool Agent
+
+## Role
+Testing only.
+`;
+      const filePath = path.join(agentsDir, 'bad-tool-agent.md');
+      fs.writeFileSync(filePath, content);
+
+      const result = validateAgentFile(filePath, { checkRegistry: false });
+
+      expect(result.valid).toBe(false);
+      expect(result.errors.some((e) => e.field.includes('tools'))).toBe(true);
+    } finally {
+      teardown();
+    }
+  });
+
+  it('rejects an agent declaring an unknown model', () => {
+    const { agentsDir } = setup();
+    try {
+      const content = `---
+name: bad-model-agent
+description: Agent with an unknown model for negative testing
+tools:
+  - Read
+model: gpt-4
+---
+
+# Bad Model Agent
+
+## Role
+Testing only.
+`;
+      const filePath = path.join(agentsDir, 'bad-model-agent.md');
+      fs.writeFileSync(filePath, content);
+
+      const result = validateAgentFile(filePath, { checkRegistry: false });
+
+      expect(result.valid).toBe(false);
+      expect(result.errors.some((e) => e.field === 'model')).toBe(true);
+    } finally {
+      teardown();
+    }
+  });
+
+  it('accepts an agent declaring model: inherit', () => {
+    const { agentsDir } = setup();
+    try {
+      const content = `---
+name: inherit-model-agent
+description: Agent using the inherit model keyword
+tools:
+  - Read
+  - Write
+model: inherit
+---
+
+# Inherit Model Agent
+
+## Role
+Testing inherit model acceptance.
+`;
+      const filePath = path.join(agentsDir, 'inherit-model-agent.md');
+      fs.writeFileSync(filePath, content);
+
+      const result = validateAgentFile(filePath, { checkRegistry: false });
+
+      expect(result.valid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+    } finally {
+      teardown();
+    }
+  });
+
+  it('accepts an agent declaring model: haiku', () => {
+    const { agentsDir } = setup();
+    try {
+      const content = `---
+name: haiku-model-agent
+description: Agent using the haiku model
+tools:
+  - Read
+  - Bash
+  - Glob
+model: haiku
+---
+
+# Haiku Model Agent
+
+## Role
+Testing haiku model acceptance.
+`;
+      const filePath = path.join(agentsDir, 'haiku-model-agent.md');
+      fs.writeFileSync(filePath, content);
+
+      const result = validateAgentFile(filePath, { checkRegistry: false });
+
+      expect(result.valid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+    } finally {
+      teardown();
+    }
+  });
+
+  it('accepts an agent declaring the Task tool', () => {
+    const { agentsDir } = setup();
+    try {
+      const content = `---
+name: task-tool-agent
+description: Agent using the Task tool for orchestration
+tools:
+  - Read
+  - Write
+  - Task
+  - Bash
+model: inherit
+---
+
+# Task Tool Agent
+
+## Role
+Testing Task tool acceptance.
+`;
+      const filePath = path.join(agentsDir, 'task-tool-agent.md');
+      fs.writeFileSync(filePath, content);
+
+      const result = validateAgentFile(filePath, { checkRegistry: false });
+
+      expect(result.valid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+    } finally {
+      teardown();
+    }
+  });
+});
+
+// ============================================================
+// 4. Canonical allowlist self-checks
+// ============================================================
+
+describe('Canonical allowlist self-checks', () => {
+  it('CANONICAL_TOOLS contains the minimum expected tools', () => {
+    const required = ['Read', 'Write', 'Edit', 'Bash', 'Glob', 'Grep', 'WebFetch', 'WebSearch'];
+    for (const tool of required) {
+      expect(CANONICAL_TOOLS).toContain(tool);
+    }
+  });
+
+  it('CANONICAL_TOOLS contains Task (used by orchestrator agents)', () => {
+    expect(CANONICAL_TOOLS).toContain('Task');
+  });
+
+  it('CANONICAL_MODELS contains inherit', () => {
+    expect(CANONICAL_MODELS).toContain('inherit');
+  });
+
+  it('CANONICAL_MODELS contains sonnet, opus, haiku', () => {
+    expect(CANONICAL_MODELS).toContain('sonnet');
+    expect(CANONICAL_MODELS).toContain('opus');
+    expect(CANONICAL_MODELS).toContain('haiku');
+  });
+
+  it('CANONICAL_TOOLS has no duplicates', () => {
+    const unique = new Set(CANONICAL_TOOLS);
+    expect(unique.size).toBe(CANONICAL_TOOLS.length);
+  });
+
+  it('CANONICAL_MODELS has no duplicates', () => {
+    const unique = new Set(CANONICAL_MODELS);
+    expect(unique.size).toBe(CANONICAL_MODELS.length);
+  });
+});


### PR DESCRIPTION
## What

### Summary
Introduces `src/config/allowlist.ts` as the single canonical source of truth for the agent tool and model allowlists. Wires all TypeScript consumers to import from it and enforces JSON schema parity via a new conformance test suite.

### Change Type
- [x] Feature (new functionality — allowlist module + conformance tests)
- [x] Bugfix (validator rejected `model: inherit` used by 35/36 agents; CRLF line endings in agent files broke the frontmatter parser)
- [ ] Refactor
- [x] Test

## Why

### Problem Solved
The tool/model allowlists were duplicated across five sources with no enforcement, and they had drifted:

| Source | Tools | Models |
|---|---|---|
| `src/agent-validator/schemas.ts` | 12 (incl LSP/Task/TodoWrite/NotebookEdit) | sonnet, opus, haiku |
| `src/config/schemas.ts` | 8 (no Task/LSP/TodoWrite/NotebookEdit) | sonnet, opus, haiku |
| `schemas/workflow.schema.json` | 8 | sonnet, opus, haiku |
| `schemas/agents.schema.json` | — | sonnet, opus, haiku |
| `.claude/agents/*.md` (36 files) | Read/Write/Edit/Bash/Glob/Grep/WebFetch/WebSearch/Task | **inherit** (35 agents), haiku (1 agent) |

Critical gap: `inherit` was declared by 35 of 36 real agents but rejected by every validator. CRLF line endings in all agent files caused the frontmatter parser to fail silently.

### Related Issues
Closes #871

## Who

### Reviewers
- Backend / infra team — new canonical module, schema wiring
- QA — new conformance test behaviour

## When

### Urgency
- [x] Normal

## Where

### Files Changed Summary
| Path | Change |
|---|---|
| `src/config/allowlist.ts` | NEW — canonical SSOT module |
| `src/config/schemas.ts` | Import from allowlist instead of duplicating literals |
| `src/config/ConfigManager.ts` | `AgentWorkflowConfig.model` type widened to `CanonicalModel` |
| `src/agent-validator/schemas.ts` | `VALID_TOOLS`/`VALID_MODELS` re-exported from allowlist |
| `src/agent-validator/types.ts` | `AgentTool`/`AgentModel` aliased from canonical types |
| `src/agent-validator/validator.ts` | Normalise CRLF → LF before frontmatter regex |
| `schemas/workflow.schema.json` | model enum + tools enum updated to match canonical |
| `schemas/agents.schema.json` | model_preference enum updated to match canonical |
| `tests/schemas/allowlist-conformance.test.ts` | NEW — conformance enforcement gate |

## How

### Implementation Highlights
1. **Canonical module** (`src/config/allowlist.ts`): exports `CANONICAL_TOOLS` (12 tools) and `CANONICAL_MODELS` (4 values incl. `inherit`), plus derived `Set` types for O(1) membership tests.
2. **TS consumer wiring**: both schema files import from the canonical module; no independent literals remain.
3. **JSON schema conformance test** (`tests/schemas/allowlist-conformance.test.ts`): asserts JSON enum arrays equal the canonical TS arrays — fails if anyone edits one without the other.
4. **CRLF fix**: normalise `\r\n` to `\n` before the frontmatter regex so Windows-format agent files parse correctly.
5. **Round-trip gate**: test enumerates all 36 `.claude/agents/*.md` files dynamically and asserts 0 validation failures.

### Reconciliation decisions
- **Task**: used by ad-sdlc-orchestrator, analysis-orchestrator, collector — added to superset.
- **LSP / TodoWrite / NotebookEdit**: declared in the old agent-validator list, not used by current agents — retained for forward compatibility.
- **inherit**: 35/36 agents use it; valid Claude Code frontmatter value — added to CANONICAL_MODELS.

### Testing Done
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run tests/agent-validator/ tests/config/ tests/schemas/` — 357/357 pass
- [x] Conformance: 36 agent files round-tripped, 0 rejections

### Breaking Changes
None — validator is not wired into the runtime dispatch path (this is unchanged per scope guard).

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Tests added/updated (54 new conformance tests)
- [x] No sensitive data exposed
- [x] Commits are atomic and well-described
- [x] Related issue linked: Closes #871