### PR TITLE
security(collector): block SSRF via redirect re-validation and IP-form hardening

### DIFF
--- a/src/collector/InputParser.ts
+++ b/src/collector/InputParser.ts
@@ -25,6 +25,7 @@ import {
   UrlFetchError,
   InputParseError,
 } from './errors.js';
+import { InputValidator } from '../security/InputValidator.js';
 
 /**
  * Supported file extensions and their types
@@ -56,6 +57,11 @@ export interface InputParserOptions {
   readonly urlTimeout?: number;
   /** Whether to follow redirects (default: true) */
   readonly followRedirects?: boolean;
+  /**
+   * Maximum number of redirects to follow when followRedirects is true (default: 10).
+   * Each redirect target is re-validated for SSRF before following.
+   */
+  readonly maxRedirects?: number;
 }
 
 /**
@@ -65,7 +71,18 @@ const DEFAULT_OPTIONS: Required<InputParserOptions> = {
   maxFileSize: 10 * 1024 * 1024, // 10MB
   urlTimeout: 30000,
   followRedirects: true,
+  maxRedirects: 10,
 };
+
+/**
+ * Shared InputValidator instance used by fetchUrlContent for SSRF protection.
+ * Configured to allow http: and https: and block internal hosts.
+ */
+const URL_SSRF_VALIDATOR = new InputValidator({
+  basePath: '/',
+  allowedProtocols: ['http:', 'https:'],
+  blockInternalUrls: true,
+});
 
 /**
  * InputParser class for processing various input sources
@@ -354,84 +371,207 @@ export class InputParser {
   }
 
   /**
-   * Fetch URL content
+   * Fetch URL content with SSRF protection.
+   *
+   * Security measures applied:
+   * 1. Initial URL is validated via InputValidator (blocks internal/private hosts,
+   *    decimal/hex/octal IPv4, link-local 169.254.x.x, IPv4-mapped IPv6, etc.).
+   * 2. Redirects are followed manually (redirect: 'manual') so every Location
+   *    header is re-validated before the next hop is fetched.  A redirect chain
+   *    longer than maxRedirects is rejected.
+   * 3. When followRedirects is false, 3xx responses are returned as errors
+   *    (consistent with previous 'manual' behaviour).
+   *
+   * TODO(SSRF): DNS-rebinding protection — a hostname that passes the string-based
+   * blocklist could resolve to a private IP at fetch time.  Full protection requires
+   * resolving the hostname to an IP address and re-running the blocklist against that
+   * IP before each connection.  Implementing this would require low-level socket
+   * control or a custom DNS resolver, which is out of scope for this issue and should
+   * be addressed as a tracked follow-up.
    *
    * @param url - URL to fetch
    * @returns UrlFetchResult with fetched content
    */
   public async fetchUrlContent(url: string): Promise<UrlFetchResult> {
+    // --- Step 1: Validate the initial URL ---
     try {
-      // Validate URL
-      const parsedUrl = new URL(url);
-      if (!['http:', 'https:'].includes(parsedUrl.protocol)) {
-        return {
-          success: false,
-          content: '',
-          url,
-          error: `Unsupported protocol: ${parsedUrl.protocol}`,
-        };
+      URL_SSRF_VALIDATOR.validateUrl(url);
+    } catch (error) {
+      return {
+        success: false,
+        content: '',
+        url,
+        error: error instanceof Error ? error.message : 'URL validation failed',
+      };
+    }
+
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => {
+      controller.abort();
+    }, this.options.urlTimeout);
+
+    try {
+      return await this.fetchWithRedirectGuard(url, controller, timeoutId);
+    } catch (error) {
+      clearTimeout(timeoutId);
+      if (error instanceof Error) {
+        if (error.name === 'AbortError') {
+          return { success: false, content: '', url, error: 'Request timeout' };
+        }
+        return { success: false, content: '', url, error: error.message };
       }
+      throw error;
+    }
+  }
 
-      const controller = new AbortController();
-      const timeoutId = setTimeout(() => {
-        controller.abort();
-      }, this.options.urlTimeout);
+  /**
+   * Inner redirect-aware fetch loop with per-hop SSRF re-validation.
+   *
+   * Separated from the public API to keep the outer try/catch minimal and
+   * to avoid the ESLint `no-unnecessary-condition` rule that flags `while(true)`.
+   * The loop is bounded: we perform at most (maxRedirects + 1) fetch calls total.
+   *
+   * @param initialUrl - The already-validated initial URL to fetch
+   * @param controller - AbortController shared with the timeout
+   * @param timeoutId - setTimeout handle so we can clear it on early exit
+   * @returns UrlFetchResult from the final non-redirect response
+   */
+  private async fetchWithRedirectGuard(
+    initialUrl: string,
+    controller: AbortController,
+    timeoutId: ReturnType<typeof setTimeout>
+  ): Promise<UrlFetchResult> {
+    const maxAttempts = this.options.followRedirects ? this.options.maxRedirects + 1 : 1;
+    let currentUrl = initialUrl;
 
+    // --- Step 2: Manual redirect loop, bounded by maxAttempts ---
+    for (let attempt = 0; attempt < maxAttempts; attempt++) {
+      let response: Response;
       try {
-        const response = await fetch(url, {
+        response = await fetch(currentUrl, {
           signal: controller.signal,
-          redirect: this.options.followRedirects ? 'follow' : 'manual',
+          redirect: 'manual', // always manual — we handle redirects ourselves
           headers: {
             'User-Agent': 'AD-SDLC-Collector/1.0',
             Accept: 'text/html,text/plain,application/json,*/*',
           },
         });
-
+      } catch (fetchError) {
         clearTimeout(timeoutId);
+        if (fetchError instanceof Error) {
+          if (fetchError.name === 'AbortError') {
+            return { success: false, content: '', url: initialUrl, error: 'Request timeout' };
+          }
+          return { success: false, content: '', url: initialUrl, error: fetchError.message };
+        }
+        throw fetchError;
+      }
 
-        if (!response.ok) {
+      // Handle redirects (3xx)
+      if (response.status >= 300 && response.status < 400) {
+        // followRedirects === false: treat 3xx as an error
+        if (!this.options.followRedirects) {
+          clearTimeout(timeoutId);
           return {
             success: false,
             content: '',
-            url,
+            url: initialUrl,
             error: `HTTP ${String(response.status)}: ${response.statusText}`,
           };
         }
 
-        const contentType = response.headers.get('content-type') ?? '';
-        const text = await response.text();
-        const content = this.processUrlContent(text, contentType);
-        const title = this.extractTitle(text, contentType);
-
-        return {
-          success: true,
-          content,
-          url,
-          finalUrl: response.url,
-          title,
-        };
-      } finally {
-        clearTimeout(timeoutId);
-      }
-    } catch (error) {
-      if (error instanceof Error) {
-        if (error.name === 'AbortError') {
+        // Exhausted hop budget on this iteration — the next attempt would exceed
+        // maxRedirects, so reject before following further.
+        if (attempt >= this.options.maxRedirects) {
+          clearTimeout(timeoutId);
           return {
             success: false,
             content: '',
-            url,
-            error: 'Request timeout',
+            url: initialUrl,
+            error: `Too many redirects (max ${String(this.options.maxRedirects)})`,
           };
         }
+
+        const location = response.headers.get('location');
+        if (location === null || location.length === 0) {
+          clearTimeout(timeoutId);
+          return {
+            success: false,
+            content: '',
+            url: initialUrl,
+            error: `HTTP ${String(response.status)}: redirect with no Location header`,
+          };
+        }
+
+        // Resolve relative Location against current URL
+        let nextUrl: string;
+        try {
+          nextUrl = new URL(location, currentUrl).href;
+        } catch {
+          clearTimeout(timeoutId);
+          return {
+            success: false,
+            content: '',
+            url: initialUrl,
+            error: `Invalid redirect Location: ${location}`,
+          };
+        }
+
+        // --- Step 3: Re-validate each redirect target ---
+        try {
+          URL_SSRF_VALIDATOR.validateUrl(nextUrl);
+        } catch (validationError) {
+          clearTimeout(timeoutId);
+          return {
+            success: false,
+            content: '',
+            url: initialUrl,
+            error:
+              validationError instanceof Error
+                ? validationError.message
+                : 'Redirect target URL validation failed',
+          };
+        }
+
+        currentUrl = nextUrl;
+        continue; // follow the redirect
+      }
+
+      // Non-redirect response
+      clearTimeout(timeoutId);
+
+      if (!response.ok) {
         return {
           success: false,
           content: '',
-          url,
-          error: error.message,
+          url: initialUrl,
+          error: `HTTP ${String(response.status)}: ${response.statusText}`,
         };
       }
-      throw error;
+
+      const contentType = response.headers.get('content-type') ?? '';
+      const text = await response.text();
+      const content = this.processUrlContent(text, contentType);
+      const title = this.extractTitle(text, contentType);
+
+      return {
+        success: true,
+        content,
+        url: initialUrl,
+        finalUrl: currentUrl,
+        title,
+      };
     }
+
+    // Should not be reached under normal circumstances (loop exits via return),
+    // but satisfies TypeScript's control-flow analysis.
+    clearTimeout(timeoutId);
+    return {
+      success: false,
+      content: '',
+      url: initialUrl,
+      error: `Too many redirects (max ${String(this.options.maxRedirects)})`,
+    };
   }
 
   /**

--- a/src/security/InputValidator.ts
+++ b/src/security/InputValidator.ts
@@ -23,7 +23,19 @@ import type { AuditLogger } from './AuditLogger.js';
 const DEFAULT_ALLOWED_PROTOCOLS = ['https:'] as const;
 
 /**
- * Internal hostname patterns to block
+ * Internal hostname patterns to block (string-based, no DNS resolution).
+ *
+ * Covers:
+ *  - loopback: localhost, 127.x.x.x, ::1
+ *  - private ranges: 10.x, 172.16-31.x, 192.168.x
+ *  - link-local: 169.254.x.x (incl. cloud-metadata 169.254.169.254), fe80::
+ *  - ULA IPv6: fc00:, fd00:
+ *  - unspecified: 0.0.0.0
+ *  - special TLD suffixes: .local, .internal, .localhost
+ *  - decimal IPv4 (e.g. 2130706433 == 127.0.0.1)
+ *  - hex IPv4 (e.g. 0x7f000001)
+ *  - octal-segment IPv4 (e.g. 0177.0.0.1)
+ *  - IPv4-mapped IPv6 (e.g. ::ffff:127.0.0.1)
  */
 const INTERNAL_HOSTNAME_PATTERNS = [
   /^localhost$/i,
@@ -31,6 +43,7 @@ const INTERNAL_HOSTNAME_PATTERNS = [
   /^10\.\d+\.\d+\.\d+$/,
   /^172\.(1[6-9]|2\d|3[01])\.\d+\.\d+$/,
   /^192\.168\.\d+\.\d+$/,
+  /^169\.254\.\d+\.\d+$/, // link-local (incl. cloud-metadata 169.254.169.254)
   /^0\.0\.0\.0$/,
   /^::1$/,
   /^fe80:/i,
@@ -39,7 +52,98 @@ const INTERNAL_HOSTNAME_PATTERNS = [
   /\.local$/i,
   /\.internal$/i,
   /\.localhost$/i,
+  // IPv4-mapped IPv6: ::ffff:a.b.c.d or ::ffff:0xNN...
+  /^::ffff:/i,
 ];
+
+/**
+ * Maximum numeric IPv4 address (255.255.255.255 as decimal)
+ */
+const MAX_IPV4_DECIMAL = 0xffffffff;
+
+/**
+ * Private/reserved IPv4 ranges encoded as [start, end] inclusive pairs
+ * (32-bit unsigned integers, big-endian).
+ */
+const RESERVED_IPV4_RANGES: ReadonlyArray<readonly [number, number]> = [
+  [0x00000000, 0x00ffffff], // 0.0.0.0/8  (this-network + unspecified)
+  [0x7f000000, 0x7fffffff], // 127.0.0.0/8  loopback
+  [0xa9fe0000, 0xa9feffff], // 169.254.0.0/16  link-local (cloud-metadata)
+  [0x0a000000, 0x0affffff], // 10.0.0.0/8  private
+  [0xac100000, 0xac1fffff], // 172.16.0.0/12  private
+  [0xc0a80000, 0xc0a8ffff], // 192.168.0.0/16  private
+  [0xe0000000, 0xffffffff], // 224.0.0.0/4+  multicast + reserved
+];
+
+/**
+ * Parse a hostname token as a 32-bit IPv4 integer, supporting decimal,
+ * hex (0x…), and octal (0…) representations.
+ * Returns undefined when the token is not a valid single-component IPv4.
+ *
+ * @param token - A single dot-delimited segment from an IPv4 hostname string
+ * @returns The 32-bit unsigned value of the token, or undefined if unparseable
+ */
+function parseSingleComponentIpv4(token: string): number | undefined {
+  if (token.length === 0) return undefined;
+  let value: number;
+  if (/^0x[0-9a-f]+$/i.test(token)) {
+    value = parseInt(token, 16);
+  } else if (token.startsWith('0') && token.length > 1 && /^[0-7]+$/.test(token)) {
+    value = parseInt(token, 8);
+  } else if (/^\d+$/.test(token)) {
+    value = parseInt(token, 10);
+  } else {
+    return undefined;
+  }
+  if (!isFinite(value) || value < 0 || value > MAX_IPV4_DECIMAL) return undefined;
+  return value >>> 0; // treat as unsigned 32-bit
+}
+
+/**
+ * Determine whether a hostname represents a reserved/private IPv4 address,
+ * including decimal (2130706433), hex (0x7f000001), octal (0177.0.0.1),
+ * and mixed-radix dotted forms.
+ *
+ * @param hostname - The hostname string to evaluate (brackets already stripped)
+ * @returns True when the hostname encodes a reserved/private IPv4 address
+ */
+function isReservedIpv4Hostname(hostname: string): boolean {
+  // Strip surrounding brackets (IPv6 literal in URL won't reach here, but guard anyway)
+  const h = hostname.replace(/^\[|\]$/g, '');
+  const parts = h.split('.');
+
+  // Single-component: pure decimal, hex, or octal encoding of full 32-bit address
+  if (parts.length === 1) {
+    const v = parseSingleComponentIpv4(parts[0] as string);
+    if (v === undefined) return false;
+    return RESERVED_IPV4_RANGES.some(([lo, hi]) => v >= lo && v <= hi);
+  }
+
+  // Dotted forms: 1–4 components; last component may carry multiple octets
+  if (parts.length > 4) return false;
+
+  let ip32 = 0;
+  for (let i = 0; i < parts.length; i++) {
+    const part = parts[i];
+    if (part === undefined) return false;
+    const v = parseSingleComponentIpv4(part);
+    if (v === undefined) return false;
+
+    if (i < parts.length - 1) {
+      // Leading components must be single-octet (0–255)
+      if (v > 0xff) return false;
+      ip32 = (ip32 | (v << (24 - i * 8))) >>> 0;
+    } else {
+      // Last component carries the remaining octets
+      const remainingBits = (4 - parts.length + 1) * 8;
+      const maxVal = (1 << remainingBits) - 1;
+      if (v > maxVal) return false;
+      ip32 = (ip32 | v) >>> 0;
+    }
+  }
+
+  return RESERVED_IPV4_RANGES.some(([lo, hi]) => ip32 >= lo && ip32 <= hi);
+}
 
 /**
  * Extended validation result with additional security information
@@ -318,11 +422,31 @@ export class InputValidator {
   /**
    * Check if a hostname is internal/private
    *
-   * @param hostname - The hostname to check
+   * Checks pattern-based blocklist first (fast), then handles IPv6 literals
+   * (which arrive with surrounding brackets from URL.hostname) and finally
+   * parses alternative IPv4 representations (decimal, hex, octal, mixed-radix)
+   * that bypass naive regex.
+   *
+   * Note on Node.js URL normalisation: the built-in URL parser already
+   * normalises decimal/hex/octal IPv4 addresses to dotted-decimal form, so
+   * e.g. "2130706433", "0x7f000001", and "0177.0.0.1" all become "127.0.0.1"
+   * before reaching this method.  The isReservedIpv4Hostname helper remains as
+   * a defence-in-depth layer for environments where URL normalisation differs.
+   *
+   * @param hostname - The hostname as returned by URL.hostname (may include
+   *   surrounding brackets for IPv6 literals, e.g. "[::ffff:7f00:1]").
    * @returns True if the hostname is internal
    */
   private isInternalHostname(hostname: string): boolean {
-    return INTERNAL_HOSTNAME_PATTERNS.some((pattern) => pattern.test(hostname));
+    // Strip brackets from IPv6 literals: URL.hostname returns "[::1]" etc.
+    const bare =
+      hostname.startsWith('[') && hostname.endsWith(']') ? hostname.slice(1, -1) : hostname;
+
+    if (INTERNAL_HOSTNAME_PATTERNS.some((pattern) => pattern.test(bare))) {
+      return true;
+    }
+    // Catch non-standard IPv4 encodings (decimal, hex, octal, mixed-radix)
+    return isReservedIpv4Hostname(bare);
   }
 
   /**

--- a/tests/collector/InputParser.ssrf.test.ts
+++ b/tests/collector/InputParser.ssrf.test.ts
@@ -1,0 +1,236 @@
+/**
+ * SSRF protection tests for InputParser.fetchUrlContent — issue #875.
+ *
+ * All network calls are intercepted via globalThis.fetch mock.
+ * No real network requests are made.
+ *
+ * Tests verify:
+ *  1. Direct fetch of 169.254.169.254 is blocked before any network call.
+ *  2. A redirect from a benign host to 169.254.169.254 is caught and refused.
+ *  3. A redirect from a benign host to 127.0.0.1 is caught and refused.
+ *  4. Decimal-IP form (http://2130706433/) is blocked.
+ *  5. Each redirect hop is individually re-validated (not only the initial URL).
+ *  6. A normal, allowed URL succeeds.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { InputParser } from '../../src/collector/InputParser.js';
+
+describe('InputParser SSRF protection (#875)', () => {
+  let parser: InputParser;
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    parser = new InputParser({ followRedirects: true, maxRedirects: 5 });
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Helper: build a minimal Response-like object
+  // ---------------------------------------------------------------------------
+  function makeResponse(
+    body: string,
+    options: {
+      status?: number;
+      statusText?: string;
+      contentType?: string;
+      location?: string;
+    } = {}
+  ): Response {
+    const { status = 200, statusText = 'OK', contentType = 'text/plain', location } = options;
+    const headers = new Headers({ 'content-type': contentType });
+    if (location !== undefined) headers.set('location', location);
+    return {
+      ok: status >= 200 && status < 300,
+      status,
+      statusText,
+      url: '',
+      headers,
+      text: async () => body,
+      json: async () => JSON.parse(body) as unknown,
+      clone: () => makeResponse(body, options),
+    } as Response;
+  }
+
+  // ---------------------------------------------------------------------------
+  // 1. Direct fetch of 169.254.169.254 is blocked (pre-fetch validation)
+  // ---------------------------------------------------------------------------
+  it('blocks direct fetch of 169.254.169.254 without making a network call', async () => {
+    const mockFetch = vi.fn();
+    globalThis.fetch = mockFetch;
+
+    const result = await parser.fetchUrlContent('http://169.254.169.254/latest/meta-data/');
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBeTruthy();
+    // Must not have made any real network call
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  // ---------------------------------------------------------------------------
+  // 2. Redirect from benign host → 169.254.169.254 is refused
+  // ---------------------------------------------------------------------------
+  it('blocks a redirect chain that leads to 169.254.169.254', async () => {
+    globalThis.fetch = vi
+      .fn()
+      // First request: benign host returns 302 → metadata endpoint
+      .mockResolvedValueOnce(
+        makeResponse('', {
+          status: 302,
+          statusText: 'Found',
+          location: 'http://169.254.169.254/latest/meta-data/',
+        })
+      )
+      // Second request should NEVER be called — validation must stop the chain
+      .mockResolvedValueOnce(makeResponse('SECRET', { contentType: 'text/plain' }));
+
+    const result = await parser.fetchUrlContent('https://safe.example.com/redirect');
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBeTruthy();
+    // Fetch should have been called exactly once (for the initial URL)
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  // ---------------------------------------------------------------------------
+  // 3. Redirect from benign host → 127.0.0.1 is refused
+  // ---------------------------------------------------------------------------
+  it('blocks a redirect chain that leads to 127.0.0.1', async () => {
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValueOnce(
+        makeResponse('', {
+          status: 301,
+          statusText: 'Moved Permanently',
+          location: 'http://127.0.0.1:8080/admin',
+        })
+      )
+      .mockResolvedValueOnce(makeResponse('ADMIN PAGE', { contentType: 'text/html' }));
+
+    const result = await parser.fetchUrlContent('https://safe.example.com/admin-redirect');
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBeTruthy();
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  // ---------------------------------------------------------------------------
+  // 4. Decimal-IP URL form is blocked (http://2130706433/ == 127.0.0.1)
+  // ---------------------------------------------------------------------------
+  it('blocks decimal IPv4 form http://2130706433/', async () => {
+    const mockFetch = vi.fn();
+    globalThis.fetch = mockFetch;
+
+    const result = await parser.fetchUrlContent('http://2130706433/');
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBeTruthy();
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  // ---------------------------------------------------------------------------
+  // 5. Each redirect hop is re-validated, not only the initial URL
+  //    Scenario: hop1 (benign) → hop2 (benign) → hop3 (private) — must be
+  //    caught at hop3 and not proceed to any further request.
+  // ---------------------------------------------------------------------------
+  it('re-validates every redirect hop, not just the initial URL', async () => {
+    const fetchMock = vi
+      .fn()
+      // hop 1: benign → hop2
+      .mockResolvedValueOnce(
+        makeResponse('', {
+          status: 302,
+          location: 'https://another.example.com/step2',
+        })
+      )
+      // hop 2: benign → private IP (the exploit)
+      .mockResolvedValueOnce(
+        makeResponse('', {
+          status: 302,
+          location: 'http://10.0.0.1/internal',
+        })
+      )
+      // hop 3: should NEVER be called
+      .mockResolvedValueOnce(makeResponse('INTERNAL DATA', { contentType: 'text/plain' }));
+
+    globalThis.fetch = fetchMock;
+
+    const result = await parser.fetchUrlContent('https://start.example.com/chain');
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBeTruthy();
+    // Two fetches were made (hop1 + hop2); hop3 was rejected by validation
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  // ---------------------------------------------------------------------------
+  // 6. A normal, allowed URL succeeds
+  // ---------------------------------------------------------------------------
+  it('allows a normal public URL and returns its content', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValueOnce(
+      makeResponse('Hello from example.com', {
+        status: 200,
+        contentType: 'text/plain',
+      })
+    );
+
+    const result = await parser.fetchUrlContent('https://example.com/hello');
+
+    expect(result.success).toBe(true);
+    expect(result.content).toBe('Hello from example.com');
+  });
+
+  // ---------------------------------------------------------------------------
+  // Extra: redirect to a public URL (non-private) succeeds
+  // ---------------------------------------------------------------------------
+  it('allows following redirects to legitimate public URLs', async () => {
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValueOnce(
+        makeResponse('', {
+          status: 301,
+          location: 'https://www.example.com/final',
+        })
+      )
+      .mockResolvedValueOnce(
+        makeResponse('Final destination', {
+          status: 200,
+          contentType: 'text/plain',
+        })
+      );
+
+    const result = await parser.fetchUrlContent('https://example.com/moved');
+
+    expect(result.success).toBe(true);
+    expect(result.content).toBe('Final destination');
+    expect(result.finalUrl).toBe('https://www.example.com/final');
+  });
+
+  // ---------------------------------------------------------------------------
+  // Extra: too many redirects are rejected
+  // ---------------------------------------------------------------------------
+  it('rejects redirect chains that exceed maxRedirects', async () => {
+    // maxRedirects = 5, so we set up 6 redirect hops
+    const parserStrict = new InputParser({ followRedirects: true, maxRedirects: 3 });
+    const redirectResponse = (location: string) => makeResponse('', { status: 302, location });
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(redirectResponse('https://a.example.com/2'))
+      .mockResolvedValueOnce(redirectResponse('https://b.example.com/3'))
+      .mockResolvedValueOnce(redirectResponse('https://c.example.com/4'))
+      .mockResolvedValueOnce(redirectResponse('https://d.example.com/5'))
+      .mockResolvedValueOnce(makeResponse('final', { status: 200, contentType: 'text/plain' }));
+
+    globalThis.fetch = fetchMock;
+
+    const result = await parserStrict.fetchUrlContent('https://start.example.com/1');
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/too many redirect/i);
+  });
+});

--- a/tests/collector/InputParser.test.ts
+++ b/tests/collector/InputParser.test.ts
@@ -421,9 +421,11 @@ describe('InputParser', () => {
     });
 
     it('should throw UrlFetchError for HTTP error responses', async () => {
-      globalThis.fetch = vi.fn().mockResolvedValue(
-        createMockResponse('Not Found', { status: 404, statusText: 'Not Found' })
-      );
+      globalThis.fetch = vi
+        .fn()
+        .mockResolvedValue(
+          createMockResponse('Not Found', { status: 404, statusText: 'Not Found' })
+        );
 
       await expect(parser.parseUrl('https://example.com/missing')).rejects.toThrow(UrlFetchError);
     });
@@ -447,12 +449,27 @@ describe('InputParser', () => {
     });
 
     it('should track final URL after redirects', async () => {
-      globalThis.fetch = vi.fn().mockResolvedValue(
-        createMockResponse('Redirected content', {
-          contentType: 'text/plain',
-          url: 'https://example.com/final-page',
-        })
-      );
+      // Simulate a 301 redirect: first call returns 301 with Location header,
+      // second call returns the actual content at the final URL.
+      globalThis.fetch = vi
+        .fn()
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 301,
+          statusText: 'Moved Permanently',
+          headers: new Headers({
+            'content-type': 'text/plain',
+            location: 'https://example.com/final-page',
+          }),
+          text: async () => '',
+          url: 'https://example.com/redirect',
+        } as Response)
+        .mockResolvedValueOnce(
+          createMockResponse('Redirected content', {
+            contentType: 'text/plain',
+            url: 'https://example.com/final-page',
+          })
+        );
 
       const result = await parser.parseUrl('https://example.com/redirect');
 
@@ -624,19 +641,23 @@ describe('InputParser', () => {
     });
 
     it('should include final URL in result', async () => {
+      // Without a redirect, finalUrl equals the requested URL.
+      // The previous implementation used response.url for finalUrl; the new
+      // implementation tracks the URL through the manual redirect loop and
+      // reports currentUrl as finalUrl.
       globalThis.fetch = vi.fn().mockResolvedValue({
         ok: true,
         status: 200,
         statusText: 'OK',
         headers: new Headers({ 'content-type': 'text/plain' }),
         text: async () => 'content',
-        url: 'https://example.com/final',
+        url: 'https://example.com/original',
       } as Response);
 
       const result = await parser.fetchUrlContent('https://example.com/original');
 
       expect(result.success).toBe(true);
-      expect(result.finalUrl).toBe('https://example.com/final');
+      expect(result.finalUrl).toBe('https://example.com/original');
     });
   });
 });

--- a/tests/security/InputValidator.ssrf.test.ts
+++ b/tests/security/InputValidator.ssrf.test.ts
@@ -1,0 +1,163 @@
+/**
+ * SSRF hardening tests for InputValidator.
+ *
+ * Verifies that the additional IP-form blocklist entries introduced in
+ * the fix for issue #875 are correctly rejected, while legitimate public
+ * URLs continue to pass.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { InputValidator } from '../../src/security/InputValidator.js';
+import { InvalidUrlError } from '../../src/security/errors.js';
+
+describe('InputValidator SSRF hardening (#875)', () => {
+  let validator: InputValidator;
+  const basePath = path.join(os.tmpdir(), 'ssrf-validator-test');
+
+  beforeEach(() => {
+    // Allow both http: and https: so we can test more URL forms.
+    validator = new InputValidator({
+      basePath,
+      allowedProtocols: ['http:', 'https:'],
+      blockInternalUrls: true,
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Link-local / cloud-metadata (169.254.0.0/16)
+  // -------------------------------------------------------------------------
+  describe('link-local / cloud-metadata 169.254.x.x', () => {
+    it('should block 169.254.169.254 (AWS metadata endpoint)', () => {
+      expect(() => validator.validateUrl('http://169.254.169.254/')).toThrow(InvalidUrlError);
+    });
+
+    it('should block 169.254.0.1', () => {
+      expect(() => validator.validateUrl('http://169.254.0.1/')).toThrow(InvalidUrlError);
+    });
+
+    it('should block 169.254.255.255', () => {
+      expect(() => validator.validateUrl('https://169.254.255.255/')).toThrow(InvalidUrlError);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Decimal (single-component) IPv4
+  // -------------------------------------------------------------------------
+  describe('decimal IPv4', () => {
+    it('should block 2130706433 (== 127.0.0.1)', () => {
+      expect(() => validator.validateUrl('http://2130706433/')).toThrow(InvalidUrlError);
+    });
+
+    it('should block 167772161 (== 10.0.0.1)', () => {
+      expect(() => validator.validateUrl('http://167772161/')).toThrow(InvalidUrlError);
+    });
+
+    it('should block 2851995649 (== 169.254.169.1)', () => {
+      // 169*2^24 + 254*2^16 + 169*2^8 + 1 = 2851995649
+      expect(() => validator.validateUrl('http://2851995649/')).toThrow(InvalidUrlError);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Hex IPv4
+  // -------------------------------------------------------------------------
+  describe('hex IPv4', () => {
+    it('should block 0x7f000001 (== 127.0.0.1)', () => {
+      expect(() => validator.validateUrl('http://0x7f000001/')).toThrow(InvalidUrlError);
+    });
+
+    it('should block 0xA9FEA9FE (== 169.254.169.254)', () => {
+      expect(() => validator.validateUrl('http://0xA9FEA9FE/')).toThrow(InvalidUrlError);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Octal-segment IPv4
+  // -------------------------------------------------------------------------
+  describe('octal-segment IPv4', () => {
+    it('should block 0177.0.0.1 (== 127.0.0.1)', () => {
+      expect(() => validator.validateUrl('http://0177.0.0.1/')).toThrow(InvalidUrlError);
+    });
+
+    it('should block 0251.0376.0251.0376 (== 169.254.169.254)', () => {
+      expect(() => validator.validateUrl('http://0251.0376.0251.0376/')).toThrow(InvalidUrlError);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // IPv4-mapped IPv6
+  //
+  // Node.js URL.hostname normalises these to hex-group form and strips the
+  // embedded IPv4 dotted notation, e.g.:
+  //   [::ffff:127.0.0.1]       → bare hostname  ::ffff:7f00:1
+  //   [::ffff:169.254.169.254] → bare hostname  ::ffff:a9fe:a9fe
+  // Both the original URL forms and the normalised hex forms are blocked via
+  // the "^::ffff:" pattern match applied to the bare (bracket-stripped) hostname.
+  // -------------------------------------------------------------------------
+  describe('IPv4-mapped IPv6', () => {
+    it('should block [::ffff:127.0.0.1] (normalised to ::ffff:7f00:1 by URL parser)', () => {
+      expect(() => validator.validateUrl('http://[::ffff:127.0.0.1]/')).toThrow(InvalidUrlError);
+    });
+
+    it('should block [::ffff:7f00:1] (direct hex form for 127.0.0.1)', () => {
+      expect(() => validator.validateUrl('http://[::ffff:7f00:1]/')).toThrow(InvalidUrlError);
+    });
+
+    it('should block [::ffff:169.254.169.254] (cloud-metadata, normalised to ::ffff:a9fe:a9fe)', () => {
+      expect(() => validator.validateUrl('http://[::ffff:169.254.169.254]/')).toThrow(
+        InvalidUrlError
+      );
+    });
+
+    it('should block [::ffff:a9fe:a9fe] (direct hex form for 169.254.169.254)', () => {
+      expect(() => validator.validateUrl('http://[::ffff:a9fe:a9fe]/')).toThrow(InvalidUrlError);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Existing private ranges still blocked
+  // -------------------------------------------------------------------------
+  describe('existing private/loopback ranges', () => {
+    it('should block localhost', () => {
+      expect(() => validator.validateUrl('http://localhost/')).toThrow(InvalidUrlError);
+    });
+
+    it('should block 127.0.0.1', () => {
+      expect(() => validator.validateUrl('http://127.0.0.1/')).toThrow(InvalidUrlError);
+    });
+
+    it('should block 10.0.0.1', () => {
+      expect(() => validator.validateUrl('http://10.0.0.1/')).toThrow(InvalidUrlError);
+    });
+
+    it('should block 192.168.1.1', () => {
+      expect(() => validator.validateUrl('http://192.168.1.1/')).toThrow(InvalidUrlError);
+    });
+
+    it('should block 172.16.0.1', () => {
+      expect(() => validator.validateUrl('http://172.16.0.1/')).toThrow(InvalidUrlError);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Legitimate public URLs must still pass
+  // -------------------------------------------------------------------------
+  describe('legitimate public URLs', () => {
+    it('should allow https://example.com', () => {
+      expect(() => validator.validateUrl('https://example.com/')).not.toThrow();
+    });
+
+    it('should allow https://github.com', () => {
+      expect(() =>
+        validator.validateUrl('https://github.com/kcenon/claude_code_agent')
+      ).not.toThrow();
+    });
+
+    it('should allow http://93.184.216.34 (example.com public IP)', () => {
+      // 93.184.216.34 is not in any reserved range
+      expect(() => validator.validateUrl('http://93.184.216.34/')).not.toThrow();
+    });
+  });
+});


### PR DESCRIPTION
## What

Closes #875

Hardens `fetchUrlContent` against Server-Side Request Forgery (SSRF) attacks by:

1. **Pre-fetch validation** — every URL is validated by `InputValidator` before any network call is made.
2. **Per-hop redirect re-validation** — redirects are followed manually (`redirect: 'manual'`); each `Location` header target is re-validated before the next hop, so a benign host cannot redirect to cloud-metadata or a private IP.
3. **Redirect hop cap** — chains longer than `maxRedirects` (default 10) are rejected.
4. **IP-form blocklist hardening** in `InputValidator`:
   - `169.254.0.0/16` link-local range (AWS/GCP/Azure cloud-metadata endpoint `169.254.169.254`)
   - `::ffff:` IPv4-mapped IPv6 prefix (e.g. `::ffff:7f00:1` == 127.0.0.1)
   - Non-standard IPv4 representations caught via `isReservedIpv4Hostname()` helper: decimal (`2130706433`), hex (`0x7f000001`), octal (`0177.0.0.1`), and mixed-radix dotted forms — though Node.js URL already normalises most of these to dotted-decimal before validation, the helper acts as defence-in-depth.
   - IPv6 literal brackets stripped before pattern matching so `[::ffff:7f00:1]` is correctly detected.

## Why

`InputParser.fetchUrlContent` previously only checked the URL protocol and trusted the fetch API to follow redirects (`redirect: 'follow'`), making it trivially exploitable:

- Attacker submits `http://169.254.169.254/latest/meta-data/` → cloud credentials exposed.
- Attacker submits a URL that 302-redirects to `169.254.169.254` → same result.
- Attacker uses `http://2130706433/` (decimal encoding of 127.0.0.1) → loopback bypass.

`InputValidator.validateUrl` existed but was unused in the fetch path.

## DNS-rebinding note

Full DNS-rebinding protection (resolving the hostname to an IP and re-checking against the blocklist before each connection) requires low-level socket control or a custom DNS resolver and is out of scope for this issue. A clearly-marked TODO is left in the code:

```
// TODO(SSRF): DNS-rebind protection — a hostname that passes the string-based
// blocklist could resolve to a private IP at fetch time. ...
```

This should be tracked as a follow-up.

## Who

Reviewers: verify all redirect hops are re-validated, not only the initial URL (see `InputParser.ssrf.test.ts` test "re-validates every redirect hop").

## When

Security fix; target next release.

## Where

| File | Change |
|------|--------|
| `src/security/InputValidator.ts` | Add link-local / IPv4-mapped IPv6 patterns; add `isReservedIpv4Hostname()` helper; strip brackets before hostname matching |
| `src/collector/InputParser.ts` | Wire `InputValidator`; switch to `redirect:'manual'`; add `fetchWithRedirectGuard()` with per-hop re-validation; add `maxRedirects` option |
| `tests/security/InputValidator.ssrf.test.ts` | New: 22 tests for all new IP forms |
| `tests/collector/InputParser.ssrf.test.ts` | New: 8 tests for parser-level SSRF scenarios |
| `tests/collector/InputParser.test.ts` | Update 2 existing tests to match new manual-redirect semantics |

## How

### Test plan

```
npx tsc --noEmit          # must be clean
npx vitest run tests/collector/ tests/security/  # 653 pass, 3 skip
```

All mocks intercept `globalThis.fetch` — no real network calls in tests.

### Breaking changes

None. `followRedirects` option semantics are preserved. The `maxRedirects` option is additive. Existing callers that relied on `finalUrl` == `response.url` will now receive `finalUrl` == the last URL in the followed chain (the same logical value, different source).