### PR TITLE
fix(security): fully mask variable-length GitHub tokens

### DIFF
--- a/src/security/CommandSanitizer.ts
+++ b/src/security/CommandSanitizer.ts
@@ -44,6 +44,14 @@ import { getLogger } from '../logging/index.js';
 const execFileAsync = promisify(execFileCallback);
 
 /**
+ * Matches GitHub token families (fine-grained PATs, classic PATs, OAuth, server,
+ * refresh, and app tokens). These tokens are variable length, so a fixed
+ * first-3/last-3 mask would leak most of a long token. Any substring matching
+ * this pattern must be fully redacted regardless of length.
+ */
+const GITHUB_TOKEN_PATTERN = /\b(?:github_pat_[A-Za-z0-9_]+|gh[oprs]_[A-Za-z0-9]+)\b/g;
+
+/**
  * Singleton instance of CommandSanitizer
  */
 let sanitizerInstance: CommandSanitizer | null = null;
@@ -827,6 +835,14 @@ export class CommandSanitizer {
    * @returns Masked argument
    */
   private maskSensitiveArg(arg: string): string {
+    // Fully redact GitHub token families before the length-based fallback,
+    // since their variable length would otherwise leak through first3...last3.
+    if (GITHUB_TOKEN_PATTERN.test(arg)) {
+      GITHUB_TOKEN_PATTERN.lastIndex = 0;
+      return arg.replace(GITHUB_TOKEN_PATTERN, '[REDACTED]');
+    }
+    GITHUB_TOKEN_PATTERN.lastIndex = 0;
+
     // Show first and last few characters, mask the middle
     if (arg.length <= 8) {
       return '[REDACTED]';
@@ -878,8 +894,11 @@ export class CommandSanitizer {
    * @returns Masked command string
    */
   private maskCommandForLogging(rawCommand: string): string {
-    // Mask common sensitive patterns like tokens, passwords, keys
+    // Mask common sensitive patterns like tokens, passwords, keys.
+    // Redact GitHub token families first so bare tokens are fully masked
+    // regardless of length or surrounding flag.
     return rawCommand
+      .replace(GITHUB_TOKEN_PATTERN, '[REDACTED]')
       .replace(/(--token[=\s]+)\S+/gi, '$1[REDACTED]')
       .replace(/(--password[=\s]+)\S+/gi, '$1[REDACTED]')
       .replace(/(--key[=\s]+)\S+/gi, '$1[REDACTED]')

--- a/src/security/SecretManager.ts
+++ b/src/security/SecretManager.ts
@@ -12,6 +12,14 @@ import { config as dotenvConfig } from 'dotenv';
 import type { SecretManagerOptions } from './types.js';
 import { SecretNotFoundError } from './errors.js';
 
+/**
+ * Matches GitHub token families (fine-grained PATs, classic PATs, OAuth, server,
+ * refresh, and app tokens). These tokens are variable length, so any substring
+ * matching this pattern is fully redacted regardless of whether the token is a
+ * registered secret value.
+ */
+const GITHUB_TOKEN_PATTERN = /\b(?:github_pat_[A-Za-z0-9_]+|gh[oprs]_[A-Za-z0-9]+)\b/g;
+
 /** Secrets required regardless of pipeline mode */
 const CORE_REQUIRED_SECRETS = ['ANTHROPIC_API_KEY'] as const;
 
@@ -161,7 +169,10 @@ export class SecretManager {
    * @returns The text with secrets replaced by [REDACTED]
    */
   public mask(text: string): string {
-    let masked = text;
+    // Fully redact GitHub token families first. These tokens are variable
+    // length and may appear in text even when they are not registered secrets,
+    // so the per-secret loop below would otherwise miss them.
+    let masked = text.replace(GITHUB_TOKEN_PATTERN, '[REDACTED]');
 
     for (const [key, value] of this.secrets) {
       // Skip empty or very short values to avoid false positives

--- a/tests/security/CommandSanitizer.test.ts
+++ b/tests/security/CommandSanitizer.test.ts
@@ -90,6 +90,40 @@ describe('CommandSanitizer', () => {
     });
   });
 
+  describe('GitHub token masking', () => {
+    interface MaskAccess {
+      maskSensitiveArg(arg: string): string;
+      maskCommandForLogging(rawCommand: string): string;
+    }
+
+    const access = (s: CommandSanitizer): MaskAccess => s as unknown as MaskAccess;
+
+    it('should fully redact a long fine-grained GitHub token in an argument', () => {
+      const token = `github_pat_${'A1b2C3d4E5'.repeat(8)}`;
+      const masked = access(sanitizer).maskSensitiveArg(token);
+      expect(masked).toBe('[REDACTED]');
+      expect(masked).not.toContain(token);
+    });
+
+    it('should fully redact a short classic GitHub token in an argument', () => {
+      const token = 'ghp_abc123';
+      const masked = access(sanitizer).maskSensitiveArg(token);
+      expect(masked).toBe('[REDACTED]');
+      expect(masked).not.toContain(token);
+    });
+
+    it('should fully redact GitHub tokens embedded in a raw command', () => {
+      const longToken = `github_pat_${'A1b2C3d4E5'.repeat(8)}`;
+      const shortToken = 'ghp_abc123';
+      const masked = access(sanitizer).maskCommandForLogging(
+        `gh auth login --with-token ${longToken} && echo ${shortToken}`
+      );
+      expect(masked).not.toContain(longToken);
+      expect(masked).not.toContain(shortToken);
+      expect(masked).toContain('[REDACTED]');
+    });
+  });
+
   describe('parseCommandString', () => {
     it('should parse simple command', () => {
       const result = sanitizer.parseCommandString('git status');

--- a/tests/security/SecretManager.test.ts
+++ b/tests/security/SecretManager.test.ts
@@ -86,6 +86,29 @@ describe('SecretManager', () => {
       const masked = secretManager.mask(text);
       expect(masked).toBe('First: [TOKEN_REDACTED], Second: [TOKEN_REDACTED]');
     });
+
+    it('should fully redact a long fine-grained GitHub token even when unregistered', () => {
+      const token = `github_pat_${'A1b2C3d4E5'.repeat(8)}`;
+      const masked = secretManager.mask(`Using token: ${token}`);
+      expect(masked).toBe('Using token: [REDACTED]');
+      expect(masked).not.toContain(token);
+    });
+
+    it('should fully redact short classic GitHub tokens', () => {
+      const token = 'ghp_abc123';
+      const masked = secretManager.mask(`Using token: ${token}`);
+      expect(masked).toBe('Using token: [REDACTED]');
+      expect(masked).not.toContain(token);
+    });
+
+    it('should redact all GitHub token family prefixes', () => {
+      const tokens = ['gho_oauth1234', 'ghs_server5678', 'ghr_refresh90', 'ghp_classic12'];
+      for (const token of tokens) {
+        const masked = secretManager.mask(`token=${token}`);
+        expect(masked).toBe('token=[REDACTED]');
+        expect(masked).not.toContain(token);
+      }
+    });
   });
 
   describe('createSafeLogger', () => {


### PR DESCRIPTION
## What

Add GitHub token-family detection to the masking logic so any substring matching a GitHub token shape is fully replaced with `[REDACTED]`, regardless of token length. Applied in:

- `CommandSanitizer.maskSensitiveArg` — runs before the existing `first3...last3` length-based fallback.
- `CommandSanitizer.maskCommandForLogging` — redacts bare tokens anywhere in a raw command, in addition to the existing `--flag value` patterns.
- `SecretManager.mask` — redacts tokens even when they are not registered secret values.

A shared module-level const `GITHUB_TOKEN_PATTERN` is defined in each file (the two modules have no shared util seam), matching the existing code style and the file's existing `[REDACTED]` marker.

## Why

`Closes #890`
`Part of #877`

GitHub tokens vary in length: fine-grained PATs (`github_pat_`) are long, while classic/OAuth/server/refresh tokens (`ghp_`, `gho_`, `ghs_`, `ghr_`) can be short. The previous `maskSensitiveArg` fallback showed `first3...last3`, which leaks most characters of a long token. Short tokens whose length exceeded 8 were also only partially masked. This change guarantees full redaction for the whole token family before any length-based logic runs.

## How

- New `GITHUB_TOKEN_PATTERN = /\b(?:github_pat_[A-Za-z0-9_]+|gh[oprs]_[A-Za-z0-9]+)\b/g` covering `github_pat_`, `gho_`, `ghp_`, `ghr_`, `ghs_`.
- In `maskSensitiveArg`, a match returns the token replaced with `[REDACTED]` (global-regex `lastIndex` reset around `.test()` to keep it stateless).
- In `maskCommandForLogging` and `SecretManager.mask`, the token pattern is applied first, then the existing replacements run unchanged.
- No other masking behavior is modified.

## Test Plan

Added vitest unit tests (the repo's framework):

- `tests/security/SecretManager.test.ts` — a long `github_pat_<80 chars>`, a short `ghp_abc123`, and each token-family prefix (`gho_`/`ghs_`/`ghr_`/`ghp_`) embedded in text are fully redacted; raw token chars do not appear in the masked output.
- `tests/security/CommandSanitizer.test.ts` — a long fine-grained token and a short classic token, both as a standalone argument (`maskSensitiveArg`) and embedded in a raw command (`maskCommandForLogging`), are fully redacted with no leak.

Local note: the clone has no `node_modules` (shallow clone, `npm install` not run to avoid network use), so the vitest suite was not executed locally; relying on CI. The regex behavior was validated with a standalone node script (all five families redacted, normal args untouched, no leak).
