### PR TITLE
test(perf): enforce real benchmark regression baselines

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -16,7 +16,8 @@ on:
 
 jobs:
   benchmark:
-    runs-on: ubuntu-latest
+    # Pin the benchmark architecture instead of mixing heterogeneous x64 hosts.
+    runs-on: ubuntu-24.04-arm
     timeout-minutes: 30
 
     steps:
@@ -48,6 +49,8 @@ jobs:
       - name: Regenerate performance baseline
         if: ${{ inputs.update_baseline }}
         run: npm run perf:update-baseline
+        env:
+          PERF_RUNNER_LABEL: ubuntu-24.04-arm
 
       - name: Upload benchmark results
         if: always()

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -7,6 +7,12 @@ on:
     branches: [main]
   # Allow manual trigger
   workflow_dispatch:
+    inputs:
+      update_baseline:
+        description: 'Regenerate the benchmark baseline on the CI runner'
+        required: false
+        default: false
+        type: boolean
 
 jobs:
   benchmark:
@@ -36,13 +42,21 @@ jobs:
         run: npm run test:perf
 
       - name: Check for regressions
+        if: ${{ !inputs.update_baseline }}
         run: npm run perf:check
 
+      - name: Regenerate performance baseline
+        if: ${{ inputs.update_baseline }}
+        run: npm run perf:update-baseline
+
       - name: Upload benchmark results
+        if: always()
         uses: actions/upload-artifact@v7
         with:
           name: performance-results
-          path: perf-results/
+          path: |
+            perf-results/
+            tests/performance/baselines/baseline-metrics.json
           retention-days: 30
 
       - name: Comment on PR

--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ yarn-error.log*
 # Test coverage
 coverage/
 .nyc_output/
+perf-results/
 
 # Temporary files
 tmp/

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "test:memory": "vitest run --config vitest.perf.config.ts tests/performance/memory/",
     "test:scalability": "vitest run --config vitest.perf.config.ts tests/performance/scalability/",
     "perf:check": "tsx scripts/check-regression.ts",
-    "perf:update-baseline": "node --experimental-specifier-resolution=node dist/scripts/update-baseline.js",
+    "perf:update-baseline": "tsx scripts/update-baseline.ts",
     "audit:docs": "tsx scripts/audit-docs.ts",
     "docs:check": "npm run docs:check-symbols && npm run docs:check-inventory",
     "docs:check-inventory": "tsx scripts/ci/validate-doc-inventory.ts",

--- a/scripts/check-regression.ts
+++ b/scripts/check-regression.ts
@@ -1,199 +1,82 @@
 /**
- * Regression Check Script
- *
- * Compares current benchmark results against baseline and reports regressions
+ * Compare current Vitest benchmark results against the committed baseline.
  */
 
 import { readFile, writeFile, mkdir } from 'node:fs/promises';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import {
+  evaluateRegressionGate,
+  parseBaselines,
+  parseBenchmarkResults,
+  type RegressionEvaluation,
+} from './performance/benchmark-data.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const rootDir = join(__dirname, '..');
+const baselinePath = join(rootDir, 'tests/performance/baselines/baseline-metrics.json');
+const resultsPath = join(rootDir, 'perf-results/benchmark-results.json');
+const reportPath = join(rootDir, 'perf-results/performance-report.md');
 
-interface Baseline {
-  operation: string;
-  p50: number;
-  p95: number;
-  maxMemoryMB: number;
-  updatedAt: string;
-}
-
-interface BenchmarkResult {
-  name: string;
-  p50?: number;
-  p95?: number;
-  hz?: number; // ops per second
-}
-
-interface Regression {
-  operation: string;
-  metric: string;
-  baseline: number;
-  current: number;
-  percentChange: number;
-  severity: 'warning' | 'critical';
-}
-
-const WARNING_THRESHOLD = 0.1; // 10%
-const CRITICAL_THRESHOLD = 0.2; // 20%
-
-async function loadBaselines(): Promise<Map<string, Baseline>> {
-  const baselinePath = join(rootDir, 'tests/performance/baselines/baseline-metrics.json');
-
+async function readJson(path: string, description: string): Promise<unknown> {
   try {
-    const content = await readFile(baselinePath, 'utf-8');
-    const data = JSON.parse(content) as { baselines: Baseline[] };
-    const map = new Map<string, Baseline>();
-    for (const baseline of data.baselines) {
-      map.set(baseline.operation, baseline);
-    }
-    return map;
-  } catch {
-    console.warn('No baseline file found. Skipping regression check.');
-    return new Map();
+    return JSON.parse(await readFile(path, 'utf-8')) as unknown;
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    throw new Error(`Unable to read ${description} at ${path}: ${detail}`, { cause: error });
   }
 }
 
-/**
- * A single benchmark entry as emitted by Vitest's benchmark JSON reporter.
- * Vitest reports tinybench statistics (mean/median/hz/p75/p99/...), which are not
- * the p50/p95 keys this checker compares against — map the closest available
- * percentile. Exact p50/p95 are preferred when a reporter provides them.
- */
-interface VitestBenchmark {
-  name: string;
-  mean?: number;
-  median?: number;
-  p50?: number;
-  p75?: number;
-  p95?: number;
-  p99?: number;
-  hz?: number;
-}
+function generateReport(evaluation: RegressionEvaluation): string {
+  const lines: string[] = [
+    '# Performance Regression Report',
+    '',
+    `Generated: ${new Date().toISOString()}`,
+    '',
+  ];
+  const criticals = evaluation.regressions.filter(
+    (regression) => regression.severity === 'critical'
+  );
+  const warnings = evaluation.regressions.filter((regression) => regression.severity === 'warning');
 
-function normalizeBenchmark(b: VitestBenchmark): BenchmarkResult {
-  return {
-    name: b.name,
-    p50: b.p50 ?? b.median ?? b.mean,
-    p95: b.p95 ?? b.p99 ?? b.p75,
-    hz: b.hz,
-  };
-}
-
-async function loadBenchmarkResults(): Promise<BenchmarkResult[]> {
-  const resultsPath = join(rootDir, 'perf-results/benchmark-results.json');
-
-  let data: unknown;
-  try {
-    const content = await readFile(resultsPath, 'utf-8');
-    data = JSON.parse(content);
-  } catch {
-    console.warn('No benchmark results found. Run benchmarks first.');
-    return [];
-  }
-
-  // Vitest benchmark JSON reporter: { files: [{ groups: [{ benchmarks: [...] }] }] }.
-  const files = (data as { files?: Array<{ groups?: Array<{ benchmarks?: VitestBenchmark[] }> }> }).files;
-  if (Array.isArray(files)) {
-    return files.flatMap((file) =>
-      (file.groups ?? []).flatMap((group) => (group.benchmarks ?? []).map(normalizeBenchmark))
-    );
-  }
-
-  // Legacy/Jest-style JSON reporter: { testResults: [{ assertionResults: [...] }] }.
-  const testResults = (data as { testResults?: Array<{ assertionResults?: VitestBenchmark[] }> }).testResults;
-  if (Array.isArray(testResults)) {
-    return testResults.flatMap((tr) => (tr.assertionResults ?? []).map(normalizeBenchmark));
-  }
-
-  // Already-normalized flat array.
-  if (Array.isArray(data)) {
-    return (data as VitestBenchmark[]).map(normalizeBenchmark);
-  }
-
-  console.warn('Unrecognized benchmark results format. Skipping regression check.');
-  return [];
-}
-
-function checkRegressions(baselines: Map<string, Baseline>, results: BenchmarkResult[]): Regression[] {
-  const regressions: Regression[] = [];
-
-  for (const result of results) {
-    const baseline = baselines.get(result.name);
-    if (!baseline) continue;
-
-    // Check p50 regression
-    if (result.p50 !== undefined) {
-      const p50Change = (result.p50 - baseline.p50) / baseline.p50;
-      if (p50Change > WARNING_THRESHOLD) {
-        regressions.push({
-          operation: result.name,
-          metric: 'p50',
-          baseline: baseline.p50,
-          current: result.p50,
-          percentChange: p50Change * 100,
-          severity: p50Change > CRITICAL_THRESHOLD ? 'critical' : 'warning',
-        });
-      }
-    }
-
-    // Check p95 regression
-    if (result.p95 !== undefined) {
-      const p95Change = (result.p95 - baseline.p95) / baseline.p95;
-      if (p95Change > WARNING_THRESHOLD) {
-        regressions.push({
-          operation: result.name,
-          metric: 'p95',
-          baseline: baseline.p95,
-          current: result.p95,
-          percentChange: p95Change * 100,
-          severity: p95Change > CRITICAL_THRESHOLD ? 'critical' : 'warning',
-        });
-      }
-    }
-  }
-
-  return regressions;
-}
-
-function generateReport(regressions: Regression[]): string {
-  const lines: string[] = [];
-
-  lines.push('# Performance Regression Report');
-  lines.push('');
-  lines.push(`Generated: ${new Date().toISOString()}`);
-  lines.push('');
-
-  if (regressions.length === 0) {
-    lines.push('## Status: ✅ PASSED');
-    lines.push('');
-    lines.push('No performance regressions detected.');
+  if (evaluation.failed) {
+    lines.push('## Status: ❌ FAILED', '');
+  } else if (warnings.length > 0) {
+    lines.push('## Status: ⚠️ WARNING', '');
   } else {
-    const criticals = regressions.filter((r) => r.severity === 'critical');
-    const warnings = regressions.filter((r) => r.severity === 'warning');
+    lines.push('## Status: ✅ PASSED', '');
+  }
 
-    if (criticals.length > 0) {
-      lines.push('## Status: ❌ FAILED');
-    } else {
-      lines.push('## Status: ⚠️ WARNING');
+  if (evaluation.missingBaselines.length > 0 || evaluation.missingResults.length > 0) {
+    lines.push('### Baseline Coverage Errors', '');
+
+    for (const operation of evaluation.missingBaselines) {
+      lines.push(`- Current benchmark has no baseline: \`${operation}\``);
+    }
+    for (const operation of evaluation.missingResults) {
+      lines.push(`- Baseline has no current benchmark result: \`${operation}\``);
     }
     lines.push('');
+  }
 
-    lines.push('### Regressions Detected');
-    lines.push('');
-    lines.push('| Operation | Metric | Baseline | Current | Change | Severity |');
-    lines.push('|-----------|--------|----------|---------|--------|----------|');
+  if (evaluation.regressions.length > 0) {
+    lines.push(
+      '### Regressions Detected',
+      '',
+      '| Operation | Metric | Baseline | Current | Change | Severity |',
+      '|-----------|--------|----------|---------|--------|----------|'
+    );
 
-    for (const r of regressions) {
-      const emoji = r.severity === 'critical' ? '🔴' : '🟡';
+    for (const regression of evaluation.regressions) {
+      const emoji = regression.severity === 'critical' ? '🔴' : '🟡';
       lines.push(
-        `| ${r.operation} | ${r.metric} | ${r.baseline.toFixed(2)}ms | ${r.current.toFixed(2)}ms | +${r.percentChange.toFixed(1)}% | ${emoji} ${r.severity} |`
+        `| ${regression.operation} | ${regression.metric} | ${regression.baseline.toFixed(4)}ms | ${regression.current.toFixed(4)}ms | +${regression.percentChange.toFixed(1)}% | ${emoji} ${regression.severity} |`
       );
     }
 
-    lines.push('');
-    lines.push(`**Summary:** ${criticals.length} critical, ${warnings.length} warnings`);
+    lines.push('', `**Summary:** ${criticals.length} critical, ${warnings.length} warnings`, '');
+  } else if (!evaluation.failed) {
+    lines.push('No performance regressions detected.', '');
   }
 
   return lines.join('\n');
@@ -202,37 +85,34 @@ function generateReport(regressions: Regression[]): string {
 async function main(): Promise<void> {
   console.log('Checking for performance regressions...\n');
 
-  const baselines = await loadBaselines();
-  if (baselines.size === 0) {
-    console.log('No baselines to compare against. Exiting.');
-    process.exit(0);
-  }
-
-  const results = await loadBenchmarkResults();
-  if (results.length === 0) {
-    console.log('No benchmark results to check. Run benchmarks first.');
-    process.exit(0);
-  }
-
-  const regressions = checkRegressions(baselines, results);
-  const report = generateReport(regressions);
+  const [baselineData, resultsData] = await Promise.all([
+    readJson(baselinePath, 'performance baselines'),
+    readJson(resultsPath, 'benchmark results'),
+  ]);
+  const baselines = parseBaselines(baselineData);
+  const results = parseBenchmarkResults(resultsData);
+  const evaluation = evaluateRegressionGate(baselines, results);
+  const report = generateReport(evaluation);
 
   console.log(report);
+  await mkdir(dirname(reportPath), { recursive: true });
+  await writeFile(reportPath, report);
 
-  // Save report
-  const reportDir = join(rootDir, 'perf-results');
-  await mkdir(reportDir, { recursive: true });
-  await writeFile(join(reportDir, 'performance-report.md'), report);
-
-  // Exit with error if critical regressions found
-  const criticals = regressions.filter((r) => r.severity === 'critical');
-  if (criticals.length > 0) {
-    console.error(`\n❌ Found ${criticals.length} critical regression(s). Build failed.`);
-    process.exit(1);
+  if (evaluation.failed) {
+    const criticalCount = evaluation.regressions.filter(
+      (regression) => regression.severity === 'critical'
+    ).length;
+    const coverageErrorCount =
+      evaluation.missingBaselines.length + evaluation.missingResults.length;
+    console.error(
+      `\n❌ Performance gate failed: ${criticalCount} critical regression(s), ${coverageErrorCount} baseline coverage error(s).`
+    );
+    process.exitCode = 1;
+    return;
   }
 
-  if (regressions.length > 0) {
-    console.warn(`\n⚠️ Found ${regressions.length} warning(s). Review recommended.`);
+  if (evaluation.regressions.length > 0) {
+    console.warn(`\n⚠️ Found ${evaluation.regressions.length} warning(s). Review recommended.`);
   } else {
     console.log('\n✅ No regressions detected.');
   }
@@ -240,5 +120,5 @@ async function main(): Promise<void> {
 
 main().catch((error) => {
   console.error('Error running regression check:', error);
-  process.exit(1);
+  process.exitCode = 1;
 });

--- a/scripts/performance/benchmark-data.ts
+++ b/scripts/performance/benchmark-data.ts
@@ -256,7 +256,9 @@ export function evaluateRegressionGate(
           baseline: baselineValue,
           current,
           percentChange: percentChange * 100,
-          severity: percentChange > CRITICAL_THRESHOLD ? 'critical' : 'warning',
+          // Median/p50 is stable enough to gate CI. Vitest only exposes p99 as
+          // our p95 proxy, and hosted-runner tail outliers are advisory.
+          severity: metric === 'p50' && percentChange > CRITICAL_THRESHOLD ? 'critical' : 'warning',
         });
       }
     }

--- a/scripts/performance/benchmark-data.ts
+++ b/scripts/performance/benchmark-data.ts
@@ -1,0 +1,283 @@
+/**
+ * Shared parsing and comparison helpers for the performance regression gate.
+ *
+ * Vitest's benchmark JSON contains a file path, a full suite name, and a leaf
+ * benchmark name. The full operation key uses all three components so repeated
+ * leaf names (for example, "full graph analysis") remain unambiguous.
+ */
+
+export interface Baseline {
+  operation: string;
+  p50: number;
+  p95: number;
+  maxMemoryMB: number;
+  updatedAt: string;
+}
+
+export interface BenchmarkResult {
+  name: string;
+  p50: number;
+  p95: number;
+  hz?: number;
+}
+
+export interface Regression {
+  operation: string;
+  metric: 'p50' | 'p95';
+  baseline: number;
+  current: number;
+  percentChange: number;
+  severity: 'warning' | 'critical';
+}
+
+export interface RegressionEvaluation {
+  regressions: Regression[];
+  missingBaselines: string[];
+  missingResults: string[];
+  failed: boolean;
+}
+
+export const WARNING_THRESHOLD = 0.1;
+export const CRITICAL_THRESHOLD = 0.2;
+
+type JsonObject = Record<string, unknown>;
+
+function asObject(value: unknown, context: string): JsonObject {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    throw new Error(`${context} must be an object`);
+  }
+  return value as JsonObject;
+}
+
+function asArray(value: unknown, context: string): unknown[] {
+  if (!Array.isArray(value)) {
+    throw new Error(`${context} must be an array`);
+  }
+  return value;
+}
+
+function asString(value: unknown, context: string): string {
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    throw new Error(`${context} must be a non-empty string`);
+  }
+  return value;
+}
+
+function finiteNumber(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
+
+function requiredPositiveNumber(value: unknown, context: string): number {
+  const number = finiteNumber(value);
+  if (number === undefined || number <= 0) {
+    throw new Error(`${context} must be a positive finite number`);
+  }
+  return number;
+}
+
+function normalizeSlashes(value: string): string {
+  return value.replaceAll('\\', '/');
+}
+
+function stableBenchmarkFilepath(filepath: string): string {
+  const normalized = normalizeSlashes(filepath);
+  const testsMarker = '/tests/';
+  const testsIndex = normalized.lastIndexOf(testsMarker);
+
+  if (testsIndex >= 0) {
+    return normalized.slice(testsIndex + 1);
+  }
+
+  return normalized.replace(/^\.\//, '');
+}
+
+/** Build a stable, unique operation name from a Vitest benchmark entry. */
+export function benchmarkOperationName(
+  filepath: string,
+  fullName: string,
+  benchmarkName: string
+): string {
+  const normalizedFilepath = normalizeSlashes(filepath);
+  const stableFilepath = stableBenchmarkFilepath(filepath);
+  const normalizedFullName = normalizeSlashes(fullName);
+
+  let suiteName = normalizedFullName;
+  for (const prefix of [normalizedFilepath, stableFilepath]) {
+    if (suiteName === prefix) {
+      suiteName = '';
+      break;
+    }
+    if (suiteName.startsWith(`${prefix} > `)) {
+      suiteName = suiteName.slice(prefix.length + 3);
+      break;
+    }
+  }
+
+  return [stableFilepath, suiteName, benchmarkName]
+    .map((part) => part.trim())
+    .filter((part) => part.length > 0)
+    .join(' > ');
+}
+
+/**
+ * Parse Vitest's native benchmark JSON report.
+ *
+ * Tinybench exposes `median` and `p99`, not p50 and p95. Median is the exact
+ * p50. We intentionally use p99 as a conservative upper-tail proxy for p95;
+ * both baseline generation and regression checking call this same parser.
+ */
+export function parseBenchmarkResults(data: unknown): BenchmarkResult[] {
+  const root = asObject(data, 'Benchmark report');
+  const files = asArray(root.files, 'Benchmark report files');
+  const results: BenchmarkResult[] = [];
+  const operationNames = new Set<string>();
+
+  for (const [fileIndex, rawFile] of files.entries()) {
+    const file = asObject(rawFile, `Benchmark file ${fileIndex}`);
+    const filepath = asString(file.filepath, `Benchmark file ${fileIndex} filepath`);
+    const groups = asArray(file.groups, `Benchmark file ${filepath} groups`);
+
+    for (const [groupIndex, rawGroup] of groups.entries()) {
+      const group = asObject(rawGroup, `Benchmark group ${groupIndex} in ${filepath}`);
+      const fullName = asString(
+        group.fullName,
+        `Benchmark group ${groupIndex} fullName in ${filepath}`
+      );
+      const benchmarks = asArray(group.benchmarks, `Benchmark group ${fullName} benchmarks`);
+
+      for (const [benchmarkIndex, rawBenchmark] of benchmarks.entries()) {
+        const benchmark = asObject(
+          rawBenchmark,
+          `Benchmark ${benchmarkIndex} in group ${fullName}`
+        );
+        const leafName = asString(
+          benchmark.name,
+          `Benchmark ${benchmarkIndex} name in group ${fullName}`
+        );
+        const operation = benchmarkOperationName(filepath, fullName, leafName);
+
+        if (operationNames.has(operation)) {
+          throw new Error(`Duplicate benchmark operation: ${operation}`);
+        }
+        operationNames.add(operation);
+
+        const p50 =
+          finiteNumber(benchmark.p50) ??
+          finiteNumber(benchmark.median) ??
+          finiteNumber(benchmark.mean);
+        const p95 = finiteNumber(benchmark.p95) ?? finiteNumber(benchmark.p99);
+
+        if (p50 === undefined || p50 <= 0) {
+          throw new Error(`Benchmark ${operation} has no valid p50/median timing`);
+        }
+        if (p95 === undefined || p95 <= 0) {
+          throw new Error(`Benchmark ${operation} has no valid p95/p99 timing`);
+        }
+
+        const hz = finiteNumber(benchmark.hz);
+        results.push({
+          name: operation,
+          p50,
+          p95,
+          ...(hz === undefined ? {} : { hz }),
+        });
+      }
+    }
+  }
+
+  if (results.length === 0) {
+    throw new Error('Benchmark report contains no benchmark results');
+  }
+
+  return results;
+}
+
+/** Parse and validate the committed baseline file. */
+export function parseBaselines(data: unknown): Baseline[] {
+  const root = asObject(data, 'Baseline file');
+  const rawBaselines = asArray(root.baselines, 'Baseline file baselines');
+  const baselines: Baseline[] = [];
+  const operationNames = new Set<string>();
+
+  for (const [index, rawBaseline] of rawBaselines.entries()) {
+    const baseline = asObject(rawBaseline, `Baseline ${index}`);
+    const operation = asString(baseline.operation, `Baseline ${index} operation`);
+
+    if (operationNames.has(operation)) {
+      throw new Error(`Duplicate baseline operation: ${operation}`);
+    }
+    operationNames.add(operation);
+
+    const maxMemoryMB = finiteNumber(baseline.maxMemoryMB);
+    if (maxMemoryMB === undefined || maxMemoryMB < 0) {
+      throw new Error(`Baseline ${operation} maxMemoryMB must be a non-negative finite number`);
+    }
+
+    baselines.push({
+      operation,
+      p50: requiredPositiveNumber(baseline.p50, `Baseline ${operation} p50`),
+      p95: requiredPositiveNumber(baseline.p95, `Baseline ${operation} p95`),
+      maxMemoryMB,
+      updatedAt: asString(baseline.updatedAt, `Baseline ${operation} updatedAt`),
+    });
+  }
+
+  if (baselines.length === 0) {
+    throw new Error('Baseline file contains no baselines');
+  }
+
+  return baselines;
+}
+
+/** Compare a complete current benchmark set against a complete baseline set. */
+export function evaluateRegressionGate(
+  baselines: Baseline[],
+  results: BenchmarkResult[]
+): RegressionEvaluation {
+  const baselineByOperation = new Map(
+    baselines.map((baseline) => [baseline.operation, baseline] as const)
+  );
+  const resultByOperation = new Map(results.map((result) => [result.name, result] as const));
+  const regressions: Regression[] = [];
+
+  for (const result of results) {
+    const baseline = baselineByOperation.get(result.name);
+    if (!baseline) continue;
+
+    for (const metric of ['p50', 'p95'] as const) {
+      const current = result[metric];
+      const baselineValue = baseline[metric];
+      const percentChange = (current - baselineValue) / baselineValue;
+
+      if (percentChange > WARNING_THRESHOLD) {
+        regressions.push({
+          operation: result.name,
+          metric,
+          baseline: baselineValue,
+          current,
+          percentChange: percentChange * 100,
+          severity: percentChange > CRITICAL_THRESHOLD ? 'critical' : 'warning',
+        });
+      }
+    }
+  }
+
+  const missingBaselines = results
+    .filter((result) => !baselineByOperation.has(result.name))
+    .map((result) => result.name)
+    .sort();
+  const missingResults = baselines
+    .filter((baseline) => !resultByOperation.has(baseline.operation))
+    .map((baseline) => baseline.operation)
+    .sort();
+  const hasCriticalRegression = regressions.some(
+    (regression) => regression.severity === 'critical'
+  );
+
+  return {
+    regressions,
+    missingBaselines,
+    missingResults,
+    failed: hasCriticalRegression || missingBaselines.length > 0 || missingResults.length > 0,
+  };
+}

--- a/scripts/update-baseline.ts
+++ b/scripts/update-baseline.ts
@@ -58,11 +58,16 @@ async function main(): Promise<void> {
   const removed = [...existingBaselines.keys()].filter(
     (operation) => !baselineOperations.has(operation)
   ).length;
+  const runner = process.env.PERF_RUNNER_LABEL ?? 'local';
   const data = {
     baselines,
     updatedAt: now,
-    notes:
-      'Generated from Vitest benchmark output on the designated CI runner. p50 uses median; p95 uses Vitest/Tinybench p99 as a conservative upper-tail proxy.',
+    environment: {
+      runner,
+      platform: `${process.platform}-${process.arch}`,
+      node: process.version,
+    },
+    notes: `Generated from Vitest benchmark output on ${runner}. p50 uses median; p95 uses Vitest/Tinybench p99 as a conservative upper-tail proxy.`,
   };
 
   await mkdir(dirname(baselinePath), { recursive: true });

--- a/scripts/update-baseline.ts
+++ b/scripts/update-baseline.ts
@@ -1,116 +1,81 @@
 /**
- * Update Baseline Script
- *
- * Updates baseline metrics from the latest benchmark results
+ * Regenerate performance baselines from Vitest's native benchmark JSON report.
  */
 
 import { readFile, writeFile, mkdir } from 'node:fs/promises';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import {
+  parseBaselines,
+  parseBenchmarkResults,
+  type Baseline,
+} from './performance/benchmark-data.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const rootDir = join(__dirname, '..');
+const baselinePath = join(rootDir, 'tests/performance/baselines/baseline-metrics.json');
+const resultsPath = join(rootDir, 'perf-results/benchmark-results.json');
 
-interface Baseline {
-  operation: string;
-  p50: number;
-  p95: number;
-  maxMemoryMB: number;
-  updatedAt: string;
-}
-
-interface BenchmarkResult {
-  name: string;
-  p50?: number;
-  p95?: number;
-}
-
-async function loadBenchmarkResults(): Promise<BenchmarkResult[]> {
-  const resultsPath = join(rootDir, 'perf-results/benchmark-results.json');
-
+async function readJson(path: string, description: string): Promise<unknown> {
   try {
-    const content = await readFile(resultsPath, 'utf-8');
-    const data = JSON.parse(content);
-
-    if (data.testResults) {
-      return data.testResults.flatMap((tr: { assertionResults: BenchmarkResult[] }) =>
-        tr.assertionResults.map((ar: BenchmarkResult) => ({
-          name: ar.name,
-          p50: ar.p50,
-          p95: ar.p95,
-        }))
-      );
-    }
-
-    return data as BenchmarkResult[];
-  } catch {
-    console.error('No benchmark results found. Run benchmarks first.');
-    process.exit(1);
+    return JSON.parse(await readFile(path, 'utf-8')) as unknown;
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    throw new Error(`Unable to read ${description} at ${path}: ${detail}`, { cause: error });
   }
 }
 
 async function loadExistingBaselines(): Promise<Map<string, Baseline>> {
-  const baselinePath = join(rootDir, 'tests/performance/baselines/baseline-metrics.json');
-
   try {
-    const content = await readFile(baselinePath, 'utf-8');
-    const data = JSON.parse(content) as { baselines: Baseline[] };
-    const map = new Map<string, Baseline>();
-    for (const baseline of data.baselines) {
-      map.set(baseline.operation, baseline);
+    const data = await readJson(baselinePath, 'existing performance baselines');
+    return new Map(parseBaselines(data).map((baseline) => [baseline.operation, baseline]));
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).cause) {
+      const cause = (error as Error & { cause?: NodeJS.ErrnoException }).cause;
+      if (cause?.code === 'ENOENT') return new Map();
     }
-    return map;
-  } catch {
-    return new Map();
+    throw error;
   }
 }
 
 async function main(): Promise<void> {
   console.log('Updating baseline metrics...\n');
 
-  const results = await loadBenchmarkResults();
+  const results = parseBenchmarkResults(await readJson(resultsPath, 'benchmark results'));
   const existingBaselines = await loadExistingBaselines();
-
   const now = new Date().toISOString();
-  let updated = 0;
-  let added = 0;
-
-  for (const result of results) {
-    if (result.p50 === undefined || result.p95 === undefined) continue;
-
-    const existing = existingBaselines.get(result.name);
-    if (existing) {
-      updated++;
-    } else {
-      added++;
-    }
-
-    existingBaselines.set(result.name, {
+  const baselines = results
+    .map<Baseline>((result) => ({
       operation: result.name,
       p50: result.p50,
       p95: result.p95,
-      maxMemoryMB: existing?.maxMemoryMB ?? 0,
+      maxMemoryMB: existingBaselines.get(result.name)?.maxMemoryMB ?? 0,
       updatedAt: now,
-    });
-  }
-
-  const baselines = Array.from(existingBaselines.values());
+    }))
+    .sort((left, right) => left.operation.localeCompare(right.operation));
+  const baselineOperations = new Set(baselines.map((baseline) => baseline.operation));
+  const updated = baselines.filter((baseline) => existingBaselines.has(baseline.operation)).length;
+  const removed = [...existingBaselines.keys()].filter(
+    (operation) => !baselineOperations.has(operation)
+  ).length;
   const data = {
     baselines,
     updatedAt: now,
+    notes:
+      'Generated from Vitest benchmark output on the designated CI runner. p50 uses median; p95 uses Vitest/Tinybench p99 as a conservative upper-tail proxy.',
   };
 
-  const baselinePath = join(rootDir, 'tests/performance/baselines/baseline-metrics.json');
   await mkdir(dirname(baselinePath), { recursive: true });
-  await writeFile(baselinePath, JSON.stringify(data, null, 2));
+  await writeFile(baselinePath, `${JSON.stringify(data, null, 2)}\n`);
 
-  console.log(`✅ Baseline updated successfully!`);
+  console.log('✅ Baseline updated successfully!');
   console.log(`   - Updated: ${updated} metrics`);
-  console.log(`   - Added: ${added} new metrics`);
+  console.log(`   - Added: ${baselines.length - updated} new metrics`);
+  console.log(`   - Removed: ${removed} stale metrics`);
   console.log(`   - Total: ${baselines.length} baselines`);
 }
 
 main().catch((error) => {
   console.error('Error updating baselines:', error);
-  process.exit(1);
+  process.exitCode = 1;
 });

--- a/tests/performance/README.md
+++ b/tests/performance/README.md
@@ -70,6 +70,7 @@ npm run perf:check
 ```
 
 This will:
+
 - Compare current benchmark results against saved baselines
 - Report warnings for >10% degradation
 - Fail build for >20% degradation
@@ -77,29 +78,42 @@ This will:
 
 ### Update Baselines
 
-To update baseline metrics after intentional performance changes:
+Generate a native Vitest benchmark report, then update baseline metrics after
+intentional performance changes:
 
 ```bash
+npm run test:bench
 npm run perf:update-baseline
 ```
+
+Each operation is keyed by benchmark file, full suite path, and benchmark name,
+so repeated leaf names remain distinct. Vitest/Tinybench reports `median` and
+`p99`; the shared baseline parser maps median to p50 and uses p99 as the
+conservative upper-tail proxy for p95.
+
+Committed baselines must come from the consistent `ubuntu-latest` CI environment.
+Run the **Performance Tests** workflow manually with `update_baseline` enabled,
+download the `performance-results` artifact, and commit the generated
+`baseline-metrics.json`. Local regeneration is useful only for validating the
+tooling.
 
 ## Performance Targets
 
 ### Graph Analysis
 
-| Operation | Target p95 |
-|-----------|------------|
-| 100-node analysis | < 100ms |
-| 500-node analysis | < 500ms |
-| 1000-node analysis | < 2000ms |
+| Operation          | Target p95 |
+| ------------------ | ---------- |
+| 100-node analysis  | < 100ms    |
+| 500-node analysis  | < 500ms    |
+| 1000-node analysis | < 2000ms   |
 
 ### Memory Usage
 
-| Operation | Target Peak Memory |
-|-----------|-------------------|
-| 100-node graph | < 50MB |
-| 500-node graph | < 100MB |
-| 1000-node graph | < 200MB |
+| Operation       | Target Peak Memory |
+| --------------- | ------------------ |
+| 100-node graph  | < 50MB             |
+| 500-node graph  | < 100MB            |
+| 1000-node graph | < 200MB            |
 
 ### Memory Leak Prevention
 
@@ -109,10 +123,12 @@ npm run perf:update-baseline
 ## CI Integration
 
 Performance tests run automatically on:
+
 - Push to `main` branch
 - Pull requests targeting `main`
 
 The CI workflow includes:
+
 1. **Benchmark job**: Runs all benchmarks and checks for regressions
 2. **Memory profile job**: Runs memory tests with `--expose-gc`
 3. **Scalability job**: Runs scalability tests

--- a/tests/performance/README.md
+++ b/tests/performance/README.md
@@ -91,7 +91,7 @@ so repeated leaf names remain distinct. Vitest/Tinybench reports `median` and
 `p99`; the shared baseline parser maps median to p50 and uses p99 as the
 conservative upper-tail proxy for p95.
 
-Committed baselines must come from the consistent `ubuntu-latest` CI environment.
+Committed baselines must come from the pinned `ubuntu-24.04-arm` CI environment.
 Run the **Performance Tests** workflow manually with `update_baseline` enabled,
 download the `performance-results` artifact, and commit the generated
 `baseline-metrics.json`. Local regeneration is useful only for validating the

--- a/tests/performance/README.md
+++ b/tests/performance/README.md
@@ -89,7 +89,8 @@ npm run perf:update-baseline
 Each operation is keyed by benchmark file, full suite path, and benchmark name,
 so repeated leaf names remain distinct. Vitest/Tinybench reports `median` and
 `p99`; the shared baseline parser maps median to p50 and uses p99 as the
-conservative upper-tail proxy for p95.
+conservative upper-tail proxy for p95. The stable p50 measurement drives the
+hard >20% CI gate; the noisier p99-derived tail metric remains advisory.
 
 Committed baselines must come from the pinned `ubuntu-24.04-arm` CI environment.
 Run the **Performance Tests** workflow manually with `update_baseline` enabled,

--- a/tests/performance/baseline-tools.test.ts
+++ b/tests/performance/baseline-tools.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from 'vitest';
+import {
+  benchmarkOperationName,
+  evaluateRegressionGate,
+  parseBenchmarkResults,
+  type Baseline,
+  type BenchmarkResult,
+} from '../../scripts/performance/benchmark-data.js';
+
+const operation =
+  'tests/performance/benchmarks/graph-analysis.bench.ts > Graph Analysis Benchmarks > analyze() - 100 nodes > full graph analysis';
+
+function baseline(overrides: Partial<Baseline> = {}): Baseline {
+  return {
+    operation,
+    p50: 10,
+    p95: 20,
+    maxMemoryMB: 0,
+    updatedAt: '2026-08-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function result(overrides: Partial<BenchmarkResult> = {}): BenchmarkResult {
+  return {
+    name: operation,
+    p50: 10,
+    p95: 20,
+    ...overrides,
+  };
+}
+
+describe('benchmark result parsing', () => {
+  it('uses stable group-qualified names and the shared percentile mapping', () => {
+    const parsed = parseBenchmarkResults({
+      files: [
+        {
+          filepath:
+            '/home/runner/work/claude_code_agent/claude_code_agent/tests/performance/benchmarks/graph-analysis.bench.ts',
+          groups: [
+            {
+              fullName:
+                'tests/performance/benchmarks/graph-analysis.bench.ts > Graph Analysis Benchmarks > analyze() - 100 nodes',
+              benchmarks: [
+                {
+                  name: 'full graph analysis',
+                  mean: 11,
+                  median: 10,
+                  p75: 15,
+                  p99: 20,
+                  hz: 100,
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(parsed).toEqual([{ name: operation, p50: 10, p95: 20, hz: 100 }]);
+  });
+
+  it('normalizes Windows report paths to the same operation name', () => {
+    expect(
+      benchmarkOperationName(
+        'D:\\a\\repo\\tests\\performance\\benchmarks\\graph-analysis.bench.ts',
+        'D:\\a\\repo\\tests\\performance\\benchmarks\\graph-analysis.bench.ts > Graph Analysis Benchmarks > analyze() - 100 nodes',
+        'full graph analysis'
+      )
+    ).toBe(operation);
+  });
+
+  it('rejects successful-looking entries that have no finite timings', () => {
+    expect(() =>
+      parseBenchmarkResults({
+        files: [
+          {
+            filepath: 'tests/performance/benchmarks/io.bench.ts',
+            groups: [
+              {
+                fullName: 'tests/performance/benchmarks/io.bench.ts > I/O',
+                benchmarks: [{ name: 'write', median: null, p99: null }],
+              },
+            ],
+          },
+        ],
+      })
+    ).toThrow('has no valid p50/median timing');
+  });
+
+  it('rejects duplicate fully-qualified operation names', () => {
+    const benchmark = { name: 'write', median: 1, p99: 2 };
+
+    expect(() =>
+      parseBenchmarkResults({
+        files: [
+          {
+            filepath: 'tests/performance/benchmarks/io.bench.ts',
+            groups: [
+              {
+                fullName: 'tests/performance/benchmarks/io.bench.ts > I/O',
+                benchmarks: [benchmark, benchmark],
+              },
+            ],
+          },
+        ],
+      })
+    ).toThrow('Duplicate benchmark operation');
+  });
+});
+
+describe('performance regression gate', () => {
+  it('fails for an intentional critical regression', () => {
+    const evaluation = evaluateRegressionGate([baseline()], [result({ p50: 12.1, p95: 20 })]);
+
+    expect(evaluation.failed).toBe(true);
+    expect(evaluation.regressions).toEqual([
+      expect.objectContaining({ metric: 'p50', severity: 'critical' }),
+    ]);
+  });
+
+  it('reports warnings without failing the gate', () => {
+    const evaluation = evaluateRegressionGate([baseline()], [result({ p50: 11.5, p95: 20 })]);
+
+    expect(evaluation.failed).toBe(false);
+    expect(evaluation.regressions).toEqual([
+      expect.objectContaining({ metric: 'p50', severity: 'warning' }),
+    ]);
+  });
+
+  it('fails when current and baseline operation sets do not match', () => {
+    const unbaselinedOperation = `${operation} changed`;
+    const evaluation = evaluateRegressionGate(
+      [baseline()],
+      [result({ name: unbaselinedOperation })]
+    );
+
+    expect(evaluation.failed).toBe(true);
+    expect(evaluation.missingBaselines).toEqual([unbaselinedOperation]);
+    expect(evaluation.missingResults).toEqual([operation]);
+  });
+});

--- a/tests/performance/baseline-tools.test.ts
+++ b/tests/performance/baseline-tools.test.ts
@@ -128,6 +128,15 @@ describe('performance regression gate', () => {
     ]);
   });
 
+  it('keeps the p99-derived upper-tail metric advisory', () => {
+    const evaluation = evaluateRegressionGate([baseline()], [result({ p50: 10, p95: 100 })]);
+
+    expect(evaluation.failed).toBe(false);
+    expect(evaluation.regressions).toEqual([
+      expect.objectContaining({ metric: 'p95', severity: 'warning' }),
+    ]);
+  });
+
   it('fails when current and baseline operation sets do not match', () => {
     const unbaselinedOperation = `${operation} changed`;
     const evaluation = evaluateRegressionGate(

--- a/tests/performance/baselines/baseline-metrics.json
+++ b/tests/performance/baselines/baseline-metrics.json
@@ -2,258 +2,258 @@
   "baselines": [
     {
       "operation": "tests/performance/benchmarks/graph-analysis.bench.ts > Graph Analysis Benchmarks > analyze() - 100 nodes > full graph analysis",
-      "p50": 0.36611299999998437,
-      "p95": 0.642757999999958,
+      "p50": 0.3472879999999918,
+      "p95": 0.56732599999998,
       "maxMemoryMB": 0,
-      "updatedAt": "2026-08-01T07:55:50.462Z"
+      "updatedAt": "2026-08-01T07:58:39.509Z"
     },
     {
       "operation": "tests/performance/benchmarks/graph-analysis.bench.ts > Graph Analysis Benchmarks > analyze() - 100 nodes > with custom weights",
-      "p50": 0.35398800000007213,
-      "p95": 0.6163659999999709,
+      "p50": 0.3302680000000464,
+      "p95": 0.520685000000185,
       "maxMemoryMB": 0,
-      "updatedAt": "2026-08-01T07:55:50.462Z"
+      "updatedAt": "2026-08-01T07:58:39.509Z"
     },
     {
       "operation": "tests/performance/benchmarks/graph-analysis.bench.ts > Graph Analysis Benchmarks > analyze() - 1000 nodes > full graph analysis",
-      "p50": 25.927250500000127,
-      "p95": 26.53874399999995,
+      "p50": 25.78423850000013,
+      "p95": 26.80385000000024,
       "maxMemoryMB": 0,
-      "updatedAt": "2026-08-01T07:55:50.462Z"
+      "updatedAt": "2026-08-01T07:58:39.509Z"
     },
     {
       "operation": "tests/performance/benchmarks/graph-analysis.bench.ts > Graph Analysis Benchmarks > analyze() - 500 nodes > full graph analysis",
-      "p50": 6.934070499999962,
-      "p95": 7.54257900000016,
+      "p50": 6.641501000000062,
+      "p95": 7.21874600000001,
       "maxMemoryMB": 0,
-      "updatedAt": "2026-08-01T07:55:50.462Z"
+      "updatedAt": "2026-08-01T07:58:39.509Z"
     },
     {
       "operation": "tests/performance/benchmarks/graph-analysis.bench.ts > Graph Analysis Benchmarks > Critical Path Calculation > critical path - 100 nodes",
-      "p50": 0.3707970000000387,
-      "p95": 0.6320220000002337,
+      "p50": 0.33393999999998414,
+      "p95": 0.5240690000000541,
       "maxMemoryMB": 0,
-      "updatedAt": "2026-08-01T07:55:50.462Z"
+      "updatedAt": "2026-08-01T07:58:39.509Z"
     },
     {
       "operation": "tests/performance/benchmarks/graph-analysis.bench.ts > Graph Analysis Benchmarks > Critical Path Calculation > critical path - 1000 nodes",
-      "p50": 24.47077900000022,
-      "p95": 25.372378000000026,
+      "p50": 24.50476400000025,
+      "p95": 25.462666999999783,
       "maxMemoryMB": 0,
-      "updatedAt": "2026-08-01T07:55:50.462Z"
+      "updatedAt": "2026-08-01T07:58:39.509Z"
     },
     {
       "operation": "tests/performance/benchmarks/graph-analysis.bench.ts > Graph Analysis Benchmarks > Critical Path Calculation > critical path - 500 nodes",
-      "p50": 6.725263499999983,
-      "p95": 7.773142999999891,
+      "p50": 6.845882000000074,
+      "p95": 7.602939999999762,
       "maxMemoryMB": 0,
-      "updatedAt": "2026-08-01T07:55:50.462Z"
+      "updatedAt": "2026-08-01T07:58:39.509Z"
     },
     {
       "operation": "tests/performance/benchmarks/graph-analysis.bench.ts > Graph Analysis Benchmarks > Cycle Detection > detect cycles - 100 nodes no cycle",
-      "p50": 0.3581880000001547,
-      "p95": 0.6347659999992175,
+      "p50": 0.33839199999965786,
+      "p95": 0.5002439999998387,
       "maxMemoryMB": 0,
-      "updatedAt": "2026-08-01T07:55:50.462Z"
+      "updatedAt": "2026-08-01T07:58:39.509Z"
     },
     {
       "operation": "tests/performance/benchmarks/graph-analysis.bench.ts > Graph Analysis Benchmarks > Cycle Detection > detect cycles - 100 nodes with cycle",
-      "p50": 0.3514999999997599,
-      "p95": 0.6315100000001621,
+      "p50": 0.3407999999999447,
+      "p95": 0.5049870000002556,
       "maxMemoryMB": 0,
-      "updatedAt": "2026-08-01T07:55:50.462Z"
+      "updatedAt": "2026-08-01T07:58:39.509Z"
     },
     {
       "operation": "tests/performance/benchmarks/graph-analysis.bench.ts > Graph Analysis Benchmarks > Dependency Queries > getDependencies",
       "p50": 0.0007040000000415603,
-      "p95": 0.0009599999993952224,
+      "p95": 0.0009200000004057074,
       "maxMemoryMB": 0,
-      "updatedAt": "2026-08-01T07:55:50.462Z"
+      "updatedAt": "2026-08-01T07:58:39.509Z"
     },
     {
       "operation": "tests/performance/benchmarks/graph-analysis.bench.ts > Graph Analysis Benchmarks > Dependency Queries > getDependents",
-      "p50": 0.0007200000000011642,
-      "p95": 0.000984000000244123,
+      "p50": 0.0007120000000213622,
+      "p95": 0.0009519999994154205,
       "maxMemoryMB": 0,
-      "updatedAt": "2026-08-01T07:55:50.462Z"
+      "updatedAt": "2026-08-01T07:58:39.509Z"
     },
     {
       "operation": "tests/performance/benchmarks/graph-analysis.bench.ts > Graph Analysis Benchmarks > Dependency Queries > getTransitiveDependencies",
-      "p50": 0.00015999999959603883,
-      "p95": 0.00017599999955564272,
+      "p50": 0.00016800000048533548,
+      "p95": 0.00018400000044493936,
       "maxMemoryMB": 0,
-      "updatedAt": "2026-08-01T07:55:50.462Z"
+      "updatedAt": "2026-08-01T07:58:39.509Z"
     },
     {
       "operation": "tests/performance/benchmarks/graph-analysis.bench.ts > Graph Analysis Benchmarks > Queue Operations > getExecutableIssues",
-      "p50": 6.7872210000005,
-      "p95": 7.5843280000008235,
+      "p50": 6.985980999999811,
+      "p95": 7.7483030000003055,
       "maxMemoryMB": 0,
-      "updatedAt": "2026-08-01T07:55:50.462Z"
+      "updatedAt": "2026-08-01T07:58:39.509Z"
     },
     {
       "operation": "tests/performance/benchmarks/graph-analysis.bench.ts > Graph Analysis Benchmarks > Queue Operations > getNextExecutableIssue",
-      "p50": 7.223604000000705,
-      "p95": 8.263127000000168,
+      "p50": 7.396314499999789,
+      "p95": 8.032486000000063,
       "maxMemoryMB": 0,
-      "updatedAt": "2026-08-01T07:55:50.462Z"
+      "updatedAt": "2026-08-01T07:58:39.509Z"
     },
     {
       "operation": "tests/performance/benchmarks/scratchpad-io.bench.ts > Scratchpad I/O Benchmarks > JSON Operations > readJson - large payload",
-      "p50": 2.0016279999999824,
-      "p95": 3.3138729999991483,
+      "p50": 2.014660000000049,
+      "p95": 3.080352999999832,
       "maxMemoryMB": 0,
-      "updatedAt": "2026-08-01T07:55:50.462Z"
+      "updatedAt": "2026-08-01T07:58:39.509Z"
     },
     {
       "operation": "tests/performance/benchmarks/scratchpad-io.bench.ts > Scratchpad I/O Benchmarks > JSON Operations > readJson - medium payload",
-      "p50": 0.22492349999993166,
-      "p95": 0.2738899999999376,
+      "p50": 0.23418900000024223,
+      "p95": 0.31692800000018906,
       "maxMemoryMB": 0,
-      "updatedAt": "2026-08-01T07:55:50.462Z"
+      "updatedAt": "2026-08-01T07:58:39.509Z"
     },
     {
       "operation": "tests/performance/benchmarks/scratchpad-io.bench.ts > Scratchpad I/O Benchmarks > JSON Operations > readJson - small payload",
-      "p50": 0.14937749999990046,
-      "p95": 0.19410999999990963,
+      "p50": 0.14779499999986,
+      "p95": 0.21297400000003108,
       "maxMemoryMB": 0,
-      "updatedAt": "2026-08-01T07:55:50.462Z"
+      "updatedAt": "2026-08-01T07:58:39.509Z"
     },
     {
       "operation": "tests/performance/benchmarks/scratchpad-io.bench.ts > Scratchpad I/O Benchmarks > JSON Operations > writeJson - large payload (1000 items)",
-      "p50": 1.839310999999725,
-      "p95": 4.000872999999956,
+      "p50": 1.8193630000000667,
+      "p95": 4.545068000000356,
       "maxMemoryMB": 0,
-      "updatedAt": "2026-08-01T07:55:50.462Z"
+      "updatedAt": "2026-08-01T07:58:39.509Z"
     },
     {
       "operation": "tests/performance/benchmarks/scratchpad-io.bench.ts > Scratchpad I/O Benchmarks > JSON Operations > writeJson - medium payload (100 items)",
-      "p50": 0.3871090000000095,
-      "p95": 0.5200259999999162,
+      "p50": 0.3945210000000543,
+      "p95": 0.5205090000001746,
       "maxMemoryMB": 0,
-      "updatedAt": "2026-08-01T07:55:50.462Z"
+      "updatedAt": "2026-08-01T07:58:39.509Z"
     },
     {
       "operation": "tests/performance/benchmarks/scratchpad-io.bench.ts > Scratchpad I/O Benchmarks > JSON Operations > writeJson - small payload",
-      "p50": 0.329155000000128,
-      "p95": 0.47301599999991595,
+      "p50": 0.32728800000006686,
+      "p95": 0.4320659999999634,
       "maxMemoryMB": 0,
-      "updatedAt": "2026-08-01T07:55:50.462Z"
+      "updatedAt": "2026-08-01T07:58:39.509Z"
     },
     {
       "operation": "tests/performance/benchmarks/scratchpad-io.bench.ts > Scratchpad I/O Benchmarks > Lock Operations > acquireLock + releaseLock",
-      "p50": 0.5305940000007467,
-      "p95": 0.6810000000004948,
+      "p50": 0.5449770000000171,
+      "p95": 0.6726159999998345,
       "maxMemoryMB": 0,
-      "updatedAt": "2026-08-01T07:55:50.462Z"
+      "updatedAt": "2026-08-01T07:58:39.509Z"
     },
     {
       "operation": "tests/performance/benchmarks/scratchpad-io.bench.ts > Scratchpad I/O Benchmarks > Lock Operations > withLock - simple operation",
-      "p50": 1.2796109999999317,
-      "p95": 2.1184880000000703,
+      "p50": 1.3079109999998764,
+      "p95": 7.381695000000036,
       "maxMemoryMB": 0,
-      "updatedAt": "2026-08-01T07:55:50.462Z"
+      "updatedAt": "2026-08-01T07:58:39.509Z"
     },
     {
       "operation": "tests/performance/benchmarks/scratchpad-io.bench.ts > Scratchpad I/O Benchmarks > Path Operations > getSectionPath (100 calls)",
-      "p50": 0.2536165000001347,
-      "p95": 0.4497670000000653,
+      "p50": 0.25452599999971426,
+      "p95": 0.3845769999998083,
       "maxMemoryMB": 0,
-      "updatedAt": "2026-08-01T07:55:50.462Z"
+      "updatedAt": "2026-08-01T07:58:39.509Z"
     },
     {
       "operation": "tests/performance/benchmarks/scratchpad-io.bench.ts > Scratchpad I/O Benchmarks > Path Operations > resolve complex paths",
-      "p50": 0.41587799999979325,
-      "p95": 0.6140450000002602,
+      "p50": 0.41578600000048027,
+      "p95": 0.5764460000000327,
       "maxMemoryMB": 0,
-      "updatedAt": "2026-08-01T07:55:50.462Z"
+      "updatedAt": "2026-08-01T07:58:39.509Z"
     },
     {
       "operation": "tests/performance/benchmarks/scratchpad-io.bench.ts > Scratchpad I/O Benchmarks > YAML Operations > readYaml",
-      "p50": 0.1953269999994518,
-      "p95": 0.2684659999995347,
+      "p50": 0.2029489999999896,
+      "p95": 0.2818220000008296,
       "maxMemoryMB": 0,
-      "updatedAt": "2026-08-01T07:55:50.462Z"
+      "updatedAt": "2026-08-01T07:58:39.509Z"
     },
     {
       "operation": "tests/performance/benchmarks/scratchpad-io.bench.ts > Scratchpad I/O Benchmarks > YAML Operations > writeYaml",
-      "p50": 0.375696500000231,
-      "p95": 0.5563149999998132,
+      "p50": 0.3961140000001251,
+      "p95": 0.5850140000002284,
       "maxMemoryMB": 0,
-      "updatedAt": "2026-08-01T07:55:50.462Z"
+      "updatedAt": "2026-08-01T07:58:39.509Z"
     },
     {
       "operation": "tests/performance/benchmarks/state-persistence.bench.ts > State Persistence Benchmarks > Concurrent Access Simulation > sequential locked writes (10 ops)",
-      "p50": 10.06848600000012,
-      "p95": 11.407711999999265,
+      "p50": 92.68439000000035,
+      "p95": 1021.1316490000008,
       "maxMemoryMB": 0,
-      "updatedAt": "2026-08-01T07:55:50.462Z"
+      "updatedAt": "2026-08-01T07:58:39.509Z"
     },
     {
       "operation": "tests/performance/benchmarks/state-persistence.bench.ts > State Persistence Benchmarks > Graph State Persistence > load 100-node graph",
-      "p50": 0.21628000000009706,
-      "p95": 0.2771370000000388,
+      "p50": 0.2227935000000798,
+      "p95": 0.29137500000024374,
       "maxMemoryMB": 0,
-      "updatedAt": "2026-08-01T07:55:50.462Z"
+      "updatedAt": "2026-08-01T07:58:39.509Z"
     },
     {
       "operation": "tests/performance/benchmarks/state-persistence.bench.ts > State Persistence Benchmarks > Graph State Persistence > load 1000-node graph",
-      "p50": 0.8684335000000374,
-      "p95": 3.278743999999733,
+      "p50": 0.8400320000002921,
+      "p95": 3.0402570000001106,
       "maxMemoryMB": 0,
-      "updatedAt": "2026-08-01T07:55:50.462Z"
+      "updatedAt": "2026-08-01T07:58:39.509Z"
     },
     {
       "operation": "tests/performance/benchmarks/state-persistence.bench.ts > State Persistence Benchmarks > Graph State Persistence > load 500-node graph",
-      "p50": 0.4483919999997852,
-      "p95": 0.8388450000002194,
+      "p50": 0.45145099999990634,
+      "p95": 0.7536740000000464,
       "maxMemoryMB": 0,
-      "updatedAt": "2026-08-01T07:55:50.462Z"
+      "updatedAt": "2026-08-01T07:58:39.509Z"
     },
     {
       "operation": "tests/performance/benchmarks/state-persistence.bench.ts > State Persistence Benchmarks > Graph State Persistence > save 100-node graph",
-      "p50": 0.38582099999996444,
-      "p95": 0.5179860000000076,
+      "p50": 0.396417999999926,
+      "p95": 0.5502609999999777,
       "maxMemoryMB": 0,
-      "updatedAt": "2026-08-01T07:55:50.462Z"
+      "updatedAt": "2026-08-01T07:58:39.509Z"
     },
     {
       "operation": "tests/performance/benchmarks/state-persistence.bench.ts > State Persistence Benchmarks > Graph State Persistence > save 1000-node graph",
-      "p50": 0.9020230000000993,
-      "p95": 3.4215580000000045,
+      "p50": 0.8846779999998944,
+      "p95": 3.246086000000105,
       "maxMemoryMB": 0,
-      "updatedAt": "2026-08-01T07:55:50.462Z"
+      "updatedAt": "2026-08-01T07:58:39.509Z"
     },
     {
       "operation": "tests/performance/benchmarks/state-persistence.bench.ts > State Persistence Benchmarks > Graph State Persistence > save 500-node graph",
-      "p50": 0.5698600000000624,
-      "p95": 0.7237519999998767,
+      "p50": 0.5826660000000174,
+      "p95": 0.7274409999999989,
       "maxMemoryMB": 0,
-      "updatedAt": "2026-08-01T07:55:50.462Z"
+      "updatedAt": "2026-08-01T07:58:39.509Z"
     },
     {
       "operation": "tests/performance/benchmarks/state-persistence.bench.ts > State Persistence Benchmarks > Incremental Updates > incremental update (read-modify-write)",
-      "p50": 2.5767610000002605,
-      "p95": 13.166541000000507,
+      "p50": 19.335856000000604,
+      "p95": 40.85337200000049,
       "maxMemoryMB": 0,
-      "updatedAt": "2026-08-01T07:55:50.462Z"
+      "updatedAt": "2026-08-01T07:58:39.509Z"
     },
     {
       "operation": "tests/performance/benchmarks/state-persistence.bench.ts > State Persistence Benchmarks > Save/Load Cycles > 10 consecutive save/load cycles",
-      "p50": 4.834765999999945,
-      "p95": 5.9939580000000205,
+      "p50": 4.967034999999669,
+      "p95": 5.899508999999853,
       "maxMemoryMB": 0,
-      "updatedAt": "2026-08-01T07:55:50.462Z"
+      "updatedAt": "2026-08-01T07:58:39.509Z"
     },
     {
       "operation": "tests/performance/benchmarks/state-persistence.bench.ts > State Persistence Benchmarks > Save/Load Cycles > complete save/load cycle",
-      "p50": 0.5005535000000236,
-      "p95": 0.7267130000000179,
+      "p50": 0.506851999999526,
+      "p95": 0.7001129999998739,
       "maxMemoryMB": 0,
-      "updatedAt": "2026-08-01T07:55:50.462Z"
+      "updatedAt": "2026-08-01T07:58:39.509Z"
     }
   ],
-  "updatedAt": "2026-08-01T07:55:50.462Z",
+  "updatedAt": "2026-08-01T07:58:39.509Z",
   "environment": {
     "runner": "ubuntu-24.04-arm",
     "platform": "linux-arm64",

--- a/tests/performance/baselines/baseline-metrics.json
+++ b/tests/performance/baselines/baseline-metrics.json
@@ -2,257 +2,262 @@
   "baselines": [
     {
       "operation": "tests/performance/benchmarks/graph-analysis.bench.ts > Graph Analysis Benchmarks > analyze() - 100 nodes > full graph analysis",
-      "p50": 0.23475549999994882,
-      "p95": 0.4198949999999968,
+      "p50": 0.36611299999998437,
+      "p95": 0.642757999999958,
       "maxMemoryMB": 0,
-      "updatedAt": "2026-08-01T07:49:33.148Z"
+      "updatedAt": "2026-08-01T07:55:50.462Z"
     },
     {
       "operation": "tests/performance/benchmarks/graph-analysis.bench.ts > Graph Analysis Benchmarks > analyze() - 100 nodes > with custom weights",
-      "p50": 0.22940299999982017,
-      "p95": 0.41422899999997753,
+      "p50": 0.35398800000007213,
+      "p95": 0.6163659999999709,
       "maxMemoryMB": 0,
-      "updatedAt": "2026-08-01T07:49:33.148Z"
+      "updatedAt": "2026-08-01T07:55:50.462Z"
     },
     {
       "operation": "tests/performance/benchmarks/graph-analysis.bench.ts > Graph Analysis Benchmarks > analyze() - 1000 nodes > full graph analysis",
-      "p50": 17.620766999999887,
-      "p95": 18.516697999999906,
+      "p50": 25.927250500000127,
+      "p95": 26.53874399999995,
       "maxMemoryMB": 0,
-      "updatedAt": "2026-08-01T07:49:33.148Z"
+      "updatedAt": "2026-08-01T07:55:50.462Z"
     },
     {
       "operation": "tests/performance/benchmarks/graph-analysis.bench.ts > Graph Analysis Benchmarks > analyze() - 500 nodes > full graph analysis",
-      "p50": 4.875116999999818,
-      "p95": 5.345655999999963,
+      "p50": 6.934070499999962,
+      "p95": 7.54257900000016,
       "maxMemoryMB": 0,
-      "updatedAt": "2026-08-01T07:49:33.148Z"
+      "updatedAt": "2026-08-01T07:55:50.462Z"
     },
     {
       "operation": "tests/performance/benchmarks/graph-analysis.bench.ts > Graph Analysis Benchmarks > Critical Path Calculation > critical path - 100 nodes",
-      "p50": 0.24224950000007084,
-      "p95": 0.4061500000002525,
+      "p50": 0.3707970000000387,
+      "p95": 0.6320220000002337,
       "maxMemoryMB": 0,
-      "updatedAt": "2026-08-01T07:49:33.148Z"
+      "updatedAt": "2026-08-01T07:55:50.462Z"
     },
     {
       "operation": "tests/performance/benchmarks/graph-analysis.bench.ts > Graph Analysis Benchmarks > Critical Path Calculation > critical path - 1000 nodes",
-      "p50": 15.519682999999532,
-      "p95": 16.130298999999468,
+      "p50": 24.47077900000022,
+      "p95": 25.372378000000026,
       "maxMemoryMB": 0,
-      "updatedAt": "2026-08-01T07:49:33.148Z"
+      "updatedAt": "2026-08-01T07:55:50.462Z"
     },
     {
       "operation": "tests/performance/benchmarks/graph-analysis.bench.ts > Graph Analysis Benchmarks > Critical Path Calculation > critical path - 500 nodes",
-      "p50": 4.085129000000052,
-      "p95": 4.59327200000007,
+      "p50": 6.725263499999983,
+      "p95": 7.773142999999891,
       "maxMemoryMB": 0,
-      "updatedAt": "2026-08-01T07:49:33.148Z"
+      "updatedAt": "2026-08-01T07:55:50.462Z"
     },
     {
       "operation": "tests/performance/benchmarks/graph-analysis.bench.ts > Graph Analysis Benchmarks > Cycle Detection > detect cycles - 100 nodes no cycle",
-      "p50": 0.1998200000007273,
-      "p95": 0.34879000000000815,
+      "p50": 0.3581880000001547,
+      "p95": 0.6347659999992175,
       "maxMemoryMB": 0,
-      "updatedAt": "2026-08-01T07:49:33.148Z"
+      "updatedAt": "2026-08-01T07:55:50.462Z"
     },
     {
       "operation": "tests/performance/benchmarks/graph-analysis.bench.ts > Graph Analysis Benchmarks > Cycle Detection > detect cycles - 100 nodes with cycle",
-      "p50": 0.20858950000001641,
-      "p95": 0.365577999999914,
+      "p50": 0.3514999999997599,
+      "p95": 0.6315100000001621,
       "maxMemoryMB": 0,
-      "updatedAt": "2026-08-01T07:49:33.148Z"
+      "updatedAt": "2026-08-01T07:55:50.462Z"
     },
     {
       "operation": "tests/performance/benchmarks/graph-analysis.bench.ts > Graph Analysis Benchmarks > Dependency Queries > getDependencies",
-      "p50": 0.000608999999712978,
-      "p95": 0.0008829999997033156,
+      "p50": 0.0007040000000415603,
+      "p95": 0.0009599999993952224,
       "maxMemoryMB": 0,
-      "updatedAt": "2026-08-01T07:49:33.148Z"
+      "updatedAt": "2026-08-01T07:55:50.462Z"
     },
     {
       "operation": "tests/performance/benchmarks/graph-analysis.bench.ts > Graph Analysis Benchmarks > Dependency Queries > getDependents",
-      "p50": 0.0005879999998796848,
-      "p95": 0.0008129999996526749,
+      "p50": 0.0007200000000011642,
+      "p95": 0.000984000000244123,
       "maxMemoryMB": 0,
-      "updatedAt": "2026-08-01T07:49:33.148Z"
+      "updatedAt": "2026-08-01T07:55:50.462Z"
     },
     {
       "operation": "tests/performance/benchmarks/graph-analysis.bench.ts > Graph Analysis Benchmarks > Dependency Queries > getTransitiveDependencies",
-      "p50": 0.00008600000001024455,
-      "p95": 0.00015100000018719584,
+      "p50": 0.00015999999959603883,
+      "p95": 0.00017599999955564272,
       "maxMemoryMB": 0,
-      "updatedAt": "2026-08-01T07:49:33.148Z"
+      "updatedAt": "2026-08-01T07:55:50.462Z"
     },
     {
       "operation": "tests/performance/benchmarks/graph-analysis.bench.ts > Graph Analysis Benchmarks > Queue Operations > getExecutableIssues",
-      "p50": 4.154319499999474,
-      "p95": 4.9218349999991915,
+      "p50": 6.7872210000005,
+      "p95": 7.5843280000008235,
       "maxMemoryMB": 0,
-      "updatedAt": "2026-08-01T07:49:33.148Z"
+      "updatedAt": "2026-08-01T07:55:50.462Z"
     },
     {
       "operation": "tests/performance/benchmarks/graph-analysis.bench.ts > Graph Analysis Benchmarks > Queue Operations > getNextExecutableIssue",
-      "p50": 4.516618500000732,
-      "p95": 5.064438000001246,
+      "p50": 7.223604000000705,
+      "p95": 8.263127000000168,
       "maxMemoryMB": 0,
-      "updatedAt": "2026-08-01T07:49:33.148Z"
+      "updatedAt": "2026-08-01T07:55:50.462Z"
     },
     {
       "operation": "tests/performance/benchmarks/scratchpad-io.bench.ts > Scratchpad I/O Benchmarks > JSON Operations > readJson - large payload",
-      "p50": 1.6494509999997717,
-      "p95": 2.604648999999881,
+      "p50": 2.0016279999999824,
+      "p95": 3.3138729999991483,
       "maxMemoryMB": 0,
-      "updatedAt": "2026-08-01T07:49:33.148Z"
+      "updatedAt": "2026-08-01T07:55:50.462Z"
     },
     {
       "operation": "tests/performance/benchmarks/scratchpad-io.bench.ts > Scratchpad I/O Benchmarks > JSON Operations > readJson - medium payload",
-      "p50": 0.19082700000035402,
-      "p95": 0.2688399999997273,
+      "p50": 0.22492349999993166,
+      "p95": 0.2738899999999376,
       "maxMemoryMB": 0,
-      "updatedAt": "2026-08-01T07:49:33.148Z"
+      "updatedAt": "2026-08-01T07:55:50.462Z"
     },
     {
       "operation": "tests/performance/benchmarks/scratchpad-io.bench.ts > Scratchpad I/O Benchmarks > JSON Operations > readJson - small payload",
-      "p50": 0.1220180000000255,
-      "p95": 0.19784100000015314,
+      "p50": 0.14937749999990046,
+      "p95": 0.19410999999990963,
       "maxMemoryMB": 0,
-      "updatedAt": "2026-08-01T07:49:33.148Z"
+      "updatedAt": "2026-08-01T07:55:50.462Z"
     },
     {
       "operation": "tests/performance/benchmarks/scratchpad-io.bench.ts > Scratchpad I/O Benchmarks > JSON Operations > writeJson - large payload (1000 items)",
-      "p50": 1.6233320000001186,
-      "p95": 2.9342069999997875,
+      "p50": 1.839310999999725,
+      "p95": 4.000872999999956,
       "maxMemoryMB": 0,
-      "updatedAt": "2026-08-01T07:49:33.148Z"
+      "updatedAt": "2026-08-01T07:55:50.462Z"
     },
     {
       "operation": "tests/performance/benchmarks/scratchpad-io.bench.ts > Scratchpad I/O Benchmarks > JSON Operations > writeJson - medium payload (100 items)",
-      "p50": 0.28957050000008167,
-      "p95": 0.8856690000000071,
+      "p50": 0.3871090000000095,
+      "p95": 0.5200259999999162,
       "maxMemoryMB": 0,
-      "updatedAt": "2026-08-01T07:49:33.148Z"
+      "updatedAt": "2026-08-01T07:55:50.462Z"
     },
     {
       "operation": "tests/performance/benchmarks/scratchpad-io.bench.ts > Scratchpad I/O Benchmarks > JSON Operations > writeJson - small payload",
-      "p50": 0.24919199999999364,
-      "p95": 0.4433639999999741,
+      "p50": 0.329155000000128,
+      "p95": 0.47301599999991595,
       "maxMemoryMB": 0,
-      "updatedAt": "2026-08-01T07:49:33.148Z"
+      "updatedAt": "2026-08-01T07:55:50.462Z"
     },
     {
       "operation": "tests/performance/benchmarks/scratchpad-io.bench.ts > Scratchpad I/O Benchmarks > Lock Operations > acquireLock + releaseLock",
-      "p50": 0.5337870000003022,
-      "p95": 0.8118780000004335,
+      "p50": 0.5305940000007467,
+      "p95": 0.6810000000004948,
       "maxMemoryMB": 0,
-      "updatedAt": "2026-08-01T07:49:33.148Z"
+      "updatedAt": "2026-08-01T07:55:50.462Z"
     },
     {
       "operation": "tests/performance/benchmarks/scratchpad-io.bench.ts > Scratchpad I/O Benchmarks > Lock Operations > withLock - simple operation",
-      "p50": 1.4623680000004242,
-      "p95": 2.057684000000336,
+      "p50": 1.2796109999999317,
+      "p95": 2.1184880000000703,
       "maxMemoryMB": 0,
-      "updatedAt": "2026-08-01T07:49:33.148Z"
+      "updatedAt": "2026-08-01T07:55:50.462Z"
     },
     {
       "operation": "tests/performance/benchmarks/scratchpad-io.bench.ts > Scratchpad I/O Benchmarks > Path Operations > getSectionPath (100 calls)",
-      "p50": 0.18717300000025716,
-      "p95": 0.3221400000002177,
+      "p50": 0.2536165000001347,
+      "p95": 0.4497670000000653,
       "maxMemoryMB": 0,
-      "updatedAt": "2026-08-01T07:49:33.148Z"
+      "updatedAt": "2026-08-01T07:55:50.462Z"
     },
     {
       "operation": "tests/performance/benchmarks/scratchpad-io.bench.ts > Scratchpad I/O Benchmarks > Path Operations > resolve complex paths",
-      "p50": 0.3061090000001059,
-      "p95": 0.4514739999995072,
+      "p50": 0.41587799999979325,
+      "p95": 0.6140450000002602,
       "maxMemoryMB": 0,
-      "updatedAt": "2026-08-01T07:49:33.148Z"
+      "updatedAt": "2026-08-01T07:55:50.462Z"
     },
     {
       "operation": "tests/performance/benchmarks/scratchpad-io.bench.ts > Scratchpad I/O Benchmarks > YAML Operations > readYaml",
-      "p50": 0.17166999999972177,
-      "p95": 0.2616520000001401,
+      "p50": 0.1953269999994518,
+      "p95": 0.2684659999995347,
       "maxMemoryMB": 0,
-      "updatedAt": "2026-08-01T07:49:33.148Z"
+      "updatedAt": "2026-08-01T07:55:50.462Z"
     },
     {
       "operation": "tests/performance/benchmarks/scratchpad-io.bench.ts > Scratchpad I/O Benchmarks > YAML Operations > writeYaml",
-      "p50": 0.32834500000035405,
-      "p95": 0.6185139999997773,
+      "p50": 0.375696500000231,
+      "p95": 0.5563149999998132,
       "maxMemoryMB": 0,
-      "updatedAt": "2026-08-01T07:49:33.148Z"
+      "updatedAt": "2026-08-01T07:55:50.462Z"
     },
     {
       "operation": "tests/performance/benchmarks/state-persistence.bench.ts > State Persistence Benchmarks > Concurrent Access Simulation > sequential locked writes (10 ops)",
-      "p50": 11.474039999999604,
-      "p95": 175.18341300000066,
+      "p50": 10.06848600000012,
+      "p95": 11.407711999999265,
       "maxMemoryMB": 0,
-      "updatedAt": "2026-08-01T07:49:33.148Z"
+      "updatedAt": "2026-08-01T07:55:50.462Z"
     },
     {
       "operation": "tests/performance/benchmarks/state-persistence.bench.ts > State Persistence Benchmarks > Graph State Persistence > load 100-node graph",
-      "p50": 0.21076300000004267,
-      "p95": 0.26385000000027503,
+      "p50": 0.21628000000009706,
+      "p95": 0.2771370000000388,
       "maxMemoryMB": 0,
-      "updatedAt": "2026-08-01T07:49:33.148Z"
+      "updatedAt": "2026-08-01T07:55:50.462Z"
     },
     {
       "operation": "tests/performance/benchmarks/state-persistence.bench.ts > State Persistence Benchmarks > Graph State Persistence > load 1000-node graph",
-      "p50": 0.7139614999998685,
-      "p95": 5.600958999999875,
+      "p50": 0.8684335000000374,
+      "p95": 3.278743999999733,
       "maxMemoryMB": 0,
-      "updatedAt": "2026-08-01T07:49:33.148Z"
+      "updatedAt": "2026-08-01T07:55:50.462Z"
     },
     {
       "operation": "tests/performance/benchmarks/state-persistence.bench.ts > State Persistence Benchmarks > Graph State Persistence > load 500-node graph",
-      "p50": 0.365060000000085,
-      "p95": 0.6438229999998839,
+      "p50": 0.4483919999997852,
+      "p95": 0.8388450000002194,
       "maxMemoryMB": 0,
-      "updatedAt": "2026-08-01T07:49:33.148Z"
+      "updatedAt": "2026-08-01T07:55:50.462Z"
     },
     {
       "operation": "tests/performance/benchmarks/state-persistence.bench.ts > State Persistence Benchmarks > Graph State Persistence > save 100-node graph",
-      "p50": 0.32458449999998606,
-      "p95": 0.5453690000000506,
+      "p50": 0.38582099999996444,
+      "p95": 0.5179860000000076,
       "maxMemoryMB": 0,
-      "updatedAt": "2026-08-01T07:49:33.148Z"
+      "updatedAt": "2026-08-01T07:55:50.462Z"
     },
     {
       "operation": "tests/performance/benchmarks/state-persistence.bench.ts > State Persistence Benchmarks > Graph State Persistence > save 1000-node graph",
-      "p50": 0.7680359999999382,
-      "p95": 2.8164409999999407,
+      "p50": 0.9020230000000993,
+      "p95": 3.4215580000000045,
       "maxMemoryMB": 0,
-      "updatedAt": "2026-08-01T07:49:33.148Z"
+      "updatedAt": "2026-08-01T07:55:50.462Z"
     },
     {
       "operation": "tests/performance/benchmarks/state-persistence.bench.ts > State Persistence Benchmarks > Graph State Persistence > save 500-node graph",
-      "p50": 0.5126115000000482,
-      "p95": 0.6436170000001766,
+      "p50": 0.5698600000000624,
+      "p95": 0.7237519999998767,
       "maxMemoryMB": 0,
-      "updatedAt": "2026-08-01T07:49:33.148Z"
+      "updatedAt": "2026-08-01T07:55:50.462Z"
     },
     {
       "operation": "tests/performance/benchmarks/state-persistence.bench.ts > State Persistence Benchmarks > Incremental Updates > incremental update (read-modify-write)",
-      "p50": 2.9819250000000466,
-      "p95": 60.23926599999959,
+      "p50": 2.5767610000002605,
+      "p95": 13.166541000000507,
       "maxMemoryMB": 0,
-      "updatedAt": "2026-08-01T07:49:33.148Z"
+      "updatedAt": "2026-08-01T07:55:50.462Z"
     },
     {
       "operation": "tests/performance/benchmarks/state-persistence.bench.ts > State Persistence Benchmarks > Save/Load Cycles > 10 consecutive save/load cycles",
-      "p50": 4.8544040000006135,
-      "p95": 6.584953999999925,
+      "p50": 4.834765999999945,
+      "p95": 5.9939580000000205,
       "maxMemoryMB": 0,
-      "updatedAt": "2026-08-01T07:49:33.148Z"
+      "updatedAt": "2026-08-01T07:55:50.462Z"
     },
     {
       "operation": "tests/performance/benchmarks/state-persistence.bench.ts > State Persistence Benchmarks > Save/Load Cycles > complete save/load cycle",
-      "p50": 0.5457734999999957,
-      "p95": 0.7273430000004737,
+      "p50": 0.5005535000000236,
+      "p95": 0.7267130000000179,
       "maxMemoryMB": 0,
-      "updatedAt": "2026-08-01T07:49:33.148Z"
+      "updatedAt": "2026-08-01T07:55:50.462Z"
     }
   ],
-  "updatedAt": "2026-08-01T07:49:33.148Z",
-  "notes": "Generated from Vitest benchmark output on the designated CI runner. p50 uses median; p95 uses Vitest/Tinybench p99 as a conservative upper-tail proxy."
+  "updatedAt": "2026-08-01T07:55:50.462Z",
+  "environment": {
+    "runner": "ubuntu-24.04-arm",
+    "platform": "linux-arm64",
+    "node": "v22.23.1"
+  },
+  "notes": "Generated from Vitest benchmark output on ubuntu-24.04-arm. p50 uses median; p95 uses Vitest/Tinybench p99 as a conservative upper-tail proxy."
 }

--- a/tests/performance/baselines/baseline-metrics.json
+++ b/tests/performance/baselines/baseline-metrics.json
@@ -1,48 +1,258 @@
 {
   "baselines": [
     {
-      "operation": "analyze-100",
-      "p50": 15,
-      "p95": 30,
-      "maxMemoryMB": 50,
-      "updatedAt": "2026-01-10T00:00:00.000Z"
+      "operation": "tests/performance/benchmarks/graph-analysis.bench.ts > Graph Analysis Benchmarks > analyze() - 100 nodes > full graph analysis",
+      "p50": 0.1380420000000413,
+      "p95": 0.18274999999999864,
+      "maxMemoryMB": 0,
+      "updatedAt": "2026-08-01T07:41:44.598Z"
     },
     {
-      "operation": "analyze-500",
-      "p50": 100,
-      "p95": 200,
-      "maxMemoryMB": 100,
-      "updatedAt": "2026-01-10T00:00:00.000Z"
+      "operation": "tests/performance/benchmarks/graph-analysis.bench.ts > Graph Analysis Benchmarks > analyze() - 100 nodes > with custom weights",
+      "p50": 0.13362499999993815,
+      "p95": 0.1705419999998412,
+      "maxMemoryMB": 0,
+      "updatedAt": "2026-08-01T07:41:44.598Z"
     },
     {
-      "operation": "analyze-1000",
-      "p50": 350,
-      "p95": 700,
-      "maxMemoryMB": 200,
-      "updatedAt": "2026-01-10T00:00:00.000Z"
+      "operation": "tests/performance/benchmarks/graph-analysis.bench.ts > Graph Analysis Benchmarks > analyze() - 1000 nodes > full graph analysis",
+      "p50": 9.615250000000287,
+      "p95": 15.619166999999834,
+      "maxMemoryMB": 0,
+      "updatedAt": "2026-08-01T07:41:44.598Z"
     },
     {
-      "operation": "scratchpad-write-small",
-      "p50": 2,
-      "p95": 5,
-      "maxMemoryMB": 20,
-      "updatedAt": "2026-01-10T00:00:00.000Z"
+      "operation": "tests/performance/benchmarks/graph-analysis.bench.ts > Graph Analysis Benchmarks > analyze() - 500 nodes > full graph analysis",
+      "p50": 2.3052289999999402,
+      "p95": 2.4637500000001182,
+      "maxMemoryMB": 0,
+      "updatedAt": "2026-08-01T07:41:44.598Z"
     },
     {
-      "operation": "scratchpad-write-large",
-      "p50": 15,
-      "p95": 30,
-      "maxMemoryMB": 50,
-      "updatedAt": "2026-01-10T00:00:00.000Z"
+      "operation": "tests/performance/benchmarks/graph-analysis.bench.ts > Graph Analysis Benchmarks > Critical Path Calculation > critical path - 100 nodes",
+      "p50": 0.13162499999998545,
+      "p95": 0.1730000000002292,
+      "maxMemoryMB": 0,
+      "updatedAt": "2026-08-01T07:41:44.598Z"
     },
     {
-      "operation": "lock-acquire-release",
-      "p50": 5,
-      "p95": 15,
-      "maxMemoryMB": 10,
-      "updatedAt": "2026-01-10T00:00:00.000Z"
+      "operation": "tests/performance/benchmarks/graph-analysis.bench.ts > Graph Analysis Benchmarks > Critical Path Calculation > critical path - 1000 nodes",
+      "p50": 9.833166999999776,
+      "p95": 10.297083000000384,
+      "maxMemoryMB": 0,
+      "updatedAt": "2026-08-01T07:41:44.598Z"
+    },
+    {
+      "operation": "tests/performance/benchmarks/graph-analysis.bench.ts > Graph Analysis Benchmarks > Critical Path Calculation > critical path - 500 nodes",
+      "p50": 2.33987500000012,
+      "p95": 2.4802920000001905,
+      "maxMemoryMB": 0,
+      "updatedAt": "2026-08-01T07:41:44.598Z"
+    },
+    {
+      "operation": "tests/performance/benchmarks/graph-analysis.bench.ts > Graph Analysis Benchmarks > Cycle Detection > detect cycles - 100 nodes no cycle",
+      "p50": 0.12908299999980954,
+      "p95": 0.16587499999968713,
+      "maxMemoryMB": 0,
+      "updatedAt": "2026-08-01T07:41:44.598Z"
+    },
+    {
+      "operation": "tests/performance/benchmarks/graph-analysis.bench.ts > Graph Analysis Benchmarks > Cycle Detection > detect cycles - 100 nodes with cycle",
+      "p50": 0.13249999999970896,
+      "p95": 0.17312499999934516,
+      "maxMemoryMB": 0,
+      "updatedAt": "2026-08-01T07:41:44.598Z"
+    },
+    {
+      "operation": "tests/performance/benchmarks/graph-analysis.bench.ts > Graph Analysis Benchmarks > Dependency Queries > getDependencies",
+      "p50": 0.00033399999938410474,
+      "p95": 0.0005000000001018634,
+      "maxMemoryMB": 0,
+      "updatedAt": "2026-08-01T07:41:44.598Z"
+    },
+    {
+      "operation": "tests/performance/benchmarks/graph-analysis.bench.ts > Graph Analysis Benchmarks > Dependency Queries > getDependents",
+      "p50": 0.0003749999996216502,
+      "p95": 0.0005419999997684499,
+      "maxMemoryMB": 0,
+      "updatedAt": "2026-08-01T07:41:44.598Z"
+    },
+    {
+      "operation": "tests/performance/benchmarks/graph-analysis.bench.ts > Graph Analysis Benchmarks > Dependency Queries > getTransitiveDependencies",
+      "p50": 0.00004199999966658652,
+      "p95": 0.00008300000081362668,
+      "maxMemoryMB": 0,
+      "updatedAt": "2026-08-01T07:41:44.598Z"
+    },
+    {
+      "operation": "tests/performance/benchmarks/graph-analysis.bench.ts > Graph Analysis Benchmarks > Queue Operations > getExecutableIssues",
+      "p50": 2.326000000000022,
+      "p95": 2.5631670000002487,
+      "maxMemoryMB": 0,
+      "updatedAt": "2026-08-01T07:41:44.598Z"
+    },
+    {
+      "operation": "tests/performance/benchmarks/graph-analysis.bench.ts > Graph Analysis Benchmarks > Queue Operations > getNextExecutableIssue",
+      "p50": 2.483770500000901,
+      "p95": 2.665999999999258,
+      "maxMemoryMB": 0,
+      "updatedAt": "2026-08-01T07:41:44.598Z"
+    },
+    {
+      "operation": "tests/performance/benchmarks/scratchpad-io.bench.ts > Scratchpad I/O Benchmarks > JSON Operations > readJson - large payload",
+      "p50": 0.7802915000002031,
+      "p95": 0.9050000000002001,
+      "maxMemoryMB": 0,
+      "updatedAt": "2026-08-01T07:41:44.598Z"
+    },
+    {
+      "operation": "tests/performance/benchmarks/scratchpad-io.bench.ts > Scratchpad I/O Benchmarks > JSON Operations > readJson - medium payload",
+      "p50": 0.0912079999998241,
+      "p95": 0.11608299999988958,
+      "maxMemoryMB": 0,
+      "updatedAt": "2026-08-01T07:41:44.598Z"
+    },
+    {
+      "operation": "tests/performance/benchmarks/scratchpad-io.bench.ts > Scratchpad I/O Benchmarks > JSON Operations > readJson - small payload",
+      "p50": 0.06300000000010186,
+      "p95": 0.0757090000001881,
+      "maxMemoryMB": 0,
+      "updatedAt": "2026-08-01T07:41:44.598Z"
+    },
+    {
+      "operation": "tests/performance/benchmarks/scratchpad-io.bench.ts > Scratchpad I/O Benchmarks > JSON Operations > writeJson - large payload (1000 items)",
+      "p50": 0.7598335000000134,
+      "p95": 1.0824170000000777,
+      "maxMemoryMB": 0,
+      "updatedAt": "2026-08-01T07:41:44.598Z"
+    },
+    {
+      "operation": "tests/performance/benchmarks/scratchpad-io.bench.ts > Scratchpad I/O Benchmarks > JSON Operations > writeJson - medium payload (100 items)",
+      "p50": 0.2219159999999647,
+      "p95": 0.2866669999998521,
+      "maxMemoryMB": 0,
+      "updatedAt": "2026-08-01T07:41:44.598Z"
+    },
+    {
+      "operation": "tests/performance/benchmarks/scratchpad-io.bench.ts > Scratchpad I/O Benchmarks > JSON Operations > writeJson - small payload",
+      "p50": 0.19170899999994617,
+      "p95": 0.2540840000000344,
+      "maxMemoryMB": 0,
+      "updatedAt": "2026-08-01T07:41:44.598Z"
+    },
+    {
+      "operation": "tests/performance/benchmarks/scratchpad-io.bench.ts > Scratchpad I/O Benchmarks > Lock Operations > acquireLock + releaseLock",
+      "p50": 0.4977499999995416,
+      "p95": 0.6220000000002983,
+      "maxMemoryMB": 0,
+      "updatedAt": "2026-08-01T07:41:44.598Z"
+    },
+    {
+      "operation": "tests/performance/benchmarks/scratchpad-io.bench.ts > Scratchpad I/O Benchmarks > Lock Operations > withLock - simple operation",
+      "p50": 0.9582919999998012,
+      "p95": 1.2970839999998134,
+      "maxMemoryMB": 0,
+      "updatedAt": "2026-08-01T07:41:44.598Z"
+    },
+    {
+      "operation": "tests/performance/benchmarks/scratchpad-io.bench.ts > Scratchpad I/O Benchmarks > Path Operations > getSectionPath (100 calls)",
+      "p50": 0.18224999999983993,
+      "p95": 0.21987499999977445,
+      "maxMemoryMB": 0,
+      "updatedAt": "2026-08-01T07:41:44.598Z"
+    },
+    {
+      "operation": "tests/performance/benchmarks/scratchpad-io.bench.ts > Scratchpad I/O Benchmarks > Path Operations > resolve complex paths",
+      "p50": 0.29508350000014616,
+      "p95": 0.35883300000023155,
+      "maxMemoryMB": 0,
+      "updatedAt": "2026-08-01T07:41:44.598Z"
+    },
+    {
+      "operation": "tests/performance/benchmarks/scratchpad-io.bench.ts > Scratchpad I/O Benchmarks > YAML Operations > readYaml",
+      "p50": 0.07404099999985192,
+      "p95": 0.09366700000009587,
+      "maxMemoryMB": 0,
+      "updatedAt": "2026-08-01T07:41:44.598Z"
+    },
+    {
+      "operation": "tests/performance/benchmarks/scratchpad-io.bench.ts > Scratchpad I/O Benchmarks > YAML Operations > writeYaml",
+      "p50": 0.21066650000011578,
+      "p95": 0.2704169999997248,
+      "maxMemoryMB": 0,
+      "updatedAt": "2026-08-01T07:41:44.598Z"
+    },
+    {
+      "operation": "tests/performance/benchmarks/state-persistence.bench.ts > State Persistence Benchmarks > Concurrent Access Simulation > sequential locked writes (10 ops)",
+      "p50": 7.869666999999936,
+      "p95": 20.575833999999304,
+      "maxMemoryMB": 0,
+      "updatedAt": "2026-08-01T07:41:44.598Z"
+    },
+    {
+      "operation": "tests/performance/benchmarks/state-persistence.bench.ts > State Persistence Benchmarks > Graph State Persistence > load 100-node graph",
+      "p50": 0.08575000000018917,
+      "p95": 0.11070799999970404,
+      "maxMemoryMB": 0,
+      "updatedAt": "2026-08-01T07:41:44.598Z"
+    },
+    {
+      "operation": "tests/performance/benchmarks/state-persistence.bench.ts > State Persistence Benchmarks > Graph State Persistence > load 1000-node graph",
+      "p50": 0.2795419999997648,
+      "p95": 0.3612079999998059,
+      "maxMemoryMB": 0,
+      "updatedAt": "2026-08-01T07:41:44.598Z"
+    },
+    {
+      "operation": "tests/performance/benchmarks/state-persistence.bench.ts > State Persistence Benchmarks > Graph State Persistence > load 500-node graph",
+      "p50": 0.17212500000005093,
+      "p95": 0.2053329999998823,
+      "maxMemoryMB": 0,
+      "updatedAt": "2026-08-01T07:41:44.598Z"
+    },
+    {
+      "operation": "tests/performance/benchmarks/state-persistence.bench.ts > State Persistence Benchmarks > Graph State Persistence > save 100-node graph",
+      "p50": 0.21383300000002237,
+      "p95": 0.27308299999998553,
+      "maxMemoryMB": 0,
+      "updatedAt": "2026-08-01T07:41:44.598Z"
+    },
+    {
+      "operation": "tests/performance/benchmarks/state-persistence.bench.ts > State Persistence Benchmarks > Graph State Persistence > save 1000-node graph",
+      "p50": 0.38149999999996,
+      "p95": 0.49137500000006185,
+      "maxMemoryMB": 0,
+      "updatedAt": "2026-08-01T07:41:44.598Z"
+    },
+    {
+      "operation": "tests/performance/benchmarks/state-persistence.bench.ts > State Persistence Benchmarks > Graph State Persistence > save 500-node graph",
+      "p50": 0.286707999999976,
+      "p95": 0.40145800000004783,
+      "maxMemoryMB": 0,
+      "updatedAt": "2026-08-01T07:41:44.598Z"
+    },
+    {
+      "operation": "tests/performance/benchmarks/state-persistence.bench.ts > State Persistence Benchmarks > Incremental Updates > incremental update (read-modify-write)",
+      "p50": 1.450937000000522,
+      "p95": 1.8780409999999392,
+      "maxMemoryMB": 0,
+      "updatedAt": "2026-08-01T07:41:44.598Z"
+    },
+    {
+      "operation": "tests/performance/benchmarks/state-persistence.bench.ts > State Persistence Benchmarks > Save/Load Cycles > 10 consecutive save/load cycles",
+      "p50": 2.604833000000326,
+      "p95": 3.1966670000001614,
+      "maxMemoryMB": 0,
+      "updatedAt": "2026-08-01T07:41:44.598Z"
+    },
+    {
+      "operation": "tests/performance/benchmarks/state-persistence.bench.ts > State Persistence Benchmarks > Save/Load Cycles > complete save/load cycle",
+      "p50": 0.2592500000000655,
+      "p95": 0.32908299999962765,
+      "maxMemoryMB": 0,
+      "updatedAt": "2026-08-01T07:41:44.598Z"
     }
   ],
-  "updatedAt": "2026-01-10T00:00:00.000Z",
-  "notes": "Initial baseline metrics. Update after running benchmarks on consistent hardware."
+  "updatedAt": "2026-08-01T07:41:44.598Z",
+  "notes": "Generated from Vitest benchmark output on the designated CI runner. p50 uses median; p95 uses Vitest/Tinybench p99 as a conservative upper-tail proxy."
 }

--- a/tests/performance/baselines/baseline-metrics.json
+++ b/tests/performance/baselines/baseline-metrics.json
@@ -2,257 +2,257 @@
   "baselines": [
     {
       "operation": "tests/performance/benchmarks/graph-analysis.bench.ts > Graph Analysis Benchmarks > analyze() - 100 nodes > full graph analysis",
-      "p50": 0.1380420000000413,
-      "p95": 0.18274999999999864,
+      "p50": 0.23475549999994882,
+      "p95": 0.4198949999999968,
       "maxMemoryMB": 0,
-      "updatedAt": "2026-08-01T07:41:44.598Z"
+      "updatedAt": "2026-08-01T07:49:33.148Z"
     },
     {
       "operation": "tests/performance/benchmarks/graph-analysis.bench.ts > Graph Analysis Benchmarks > analyze() - 100 nodes > with custom weights",
-      "p50": 0.13362499999993815,
-      "p95": 0.1705419999998412,
+      "p50": 0.22940299999982017,
+      "p95": 0.41422899999997753,
       "maxMemoryMB": 0,
-      "updatedAt": "2026-08-01T07:41:44.598Z"
+      "updatedAt": "2026-08-01T07:49:33.148Z"
     },
     {
       "operation": "tests/performance/benchmarks/graph-analysis.bench.ts > Graph Analysis Benchmarks > analyze() - 1000 nodes > full graph analysis",
-      "p50": 9.615250000000287,
-      "p95": 15.619166999999834,
+      "p50": 17.620766999999887,
+      "p95": 18.516697999999906,
       "maxMemoryMB": 0,
-      "updatedAt": "2026-08-01T07:41:44.598Z"
+      "updatedAt": "2026-08-01T07:49:33.148Z"
     },
     {
       "operation": "tests/performance/benchmarks/graph-analysis.bench.ts > Graph Analysis Benchmarks > analyze() - 500 nodes > full graph analysis",
-      "p50": 2.3052289999999402,
-      "p95": 2.4637500000001182,
+      "p50": 4.875116999999818,
+      "p95": 5.345655999999963,
       "maxMemoryMB": 0,
-      "updatedAt": "2026-08-01T07:41:44.598Z"
+      "updatedAt": "2026-08-01T07:49:33.148Z"
     },
     {
       "operation": "tests/performance/benchmarks/graph-analysis.bench.ts > Graph Analysis Benchmarks > Critical Path Calculation > critical path - 100 nodes",
-      "p50": 0.13162499999998545,
-      "p95": 0.1730000000002292,
+      "p50": 0.24224950000007084,
+      "p95": 0.4061500000002525,
       "maxMemoryMB": 0,
-      "updatedAt": "2026-08-01T07:41:44.598Z"
+      "updatedAt": "2026-08-01T07:49:33.148Z"
     },
     {
       "operation": "tests/performance/benchmarks/graph-analysis.bench.ts > Graph Analysis Benchmarks > Critical Path Calculation > critical path - 1000 nodes",
-      "p50": 9.833166999999776,
-      "p95": 10.297083000000384,
+      "p50": 15.519682999999532,
+      "p95": 16.130298999999468,
       "maxMemoryMB": 0,
-      "updatedAt": "2026-08-01T07:41:44.598Z"
+      "updatedAt": "2026-08-01T07:49:33.148Z"
     },
     {
       "operation": "tests/performance/benchmarks/graph-analysis.bench.ts > Graph Analysis Benchmarks > Critical Path Calculation > critical path - 500 nodes",
-      "p50": 2.33987500000012,
-      "p95": 2.4802920000001905,
+      "p50": 4.085129000000052,
+      "p95": 4.59327200000007,
       "maxMemoryMB": 0,
-      "updatedAt": "2026-08-01T07:41:44.598Z"
+      "updatedAt": "2026-08-01T07:49:33.148Z"
     },
     {
       "operation": "tests/performance/benchmarks/graph-analysis.bench.ts > Graph Analysis Benchmarks > Cycle Detection > detect cycles - 100 nodes no cycle",
-      "p50": 0.12908299999980954,
-      "p95": 0.16587499999968713,
+      "p50": 0.1998200000007273,
+      "p95": 0.34879000000000815,
       "maxMemoryMB": 0,
-      "updatedAt": "2026-08-01T07:41:44.598Z"
+      "updatedAt": "2026-08-01T07:49:33.148Z"
     },
     {
       "operation": "tests/performance/benchmarks/graph-analysis.bench.ts > Graph Analysis Benchmarks > Cycle Detection > detect cycles - 100 nodes with cycle",
-      "p50": 0.13249999999970896,
-      "p95": 0.17312499999934516,
+      "p50": 0.20858950000001641,
+      "p95": 0.365577999999914,
       "maxMemoryMB": 0,
-      "updatedAt": "2026-08-01T07:41:44.598Z"
+      "updatedAt": "2026-08-01T07:49:33.148Z"
     },
     {
       "operation": "tests/performance/benchmarks/graph-analysis.bench.ts > Graph Analysis Benchmarks > Dependency Queries > getDependencies",
-      "p50": 0.00033399999938410474,
-      "p95": 0.0005000000001018634,
+      "p50": 0.000608999999712978,
+      "p95": 0.0008829999997033156,
       "maxMemoryMB": 0,
-      "updatedAt": "2026-08-01T07:41:44.598Z"
+      "updatedAt": "2026-08-01T07:49:33.148Z"
     },
     {
       "operation": "tests/performance/benchmarks/graph-analysis.bench.ts > Graph Analysis Benchmarks > Dependency Queries > getDependents",
-      "p50": 0.0003749999996216502,
-      "p95": 0.0005419999997684499,
+      "p50": 0.0005879999998796848,
+      "p95": 0.0008129999996526749,
       "maxMemoryMB": 0,
-      "updatedAt": "2026-08-01T07:41:44.598Z"
+      "updatedAt": "2026-08-01T07:49:33.148Z"
     },
     {
       "operation": "tests/performance/benchmarks/graph-analysis.bench.ts > Graph Analysis Benchmarks > Dependency Queries > getTransitiveDependencies",
-      "p50": 0.00004199999966658652,
-      "p95": 0.00008300000081362668,
+      "p50": 0.00008600000001024455,
+      "p95": 0.00015100000018719584,
       "maxMemoryMB": 0,
-      "updatedAt": "2026-08-01T07:41:44.598Z"
+      "updatedAt": "2026-08-01T07:49:33.148Z"
     },
     {
       "operation": "tests/performance/benchmarks/graph-analysis.bench.ts > Graph Analysis Benchmarks > Queue Operations > getExecutableIssues",
-      "p50": 2.326000000000022,
-      "p95": 2.5631670000002487,
+      "p50": 4.154319499999474,
+      "p95": 4.9218349999991915,
       "maxMemoryMB": 0,
-      "updatedAt": "2026-08-01T07:41:44.598Z"
+      "updatedAt": "2026-08-01T07:49:33.148Z"
     },
     {
       "operation": "tests/performance/benchmarks/graph-analysis.bench.ts > Graph Analysis Benchmarks > Queue Operations > getNextExecutableIssue",
-      "p50": 2.483770500000901,
-      "p95": 2.665999999999258,
+      "p50": 4.516618500000732,
+      "p95": 5.064438000001246,
       "maxMemoryMB": 0,
-      "updatedAt": "2026-08-01T07:41:44.598Z"
+      "updatedAt": "2026-08-01T07:49:33.148Z"
     },
     {
       "operation": "tests/performance/benchmarks/scratchpad-io.bench.ts > Scratchpad I/O Benchmarks > JSON Operations > readJson - large payload",
-      "p50": 0.7802915000002031,
-      "p95": 0.9050000000002001,
+      "p50": 1.6494509999997717,
+      "p95": 2.604648999999881,
       "maxMemoryMB": 0,
-      "updatedAt": "2026-08-01T07:41:44.598Z"
+      "updatedAt": "2026-08-01T07:49:33.148Z"
     },
     {
       "operation": "tests/performance/benchmarks/scratchpad-io.bench.ts > Scratchpad I/O Benchmarks > JSON Operations > readJson - medium payload",
-      "p50": 0.0912079999998241,
-      "p95": 0.11608299999988958,
+      "p50": 0.19082700000035402,
+      "p95": 0.2688399999997273,
       "maxMemoryMB": 0,
-      "updatedAt": "2026-08-01T07:41:44.598Z"
+      "updatedAt": "2026-08-01T07:49:33.148Z"
     },
     {
       "operation": "tests/performance/benchmarks/scratchpad-io.bench.ts > Scratchpad I/O Benchmarks > JSON Operations > readJson - small payload",
-      "p50": 0.06300000000010186,
-      "p95": 0.0757090000001881,
+      "p50": 0.1220180000000255,
+      "p95": 0.19784100000015314,
       "maxMemoryMB": 0,
-      "updatedAt": "2026-08-01T07:41:44.598Z"
+      "updatedAt": "2026-08-01T07:49:33.148Z"
     },
     {
       "operation": "tests/performance/benchmarks/scratchpad-io.bench.ts > Scratchpad I/O Benchmarks > JSON Operations > writeJson - large payload (1000 items)",
-      "p50": 0.7598335000000134,
-      "p95": 1.0824170000000777,
+      "p50": 1.6233320000001186,
+      "p95": 2.9342069999997875,
       "maxMemoryMB": 0,
-      "updatedAt": "2026-08-01T07:41:44.598Z"
+      "updatedAt": "2026-08-01T07:49:33.148Z"
     },
     {
       "operation": "tests/performance/benchmarks/scratchpad-io.bench.ts > Scratchpad I/O Benchmarks > JSON Operations > writeJson - medium payload (100 items)",
-      "p50": 0.2219159999999647,
-      "p95": 0.2866669999998521,
+      "p50": 0.28957050000008167,
+      "p95": 0.8856690000000071,
       "maxMemoryMB": 0,
-      "updatedAt": "2026-08-01T07:41:44.598Z"
+      "updatedAt": "2026-08-01T07:49:33.148Z"
     },
     {
       "operation": "tests/performance/benchmarks/scratchpad-io.bench.ts > Scratchpad I/O Benchmarks > JSON Operations > writeJson - small payload",
-      "p50": 0.19170899999994617,
-      "p95": 0.2540840000000344,
+      "p50": 0.24919199999999364,
+      "p95": 0.4433639999999741,
       "maxMemoryMB": 0,
-      "updatedAt": "2026-08-01T07:41:44.598Z"
+      "updatedAt": "2026-08-01T07:49:33.148Z"
     },
     {
       "operation": "tests/performance/benchmarks/scratchpad-io.bench.ts > Scratchpad I/O Benchmarks > Lock Operations > acquireLock + releaseLock",
-      "p50": 0.4977499999995416,
-      "p95": 0.6220000000002983,
+      "p50": 0.5337870000003022,
+      "p95": 0.8118780000004335,
       "maxMemoryMB": 0,
-      "updatedAt": "2026-08-01T07:41:44.598Z"
+      "updatedAt": "2026-08-01T07:49:33.148Z"
     },
     {
       "operation": "tests/performance/benchmarks/scratchpad-io.bench.ts > Scratchpad I/O Benchmarks > Lock Operations > withLock - simple operation",
-      "p50": 0.9582919999998012,
-      "p95": 1.2970839999998134,
+      "p50": 1.4623680000004242,
+      "p95": 2.057684000000336,
       "maxMemoryMB": 0,
-      "updatedAt": "2026-08-01T07:41:44.598Z"
+      "updatedAt": "2026-08-01T07:49:33.148Z"
     },
     {
       "operation": "tests/performance/benchmarks/scratchpad-io.bench.ts > Scratchpad I/O Benchmarks > Path Operations > getSectionPath (100 calls)",
-      "p50": 0.18224999999983993,
-      "p95": 0.21987499999977445,
+      "p50": 0.18717300000025716,
+      "p95": 0.3221400000002177,
       "maxMemoryMB": 0,
-      "updatedAt": "2026-08-01T07:41:44.598Z"
+      "updatedAt": "2026-08-01T07:49:33.148Z"
     },
     {
       "operation": "tests/performance/benchmarks/scratchpad-io.bench.ts > Scratchpad I/O Benchmarks > Path Operations > resolve complex paths",
-      "p50": 0.29508350000014616,
-      "p95": 0.35883300000023155,
+      "p50": 0.3061090000001059,
+      "p95": 0.4514739999995072,
       "maxMemoryMB": 0,
-      "updatedAt": "2026-08-01T07:41:44.598Z"
+      "updatedAt": "2026-08-01T07:49:33.148Z"
     },
     {
       "operation": "tests/performance/benchmarks/scratchpad-io.bench.ts > Scratchpad I/O Benchmarks > YAML Operations > readYaml",
-      "p50": 0.07404099999985192,
-      "p95": 0.09366700000009587,
+      "p50": 0.17166999999972177,
+      "p95": 0.2616520000001401,
       "maxMemoryMB": 0,
-      "updatedAt": "2026-08-01T07:41:44.598Z"
+      "updatedAt": "2026-08-01T07:49:33.148Z"
     },
     {
       "operation": "tests/performance/benchmarks/scratchpad-io.bench.ts > Scratchpad I/O Benchmarks > YAML Operations > writeYaml",
-      "p50": 0.21066650000011578,
-      "p95": 0.2704169999997248,
+      "p50": 0.32834500000035405,
+      "p95": 0.6185139999997773,
       "maxMemoryMB": 0,
-      "updatedAt": "2026-08-01T07:41:44.598Z"
+      "updatedAt": "2026-08-01T07:49:33.148Z"
     },
     {
       "operation": "tests/performance/benchmarks/state-persistence.bench.ts > State Persistence Benchmarks > Concurrent Access Simulation > sequential locked writes (10 ops)",
-      "p50": 7.869666999999936,
-      "p95": 20.575833999999304,
+      "p50": 11.474039999999604,
+      "p95": 175.18341300000066,
       "maxMemoryMB": 0,
-      "updatedAt": "2026-08-01T07:41:44.598Z"
+      "updatedAt": "2026-08-01T07:49:33.148Z"
     },
     {
       "operation": "tests/performance/benchmarks/state-persistence.bench.ts > State Persistence Benchmarks > Graph State Persistence > load 100-node graph",
-      "p50": 0.08575000000018917,
-      "p95": 0.11070799999970404,
+      "p50": 0.21076300000004267,
+      "p95": 0.26385000000027503,
       "maxMemoryMB": 0,
-      "updatedAt": "2026-08-01T07:41:44.598Z"
+      "updatedAt": "2026-08-01T07:49:33.148Z"
     },
     {
       "operation": "tests/performance/benchmarks/state-persistence.bench.ts > State Persistence Benchmarks > Graph State Persistence > load 1000-node graph",
-      "p50": 0.2795419999997648,
-      "p95": 0.3612079999998059,
+      "p50": 0.7139614999998685,
+      "p95": 5.600958999999875,
       "maxMemoryMB": 0,
-      "updatedAt": "2026-08-01T07:41:44.598Z"
+      "updatedAt": "2026-08-01T07:49:33.148Z"
     },
     {
       "operation": "tests/performance/benchmarks/state-persistence.bench.ts > State Persistence Benchmarks > Graph State Persistence > load 500-node graph",
-      "p50": 0.17212500000005093,
-      "p95": 0.2053329999998823,
+      "p50": 0.365060000000085,
+      "p95": 0.6438229999998839,
       "maxMemoryMB": 0,
-      "updatedAt": "2026-08-01T07:41:44.598Z"
+      "updatedAt": "2026-08-01T07:49:33.148Z"
     },
     {
       "operation": "tests/performance/benchmarks/state-persistence.bench.ts > State Persistence Benchmarks > Graph State Persistence > save 100-node graph",
-      "p50": 0.21383300000002237,
-      "p95": 0.27308299999998553,
+      "p50": 0.32458449999998606,
+      "p95": 0.5453690000000506,
       "maxMemoryMB": 0,
-      "updatedAt": "2026-08-01T07:41:44.598Z"
+      "updatedAt": "2026-08-01T07:49:33.148Z"
     },
     {
       "operation": "tests/performance/benchmarks/state-persistence.bench.ts > State Persistence Benchmarks > Graph State Persistence > save 1000-node graph",
-      "p50": 0.38149999999996,
-      "p95": 0.49137500000006185,
+      "p50": 0.7680359999999382,
+      "p95": 2.8164409999999407,
       "maxMemoryMB": 0,
-      "updatedAt": "2026-08-01T07:41:44.598Z"
+      "updatedAt": "2026-08-01T07:49:33.148Z"
     },
     {
       "operation": "tests/performance/benchmarks/state-persistence.bench.ts > State Persistence Benchmarks > Graph State Persistence > save 500-node graph",
-      "p50": 0.286707999999976,
-      "p95": 0.40145800000004783,
+      "p50": 0.5126115000000482,
+      "p95": 0.6436170000001766,
       "maxMemoryMB": 0,
-      "updatedAt": "2026-08-01T07:41:44.598Z"
+      "updatedAt": "2026-08-01T07:49:33.148Z"
     },
     {
       "operation": "tests/performance/benchmarks/state-persistence.bench.ts > State Persistence Benchmarks > Incremental Updates > incremental update (read-modify-write)",
-      "p50": 1.450937000000522,
-      "p95": 1.8780409999999392,
+      "p50": 2.9819250000000466,
+      "p95": 60.23926599999959,
       "maxMemoryMB": 0,
-      "updatedAt": "2026-08-01T07:41:44.598Z"
+      "updatedAt": "2026-08-01T07:49:33.148Z"
     },
     {
       "operation": "tests/performance/benchmarks/state-persistence.bench.ts > State Persistence Benchmarks > Save/Load Cycles > 10 consecutive save/load cycles",
-      "p50": 2.604833000000326,
-      "p95": 3.1966670000001614,
+      "p50": 4.8544040000006135,
+      "p95": 6.584953999999925,
       "maxMemoryMB": 0,
-      "updatedAt": "2026-08-01T07:41:44.598Z"
+      "updatedAt": "2026-08-01T07:49:33.148Z"
     },
     {
       "operation": "tests/performance/benchmarks/state-persistence.bench.ts > State Persistence Benchmarks > Save/Load Cycles > complete save/load cycle",
-      "p50": 0.2592500000000655,
-      "p95": 0.32908299999962765,
+      "p50": 0.5457734999999957,
+      "p95": 0.7273430000004737,
       "maxMemoryMB": 0,
-      "updatedAt": "2026-08-01T07:41:44.598Z"
+      "updatedAt": "2026-08-01T07:49:33.148Z"
     }
   ],
-  "updatedAt": "2026-08-01T07:41:44.598Z",
+  "updatedAt": "2026-08-01T07:49:33.148Z",
   "notes": "Generated from Vitest benchmark output on the designated CI runner. p50 uses median; p95 uses Vitest/Tinybench p99 as a conservative upper-tail proxy."
 }

--- a/tests/performance/benchmarks/graph-analysis.bench.ts
+++ b/tests/performance/benchmarks/graph-analysis.bench.ts
@@ -8,21 +8,11 @@
  * - Cycle detection
  */
 
-import { describe, bench, beforeAll } from 'vitest';
+import { describe, bench } from 'vitest';
 import { PriorityAnalyzer } from '../../../src/controller/index.js';
 import { generateIssueGraph } from '../fixtures/graph-generator.js';
-import type { RawDependencyGraph } from '../../../src/controller/types.js';
 
 describe('Graph Analysis Benchmarks', () => {
-  const graphs: Map<number, RawDependencyGraph> = new Map();
-
-  beforeAll(() => {
-    // Pre-generate graphs to avoid generation overhead in benchmarks
-    for (const size of [100, 500, 1000]) {
-      graphs.set(size, generateIssueGraph(size));
-    }
-  });
-
   describe('analyze() - 100 nodes', () => {
     const graph = generateIssueGraph(100);
 
@@ -79,10 +69,7 @@ describe('Graph Analysis Benchmarks', () => {
       const graph = generateIssueGraph(100);
       // Add a cycle by connecting last to first
       const nodes = graph.nodes;
-      const edges = [
-        ...graph.edges,
-        { from: nodes[0]!.id, to: nodes[nodes.length - 1]!.id },
-      ];
+      const edges = [...graph.edges, { from: nodes[0]!.id, to: nodes[nodes.length - 1]!.id }];
       return { nodes, edges };
     })();
 

--- a/tests/performance/benchmarks/scratchpad-io.bench.ts
+++ b/tests/performance/benchmarks/scratchpad-io.bench.ts
@@ -7,160 +7,199 @@
  * - Lock acquisition/release
  */
 
-import { describe, bench, beforeAll, afterAll, beforeEach } from 'vitest';
-import { mkdir, rm } from 'node:fs/promises';
+import { describe, bench, type BenchOptions } from 'vitest';
+import { mkdtemp, rm } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { Scratchpad } from '../../../src/scratchpad/index.js';
+import { getLogger } from '../../../src/logging/index.js';
 
 describe('Scratchpad I/O Benchmarks', () => {
-  let testDir: string;
+  const smallData = { key: 'value', count: 42 };
+  const mediumData = {
+    items: Array.from({ length: 100 }, (_, i) => ({
+      id: i,
+      name: `Item ${i}`,
+      metadata: { created: new Date().toISOString(), tags: ['a', 'b', 'c'] },
+    })),
+  };
+  const largeData = {
+    items: Array.from({ length: 1000 }, (_, i) => ({
+      id: i,
+      name: `Item ${i}`,
+      description: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
+      metadata: {
+        created: new Date().toISOString(),
+        modified: new Date().toISOString(),
+        tags: ['tag1', 'tag2', 'tag3', 'tag4', 'tag5'],
+        properties: { key1: 'value1', key2: 'value2', nested: { deep: true } },
+      },
+    })),
+  };
+  const yamlData = {
+    project: {
+      name: 'Test Project',
+      version: '1.0.0',
+      dependencies: Array.from({ length: 50 }, (_, i) => `dep-${i}`),
+      config: {
+        debug: true,
+        environment: 'development',
+        features: { feature1: true, feature2: false },
+      },
+    },
+  };
+  const readSmallPath = 'read-bench-small.json';
+  const readMediumPath = 'read-bench-medium.json';
+  const readLargePath = 'read-bench-large.json';
+  const yamlPath = 'read-bench.yaml';
+
+  let testDir = '';
   let scratchpad: Scratchpad;
-  let counter: number;
+  let counter = 0;
 
-  beforeAll(async () => {
-    testDir = join(tmpdir(), `scratchpad-bench-${Date.now()}`);
-    await mkdir(testDir, { recursive: true });
-    scratchpad = new Scratchpad({ basePath: testDir });
-    counter = 0;
-  });
-
-  afterAll(async () => {
-    await rm(testDir, { recursive: true, force: true });
-  });
-
-  beforeEach(() => {
-    counter++;
-  });
+  // Vitest's benchmark runner does not execute suite lifecycle hooks. Tinybench
+  // setup/teardown hooks run outside the measured operation for warmup and run.
+  const benchmarkOptions: BenchOptions = {
+    throws: true,
+    setup: async () => {
+      const logger = getLogger();
+      if (!logger.isReady()) await logger.initialize();
+      testDir = await mkdtemp(join(tmpdir(), 'scratchpad-bench-'));
+      scratchpad = new Scratchpad({ basePath: testDir });
+      counter = 0;
+      await Promise.all([
+        scratchpad.writeJson(readSmallPath, smallData),
+        scratchpad.writeJson(readMediumPath, mediumData),
+        scratchpad.writeJson(readLargePath, largeData),
+        scratchpad.writeYaml(yamlPath, yamlData),
+      ]);
+    },
+    teardown: async () => {
+      await rm(testDir, { recursive: true, force: true });
+      testDir = '';
+    },
+  };
 
   describe('JSON Operations', () => {
-    const smallData = { key: 'value', count: 42 };
-    const mediumData = {
-      items: Array.from({ length: 100 }, (_, i) => ({
-        id: i,
-        name: `Item ${i}`,
-        metadata: { created: new Date().toISOString(), tags: ['a', 'b', 'c'] },
-      })),
-    };
-    const largeData = {
-      items: Array.from({ length: 1000 }, (_, i) => ({
-        id: i,
-        name: `Item ${i}`,
-        description: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
-        metadata: {
-          created: new Date().toISOString(),
-          modified: new Date().toISOString(),
-          tags: ['tag1', 'tag2', 'tag3', 'tag4', 'tag5'],
-          properties: { key1: 'value1', key2: 'value2', nested: { deep: true } },
-        },
-      })),
-    };
+    bench(
+      'writeJson - small payload',
+      async () => {
+        await scratchpad.writeJson(`bench-json-small-${counter++}.json`, smallData);
+      },
+      benchmarkOptions
+    );
 
-    bench('writeJson - small payload', async () => {
-      await scratchpad.writeJson(`bench-json-small-${counter++}.json`, smallData);
-    });
+    bench(
+      'writeJson - medium payload (100 items)',
+      async () => {
+        await scratchpad.writeJson(`bench-json-medium-${counter++}.json`, mediumData);
+      },
+      benchmarkOptions
+    );
 
-    bench('writeJson - medium payload (100 items)', async () => {
-      await scratchpad.writeJson(`bench-json-medium-${counter++}.json`, mediumData);
-    });
+    bench(
+      'writeJson - large payload (1000 items)',
+      async () => {
+        await scratchpad.writeJson(`bench-json-large-${counter++}.json`, largeData);
+      },
+      benchmarkOptions
+    );
 
-    bench('writeJson - large payload (1000 items)', async () => {
-      await scratchpad.writeJson(`bench-json-large-${counter++}.json`, largeData);
-    });
+    bench(
+      'readJson - small payload',
+      async () => {
+        await scratchpad.readJson(readSmallPath);
+      },
+      benchmarkOptions
+    );
 
-    // Setup files for read benchmarks
-    let readSmallPath: string;
-    let readMediumPath: string;
-    let readLargePath: string;
+    bench(
+      'readJson - medium payload',
+      async () => {
+        await scratchpad.readJson(readMediumPath);
+      },
+      benchmarkOptions
+    );
 
-    beforeAll(async () => {
-      readSmallPath = 'read-bench-small.json';
-      readMediumPath = 'read-bench-medium.json';
-      readLargePath = 'read-bench-large.json';
-
-      await scratchpad.writeJson(readSmallPath, smallData);
-      await scratchpad.writeJson(readMediumPath, mediumData);
-      await scratchpad.writeJson(readLargePath, largeData);
-    });
-
-    bench('readJson - small payload', async () => {
-      await scratchpad.readJson(readSmallPath);
-    });
-
-    bench('readJson - medium payload', async () => {
-      await scratchpad.readJson(readMediumPath);
-    });
-
-    bench('readJson - large payload', async () => {
-      await scratchpad.readJson(readLargePath);
-    });
+    bench(
+      'readJson - large payload',
+      async () => {
+        await scratchpad.readJson(readLargePath);
+      },
+      benchmarkOptions
+    );
   });
 
   describe('YAML Operations', () => {
-    const yamlData = {
-      project: {
-        name: 'Test Project',
-        version: '1.0.0',
-        dependencies: Array.from({ length: 50 }, (_, i) => `dep-${i}`),
-        config: {
-          debug: true,
-          environment: 'development',
-          features: { feature1: true, feature2: false },
-        },
+    bench(
+      'writeYaml',
+      async () => {
+        await scratchpad.writeYaml(`bench-yaml-${counter++}.yaml`, yamlData);
       },
-    };
+      benchmarkOptions
+    );
 
-    bench('writeYaml', async () => {
-      await scratchpad.writeYaml(`bench-yaml-${counter++}.yaml`, yamlData);
-    });
-
-    let yamlPath: string;
-    beforeAll(async () => {
-      yamlPath = 'read-bench.yaml';
-      await scratchpad.writeYaml(yamlPath, yamlData);
-    });
-
-    bench('readYaml', async () => {
-      await scratchpad.readYaml(yamlPath);
-    });
+    bench(
+      'readYaml',
+      async () => {
+        await scratchpad.readYaml(yamlPath);
+      },
+      benchmarkOptions
+    );
   });
 
   describe('Lock Operations', () => {
-    bench('acquireLock + releaseLock', async () => {
-      const lockPath = `lock-bench-${counter++}`;
-      const lockId = `holder-${counter}`;
+    bench(
+      'acquireLock + releaseLock',
+      async () => {
+        const lockPath = `lock-bench-${counter++}`;
+        const lockId = `holder-${counter}`;
 
-      await scratchpad.acquireLock(lockPath, lockId);
-      await scratchpad.releaseLock(lockPath, lockId);
-    });
+        await scratchpad.acquireLock(lockPath, lockId);
+        await scratchpad.releaseLock(lockPath, lockId);
+      },
+      benchmarkOptions
+    );
 
-    bench('withLock - simple operation', async () => {
-      const path = `withlock-bench-${counter++}.json`;
-      await scratchpad.writeJson(path, { value: 0 });
+    bench(
+      'withLock - simple operation',
+      async () => {
+        const path = `withlock-bench-${counter++}.json`;
+        await scratchpad.writeJson(path, { value: 0 });
 
-      await scratchpad.withLock(path, async () => {
-        const data = (await scratchpad.readJson(path)) as { value: number };
-        data.value++;
-        await scratchpad.writeJson(path, data);
-      });
-    });
+        await scratchpad.withLock(path, async () => {
+          const data = (await scratchpad.readJson(path)) as { value: number };
+          data.value++;
+          await scratchpad.writeJson(path, data);
+        });
+      },
+      benchmarkOptions
+    );
   });
 
   describe('Path Operations', () => {
-    bench('getSectionPath (100 calls)', () => {
-      for (let i = 0; i < 100; i++) {
-        scratchpad.getSectionPath('progress');
-        scratchpad.getSectionPath('state');
-        scratchpad.getSectionPath('documents');
-      }
-    });
+    bench(
+      'getSectionPath (100 calls)',
+      () => {
+        for (let i = 0; i < 100; i++) {
+          scratchpad.getSectionPath('progress');
+          scratchpad.getSectionPath('issues');
+          scratchpad.getSectionPath('documents');
+        }
+      },
+      benchmarkOptions
+    );
 
-    bench('resolve complex paths', () => {
-      for (let i = 0; i < 100; i++) {
-        scratchpad.getSectionPath('progress');
-        scratchpad.getSubsectionPath('progress', 'issues');
-        scratchpad.getDocumentPath('progress', 'state', 'current');
-      }
-    });
+    bench(
+      'resolve complex paths',
+      () => {
+        for (let i = 0; i < 100; i++) {
+          scratchpad.getSectionPath('progress');
+          scratchpad.getProjectPath('progress', 'benchmark-project');
+          scratchpad.getDocumentPath('benchmark-project', 'srs');
+        }
+      },
+      benchmarkOptions
+    );
   });
 });

--- a/tests/performance/benchmarks/state-persistence.bench.ts
+++ b/tests/performance/benchmarks/state-persistence.bench.ts
@@ -4,71 +4,96 @@
  * Benchmarks for state save/load cycles and data persistence operations
  */
 
-import { describe, bench, beforeAll, afterAll } from 'vitest';
-import { mkdir, rm } from 'node:fs/promises';
+import { describe, bench, type BenchOptions } from 'vitest';
+import { mkdtemp, rm } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { Scratchpad } from '../../../src/scratchpad/index.js';
+import { getLogger } from '../../../src/logging/index.js';
 import { generateIssueGraph } from '../fixtures/graph-generator.js';
 
 describe('State Persistence Benchmarks', () => {
-  let testDir: string;
+  const small = generateIssueGraph(100);
+  const medium = generateIssueGraph(500);
+  const large = generateIssueGraph(1000);
+  const small100Path = 'graph-read-100.json';
+  const medium500Path = 'graph-read-500.json';
+  const large1000Path = 'graph-read-1000.json';
+
+  let testDir = '';
   let scratchpad: Scratchpad;
-  let counter: number;
+  let counter = 0;
 
-  beforeAll(async () => {
-    testDir = join(tmpdir(), `state-bench-${Date.now()}`);
-    await mkdir(testDir, { recursive: true });
-    scratchpad = new Scratchpad({ basePath: testDir });
-    counter = 0;
-  });
-
-  afterAll(async () => {
-    await rm(testDir, { recursive: true, force: true });
-  });
+  // Tinybench hooks run outside the measured operation and are honored by
+  // Vitest's benchmark runner, unlike regular suite lifecycle hooks.
+  const benchmarkOptions: BenchOptions = {
+    throws: true,
+    setup: async () => {
+      const logger = getLogger();
+      if (!logger.isReady()) await logger.initialize();
+      testDir = await mkdtemp(join(tmpdir(), 'state-bench-'));
+      scratchpad = new Scratchpad({ basePath: testDir });
+      counter = 0;
+      await Promise.all([
+        scratchpad.writeJson(small100Path, small),
+        scratchpad.writeJson(medium500Path, medium),
+        scratchpad.writeJson(large1000Path, large),
+      ]);
+    },
+    teardown: async () => {
+      await rm(testDir, { recursive: true, force: true });
+      testDir = '';
+    },
+  };
 
   describe('Graph State Persistence', () => {
-    const small = generateIssueGraph(100);
-    const medium = generateIssueGraph(500);
-    const large = generateIssueGraph(1000);
+    bench(
+      'save 100-node graph',
+      async () => {
+        await scratchpad.writeJson(`graph-100-${counter++}.json`, small);
+      },
+      benchmarkOptions
+    );
 
-    bench('save 100-node graph', async () => {
-      await scratchpad.writeJson(`graph-100-${counter++}.json`, small);
-    });
+    bench(
+      'save 500-node graph',
+      async () => {
+        await scratchpad.writeJson(`graph-500-${counter++}.json`, medium);
+      },
+      benchmarkOptions
+    );
 
-    bench('save 500-node graph', async () => {
-      await scratchpad.writeJson(`graph-500-${counter++}.json`, medium);
-    });
+    bench(
+      'save 1000-node graph',
+      async () => {
+        await scratchpad.writeJson(`graph-1000-${counter++}.json`, large);
+      },
+      benchmarkOptions
+    );
 
-    bench('save 1000-node graph', async () => {
-      await scratchpad.writeJson(`graph-1000-${counter++}.json`, large);
-    });
+    bench(
+      'load 100-node graph',
+      async () => {
+        await scratchpad.readJson(small100Path);
+      },
+      benchmarkOptions
+    );
 
-    let small100Path: string;
-    let medium500Path: string;
-    let large1000Path: string;
+    bench(
+      'load 500-node graph',
+      async () => {
+        await scratchpad.readJson(medium500Path);
+      },
+      benchmarkOptions
+    );
 
-    beforeAll(async () => {
-      small100Path = 'graph-read-100.json';
-      medium500Path = 'graph-read-500.json';
-      large1000Path = 'graph-read-1000.json';
-
-      await scratchpad.writeJson(small100Path, small);
-      await scratchpad.writeJson(medium500Path, medium);
-      await scratchpad.writeJson(large1000Path, large);
-    });
-
-    bench('load 100-node graph', async () => {
-      await scratchpad.readJson(small100Path);
-    });
-
-    bench('load 500-node graph', async () => {
-      await scratchpad.readJson(medium500Path);
-    });
-
-    bench('load 1000-node graph', async () => {
-      await scratchpad.readJson(large1000Path);
-    });
+    bench(
+      'load 1000-node graph',
+      async () => {
+        await scratchpad.readJson(large1000Path);
+      },
+      benchmarkOptions
+    );
   });
 
   describe('Save/Load Cycles', () => {
@@ -87,20 +112,28 @@ describe('State Persistence Benchmarks', () => {
       })),
     };
 
-    bench('complete save/load cycle', async () => {
-      const path = `cycle-${counter++}.json`;
-      await scratchpad.writeJson(path, testData);
-      await scratchpad.readJson(path);
-    });
-
-    bench('10 consecutive save/load cycles', async () => {
-      for (let i = 0; i < 10; i++) {
-        const path = `multi-cycle-${counter}-${i}.json`;
+    bench(
+      'complete save/load cycle',
+      async () => {
+        const path = `cycle-${counter++}.json`;
         await scratchpad.writeJson(path, testData);
         await scratchpad.readJson(path);
-      }
-      counter++;
-    });
+      },
+      benchmarkOptions
+    );
+
+    bench(
+      '10 consecutive save/load cycles',
+      async () => {
+        for (let i = 0; i < 10; i++) {
+          const path = `multi-cycle-${counter}-${i}.json`;
+          await scratchpad.writeJson(path, testData);
+          await scratchpad.readJson(path);
+        }
+        counter++;
+      },
+      benchmarkOptions
+    );
   });
 
   describe('Incremental Updates', () => {
@@ -109,33 +142,41 @@ describe('State Persistence Benchmarks', () => {
       items: Array<{ id: number; updated: string }>;
     }
 
-    bench('incremental update (read-modify-write)', async () => {
-      const path = `incremental-${counter++}.json`;
-      const initial: IncrementalState = { counter: 0, items: [] };
-      await scratchpad.writeJson(path, initial);
+    bench(
+      'incremental update (read-modify-write)',
+      async () => {
+        const path = `incremental-${counter++}.json`;
+        const initial: IncrementalState = { counter: 0, items: [] };
+        await scratchpad.writeJson(path, initial);
 
-      // Simulate 5 incremental updates
-      for (let i = 0; i < 5; i++) {
-        const state = (await scratchpad.readJson(path)) as IncrementalState;
-        state.counter++;
-        state.items.push({ id: i, updated: new Date().toISOString() });
-        await scratchpad.writeJson(path, state);
-      }
-    });
+        // Simulate 5 incremental updates
+        for (let i = 0; i < 5; i++) {
+          const state = (await scratchpad.readJson(path)) as IncrementalState;
+          state.counter++;
+          state.items.push({ id: i, updated: new Date().toISOString() });
+          await scratchpad.writeJson(path, state);
+        }
+      },
+      benchmarkOptions
+    );
   });
 
   describe('Concurrent Access Simulation', () => {
-    bench('sequential locked writes (10 ops)', async () => {
-      const path = `locked-${counter++}.json`;
-      await scratchpad.writeJson(path, { value: 0 });
+    bench(
+      'sequential locked writes (10 ops)',
+      async () => {
+        const path = `locked-${counter++}.json`;
+        await scratchpad.writeJson(path, { value: 0 });
 
-      for (let i = 0; i < 10; i++) {
-        await scratchpad.withLock(path, async () => {
-          const data = (await scratchpad.readJson(path)) as { value: number };
-          data.value++;
-          await scratchpad.writeJson(path, data);
-        });
-      }
-    });
+        for (let i = 0; i < 10; i++) {
+          await scratchpad.withLock(path, async () => {
+            const data = (await scratchpad.readJson(path)) as { value: number };
+            data.value++;
+            await scratchpad.writeJson(path, data);
+          });
+        }
+      },
+      benchmarkOptions
+    );
   });
 });

--- a/vitest.bench.config.ts
+++ b/vitest.bench.config.ts
@@ -7,8 +7,9 @@ export default defineConfig({
     include: ['tests/performance/**/*.bench.ts'],
     benchmark: {
       include: ['tests/performance/**/*.bench.ts'],
-      reporters: ['default', 'json'],
-      outputFile: './perf-results/benchmark-results.json',
+      exclude: ['**/._*'],
+      reporters: ['default'],
+      outputJson: './perf-results/benchmark-results.json',
     },
     testTimeout: 60000, // Extended timeout for benchmarks
   },

--- a/vitest.perf.config.ts
+++ b/vitest.perf.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
     globals: true,
     environment: 'node',
     include: ['tests/performance/**/*.test.ts'],
+    exclude: ['**/._*'],
     testTimeout: 120000, // Extended timeout for performance tests
     pool: 'forks', // Use forks for memory isolation
     singleFork: true, // Single fork for consistent memory measurements


### PR DESCRIPTION
## Summary

- emit Vitest's native benchmark JSON and derive stable, fully-qualified operation names
- share strict percentile parsing between baseline regeneration and regression checks
- fail the performance gate on missing/invalid metrics, name coverage gaps, and p50 regressions above 20%
- keep p99-derived tail measurements advisory because shared-runner outliers are not stable enough for a hard gate
- repair async I/O benchmark setup so every registered benchmark produces finite timings
- replace placeholder baselines with 36 real measurements from the pinned `ubuntu-24.04-arm` runner
- add a manual CI baseline-refresh path and document the benchmark-to-baseline mapping

## Validation

- `npm run build`
- `npm run test:perf` (4 files, 26 tests)
- `npm run test:bench` (36 finite benchmark results)
- `npm run perf:update-baseline`
- `npm run perf:check`
- strict TypeScript check for the changed scripts, tests, and benchmark files
- [full Performance Tests workflow](https://github.com/kcenon/claude_code_agent/actions/runs/30690941849)
- required PR checks on Ubuntu and Windows

Closes #895