### PR TITLE
fix(ci): enforce performance regression gate

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -31,17 +31,12 @@ jobs:
 
       - name: Run benchmarks
         run: npm run test:bench
-        continue-on-error: true
 
       - name: Run performance tests
         run: npm run test:perf
 
       - name: Check for regressions
-        id: regression-check
-        run: |
-          npm run perf:check
-          echo "status=$?" >> $GITHUB_OUTPUT
-        continue-on-error: true
+        run: npm run perf:check
 
       - name: Upload benchmark results
         uses: actions/upload-artifact@v7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Reconciled `package.json` `version` from `0.0.1` to `0.1.0` to match the released `[0.1.0]` CHANGELOG baseline (the cutover already shipped under `0.1.0`); fixes the stale-version disagreement so future SemVer bumps have a correct baseline (#874)
 
+### Fixed
+
+- Performance-regression gate is now enforced instead of decorative: removed `continue-on-error` from the benchmark and regression-check steps in `performance.yml` so a regression fails the job, and pointed `perf:check` at `tsx scripts/check-regression.ts` (the previous `node dist/scripts/check-regression.js` target was never emitted — `tsconfig` `rootDir`/`include` cover `src/` only, which also mis-resolved the baseline path under `dist/`). `check-regression` now parses Vitest's benchmark JSON shape (`files[].groups[].benchmarks[]`) instead of the Jest-style `testResults` shape it never received. Reconciling the placeholder baseline operation names/metrics with the real benchmarks so an intentional regression actually fires is tracked as a follow-up (#891, #895)
+
 ## [0.1.0] - 2026-05-09
 
 The v0.1.0 release completes the AD-13 cutover: every pipeline stage now routes through the official Claude Agent SDK via a single `ExecutionAdapter`, and the in-tree `AgentBridge` / `AgentDispatcher` / `AgentRegistry` stack has been removed. The 35-stage SDLC pipeline, V&V gates, and traceability matrix are unchanged; tool use, sub-agent delegation, and session management are now handled by the SDK itself. See [`docs/architecture/v0.1-hybrid-pipeline-rfc.md`](docs/architecture/v0.1-hybrid-pipeline-rfc.md) for the architecture rationale and [`docs/architecture/v0.1-migration-guide.md`](docs/architecture/v0.1-migration-guide.md) for migration steps.

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "test:perf": "vitest run --config vitest.perf.config.ts",
     "test:memory": "vitest run --config vitest.perf.config.ts tests/performance/memory/",
     "test:scalability": "vitest run --config vitest.perf.config.ts tests/performance/scalability/",
-    "perf:check": "node --experimental-specifier-resolution=node dist/scripts/check-regression.js",
+    "perf:check": "tsx scripts/check-regression.ts",
     "perf:update-baseline": "node --experimental-specifier-resolution=node dist/scripts/update-baseline.js",
     "audit:docs": "tsx scripts/audit-docs.ts",
     "lint": "eslint src --ext .ts",

--- a/scripts/check-regression.ts
+++ b/scripts/check-regression.ts
@@ -55,29 +55,65 @@ async function loadBaselines(): Promise<Map<string, Baseline>> {
   }
 }
 
+/**
+ * A single benchmark entry as emitted by Vitest's benchmark JSON reporter.
+ * Vitest reports tinybench statistics (mean/median/hz/p75/p99/...), which are not
+ * the p50/p95 keys this checker compares against — map the closest available
+ * percentile. Exact p50/p95 are preferred when a reporter provides them.
+ */
+interface VitestBenchmark {
+  name: string;
+  mean?: number;
+  median?: number;
+  p50?: number;
+  p75?: number;
+  p95?: number;
+  p99?: number;
+  hz?: number;
+}
+
+function normalizeBenchmark(b: VitestBenchmark): BenchmarkResult {
+  return {
+    name: b.name,
+    p50: b.p50 ?? b.median ?? b.mean,
+    p95: b.p95 ?? b.p99 ?? b.p75,
+    hz: b.hz,
+  };
+}
+
 async function loadBenchmarkResults(): Promise<BenchmarkResult[]> {
   const resultsPath = join(rootDir, 'perf-results/benchmark-results.json');
 
+  let data: unknown;
   try {
     const content = await readFile(resultsPath, 'utf-8');
-    const data = JSON.parse(content);
-
-    // Handle vitest bench output format
-    if (data.testResults) {
-      return data.testResults.flatMap((tr: { assertionResults: BenchmarkResult[] }) =>
-        tr.assertionResults.map((ar: BenchmarkResult) => ({
-          name: ar.name,
-          p50: ar.p50,
-          p95: ar.p95,
-        }))
-      );
-    }
-
-    return data as BenchmarkResult[];
+    data = JSON.parse(content);
   } catch {
     console.warn('No benchmark results found. Run benchmarks first.');
     return [];
   }
+
+  // Vitest benchmark JSON reporter: { files: [{ groups: [{ benchmarks: [...] }] }] }.
+  const files = (data as { files?: Array<{ groups?: Array<{ benchmarks?: VitestBenchmark[] }> }> }).files;
+  if (Array.isArray(files)) {
+    return files.flatMap((file) =>
+      (file.groups ?? []).flatMap((group) => (group.benchmarks ?? []).map(normalizeBenchmark))
+    );
+  }
+
+  // Legacy/Jest-style JSON reporter: { testResults: [{ assertionResults: [...] }] }.
+  const testResults = (data as { testResults?: Array<{ assertionResults?: VitestBenchmark[] }> }).testResults;
+  if (Array.isArray(testResults)) {
+    return testResults.flatMap((tr) => (tr.assertionResults ?? []).map(normalizeBenchmark));
+  }
+
+  // Already-normalized flat array.
+  if (Array.isArray(data)) {
+    return (data as VitestBenchmark[]).map(normalizeBenchmark);
+  }
+
+  console.warn('Unrecognized benchmark results format. Skipping regression check.');
+  return [];
 }
 
 function checkRegressions(baselines: Map<string, Baseline>, results: BenchmarkResult[]): Regression[] {


### PR DESCRIPTION
## What

Make the performance-regression gate in `performance.yml` actually enforce instead of silently passing.

- Drop `continue-on-error: true` from the **benchmark** and **regression-check** steps so a regression fails the job (kept on the PR-comment step — a failed comment must not fail the gate).
- Point `perf:check` at `tsx scripts/check-regression.ts`. The prior `node dist/scripts/check-regression.js` target is never produced (`tsconfig` `rootDir`/`include` cover `src/` only), and the `node dist/...` form also mis-resolved the baseline path to `dist/tests/...`.
- Fix `loadBenchmarkResults` to parse Vitest's benchmark JSON shape (`files[].groups[].benchmarks[]`) rather than the Jest-style `testResults`/`assertionResults` shape it never receives.

## Why

The gate was decorative at several layers: the regression script was never built (so `perf:check` failed with "module not found"), `continue-on-error` swallowed that failure, and even if it ran it parsed the wrong JSON shape. For an audit-traceability tool a green-but-inert perf gate is misleading.

## Where

| File | Change |
|------|--------|
| `.github/workflows/performance.yml` | remove `continue-on-error` (benchmark + regression-check); simplify the regression step |
| `package.json` | `perf:check` → `tsx scripts/check-regression.ts` |
| `scripts/check-regression.ts` | parse the Vitest benchmark JSON shape; never throw on an unknown shape |
| `CHANGELOG.md` | Unreleased → Fixed entry |

## How (verified locally)

`performance.yml` runs only on `main`-targeted PRs, so this PR (→ `develop`) does not exercise it in CI. The gate was verified end-to-end locally via `tsx`:

- Regressed sample (`lock-acquire-release` p50 5→10) → **exit 1**, two critical regressions reported.
- Clean sample (no regression) → **exit 0**.
- Absent results file → **exit 0** (no false failure).
- `performance.yml` parses as valid YAML.

## Scope and follow-up

The shipped `baseline-metrics.json` is a placeholder whose operation names/metrics match no real benchmark, so a regression cannot yet fire against the real suite end-to-end. That data reconciliation — rename baseline ops to the real benchmark names, fix `update-baseline.ts` the same way, finalize the metric mapping, and capture baselines on CI hardware — is tracked in **#895**. This PR fixes the gate *mechanics*; #895 closes the *data* gap.

Closes #891
