### PR TITLE
feat(orchestrator): enforce production runtime controls

### DIFF
--- a/.claude/agents/ad-sdlc-orchestrator.md
+++ b/.claude/agents/ad-sdlc-orchestrator.md
@@ -562,24 +562,17 @@ pipeline:
 ### Default Configuration
 
 ```yaml
-# .ad-sdlc/config/orchestrator.yaml (optional)
-orchestration:
-  retry_limits:
-    default: 2
-    timeout: 3
-
-  approval_gates:
-    enabled: true
-    auto_approve: false # Set true for CI/CD mode
-
-  parallelization:
-    enabled: true
-    max_concurrent: 3
-
-  logging:
-    level: info
-    output: scratchpad
+# .ad-sdlc/config/workflow.yaml
+global:
+  vnv:
+    rigor: standard # strict | standard | minimal
+    halt_on_verification_failure: false
 ```
+
+The runtime scheduler verifies every completed stage. Set rigor to `strict` and
+enable `halt_on_verification_failure` to make a failed verification stop the
+remaining DAG. Programmatic callers may also set `maxParallelAgents`; the
+scheduler never starts more than that number of parallel stages.
 
 ## Best Practices
 
@@ -591,6 +584,7 @@ orchestration:
 6. **Provide progress updates** - Keep user informed of current stage
 7. **Generate comprehensive reports** - Summarize execution at completion
 8. **Resume on failure** - Use prior session state to avoid re-executing expensive stages
+9. **Respect verification gates** - Treat strict verifier failures as pipeline failures
 
 ## Related Agents
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ GitHub Issues → Issue Reader → Controller → Worker → Validation → PR R
 | **Quality**       | PR Reviewer           | Creates PRs and performs automated code review                                                      |
 |                   | CI Fixer              | Automatically diagnoses and fixes CI failures                                                       |
 |                   | Regression Tester     | Validates existing functionality after changes                                                      |
-| **V&V**           | Stage Verifier        | Verifies pipeline stage outputs for content completeness and traceability                           |
+| **V&V**           | Stage Verifier        | Verifies every completed stage; strict mode can halt the live scheduler on failure                  |
 |                   | RTM Builder           | Builds Requirements Traceability Matrix from requirements to implementation                         |
 |                   | Validation Agent      | Validates final implementation against requirements and acceptance criteria                         |
 | **Enhancement**   | Document Reader       | Parses existing PRD/SRS/SDS documents                                                               |
@@ -171,7 +171,7 @@ Each agent reads and writes to a shared scratchpad, enabling seamless inter-agen
 - **Progress Tracking**: Real-time visibility into pipeline status
 - **Regression Testing**: Identifies affected tests when modifying existing code
 - **Doc-Code Gap Analysis**: Detects discrepancies between documentation and implementation
-- **V&V Framework**: Final validation is in the live pipeline; Stage Verifier and RTM Builder remain auxiliary until #877 resolves enforce-or-demote
+- **V&V Framework**: Final validation is a live pipeline stage, and the scheduler records per-stage verification results; strict `haltOnVerificationFailure` mode stops the DAG on the first failed gate
 - **Document Audit**: CLI script (`npm run audit:docs`) that validates pipeline-generated PRD/SRS/SDS/SDP/TM/SVP/TD/DBS documents for frontmatter, required sections, cross-references, and PRD→SRS→SDS traceability; see [Document Audit CLI](docs/doc-audit.md)
 - **Customizable Workflows**: Configure agents, templates, and quality gates
 

--- a/docs/adr/ADR-0006-keep-or-kill-orphaned-public-subsystems.md
+++ b/docs/adr/ADR-0006-keep-or-kill-orphaned-public-subsystems.md
@@ -27,9 +27,9 @@ this package. `src/index.ts` re-exports four of these subsystems wholesale via
 
 ```typescript
 export * from './control-plane/index.js'; // line 19
-export * from './data-plane/index.js';    // line 24
-export * from './agents/index.js';        // line 33
-export * from './utilities/index.js';     // line 38
+export * from './data-plane/index.js'; // line 24
+export * from './agents/index.js'; // line 33
+export * from './utilities/index.js'; // line 38
 ```
 
 Deleting any symbol reachable from these barrels is a **SemVer-breaking change**
@@ -65,12 +65,12 @@ CHANGELOG breaking entry.
 
 **Disposition vocabulary** (from #866):
 
-| Disposition | Meaning |
-|---|---|
-| `extract-optional` | Move off the default `.` entry to an optional `exports` subpath (e.g. `ad-sdlc/monitoring`); non-breaking *if* done before/with the `exports` map, breaking if it silently disappears from `.`. Default for `src/index.ts`-reachable orphans. |
-| `keep-wire` | Keep and actively route through the run-loop; not an orphan once wired. |
-| `delete-later` | Eligible for removal, but only via a coordinated SemVer bump + CHANGELOG breaking entry in a dedicated execution issue. |
-| `defer` | No keep-or-kill verdict yet; blocked on a separate decision (e.g. V&V enforce-or-demote, #877). |
+| Disposition        | Meaning                                                                                                                                                                                                                                       |
+| ------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `extract-optional` | Move off the default `.` entry to an optional `exports` subpath (e.g. `ad-sdlc/monitoring`); non-breaking _if_ done before/with the `exports` map, breaking if it silently disappears from `.`. Default for `src/index.ts`-reachable orphans. |
+| `keep-wire`        | Keep and actively route through the run-loop; not an orphan once wired.                                                                                                                                                                       |
+| `delete-later`     | Eligible for removal, but only via a coordinated SemVer bump + CHANGELOG breaking entry in a dedicated execution issue.                                                                                                                       |
+| `defer`            | No keep-or-kill verdict yet; blocked on a separate decision (e.g. V&V enforce-or-demote, #877).                                                                                                                                               |
 
 ### Verdict table
 
@@ -78,17 +78,17 @@ Axis-1 = reachable from the CLI run-loop (`src/cli.ts` -> orchestrator -> stages
 Axis-2 = reachable from the published `src/index.ts` surface (i.e. in
 `dist/index.d.ts`); evidence is `file:line -> symbol`.
 
-| Subsystem | Axis-1: run-loop | Axis-2: public export (verified evidence) | Disposition | SemVer impact | Coupling notes |
-|---|---|---|---|---|---|
-| `monitoring/` (10,872 LOC) | No — no production consumer traces from the run-loop | **Public.** `src/utilities/index.ts:319` `export * as Monitoring from '../monitoring/index.js'`, reached via `src/index.ts:38` | **extract-optional** (default) | minor (add `exports` subpath, non-breaking) now; **major/minor breaking** only if later removed from `.` | Sole reason the optional `@opentelemetry/*` peerDeps exist; extracting keeps that justification intact. |
-| `controller/` (8,820 LOC) | Partial — `worker/` statically imports its **types** | **Public.** `src/control-plane/index.ts:64,67` value re-exports `PriorityAnalyzer` / `ControllerError`; `src/agents/index.ts:725` `export * as Controller`; both reached via `src/index.ts:19,33` | **keep-wire / extract-optional** (conservative; not `delete`) | non-breaking if kept; **breaking** if removed | `worker/types.ts:11` and `worker/workerEntryPoint.ts:11-13` `import type { WorkOrder, WorkerIPCMessage } from '../controller/types.js'` — deleting `controller/` yields TS2307/TS2305 in `worker/`. Hard internal coupling; do not delete. |
-| `ControlPlane` facade (part of 1,672 LOC) | No production consumer | **Public.** `src/control-plane/index.ts:18-24` value exports `ControlPlane`, `getControlPlane`, `ControlPlaneError`; reached via `src/index.ts:19` | **extract-optional** | non-breaking if kept; **breaking** if removed | Zero production consumers but live named exports. Error codes live separately in `errors/codes.ts`, so removing the facade does not orphan them. |
-| `DataPlane` facade (part of 1,672 LOC) | No production consumer | **Public.** `src/data-plane/index.ts:21-28` value exports `DataPlane`, `getDataPlane`, `DataValidationError`; reached via `src/index.ts:24` | **extract-optional** | non-breaking if kept; **breaking** if removed | Same as `ControlPlane`: facade-only, no run-loop consumer, but a published named surface. |
-| SQLite scratchpad backend | Reachable via config — `BackendFactory.create` `case 'sqlite'` (`src/scratchpad/backends/BackendFactory.ts:64`) | **Public.** `src/scratchpad/index.ts:168` `export { SQLiteBackend }`, `:171` `export { BackendFactory }`; reached via `src/index.ts:24` (data-plane re-exports scratchpad) | **keep-wire** | non-breaking | Selectable backend (#873 routed `Scratchpad` through `BackendFactory`). Backed by optional `better-sqlite3` peerDep. Keep. |
-| Redis scratchpad backend | Reachable via config — `BackendFactory.create` `case 'redis'` (`src/scratchpad/backends/BackendFactory.ts:70`) | **Public.** `src/scratchpad/index.ts:169` `export { RedisBackend }`, `:171` `BackendFactory` | **keep-wire** | non-breaking | Same as SQLite. Backed by optional `ioredis` peerDep. Keep. |
-| TS V&V stack (`StageVerifierAgent`, `RtmBuilderAgent`, compliance writers) | No — not referenced outside `stage-verifier/` and `rtm-builder/`; gated by V&V/pipeline config, not the CLI default run-loop | **NOT public via `src/index.ts`.** `src/stage-verifier/index.ts:45` and `src/rtm-builder/index.ts` export only within their own barrels; **no plane barrel re-exports them**, so they are absent from `dist/index.d.ts` | **defer** to #877 (V&V enforce-or-demote) | none from this ADR; deletion would be **non-breaking on the published surface** but is a V&V-policy call | Because they are not on the public surface, the SemVer argument does **not** protect them — unlike the four big orphans. Their fate is a V&V enforce-or-demote decision, not a public-API decision. |
-| `src/utils` vs `src/utilities` dual-root | Both live | `utilities/` is public via `src/index.ts:38`; `utils/` is internal (imported, not re-exported on the public barrel) | **defer / keep** (consolidation, not keep-or-kill) | non-breaking if internal `utils/` is merged carefully | ~18 internal importers of `utils/index`, ~1 of `utilities/index` (verified counts). This is a naming-consolidation question, better handled with the doc/ADR-tree consolidation in #872 than as a keep-or-kill verdict. Defer. |
-| `useSdkForWorker` / `AD_SDLC_USE_SDK_FOR_WORKER` flag | Live in `config/featureFlags.ts:39,53-55`; default `false` | Public (exported from `config`) | **keep** (do not retire yet) | non-breaking | CHANGELOG `[0.1.0]` says all 33 cutover stages route through `ExecutionAdapter` "independent of" this flag (#823-#827, #795). The flag is therefore **inert for the migrated stages** but still a documented config surface; retiring it is a follow-up cleanup, not a keep-or-kill. Keep until a dedicated retire-flag issue. |
+| Subsystem                                                                  | Axis-1: run-loop                                                                                                                                                                                                                             | Axis-2: public export (verified evidence)                                                                                                                                                         | Disposition                                                        | SemVer impact                                                                                            | Coupling notes                                                                                                                                                                                                                                                                                                                 |
+| -------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `monitoring/` (10,872 LOC)                                                 | No — no production consumer traces from the run-loop                                                                                                                                                                                         | **Public.** `src/utilities/index.ts:319` `export * as Monitoring from '../monitoring/index.js'`, reached via `src/index.ts:38`                                                                    | **extract-optional** (default)                                     | minor (add `exports` subpath, non-breaking) now; **major/minor breaking** only if later removed from `.` | Sole reason the optional `@opentelemetry/*` peerDeps exist; extracting keeps that justification intact.                                                                                                                                                                                                                        |
+| `controller/` (8,820 LOC)                                                  | Partial — `worker/` statically imports its **types**                                                                                                                                                                                         | **Public.** `src/control-plane/index.ts:64,67` value re-exports `PriorityAnalyzer` / `ControllerError`; `src/agents/index.ts:725` `export * as Controller`; both reached via `src/index.ts:19,33` | **keep-wire / extract-optional** (conservative; not `delete`)      | non-breaking if kept; **breaking** if removed                                                            | `worker/types.ts:11` and `worker/workerEntryPoint.ts:11-13` `import type { WorkOrder, WorkerIPCMessage } from '../controller/types.js'` — deleting `controller/` yields TS2307/TS2305 in `worker/`. Hard internal coupling; do not delete.                                                                                     |
+| `ControlPlane` facade (part of 1,672 LOC)                                  | No production consumer                                                                                                                                                                                                                       | **Public.** `src/control-plane/index.ts:18-24` value exports `ControlPlane`, `getControlPlane`, `ControlPlaneError`; reached via `src/index.ts:19`                                                | **extract-optional**                                               | non-breaking if kept; **breaking** if removed                                                            | Zero production consumers but live named exports. Error codes live separately in `errors/codes.ts`, so removing the facade does not orphan them.                                                                                                                                                                               |
+| `DataPlane` facade (part of 1,672 LOC)                                     | No production consumer                                                                                                                                                                                                                       | **Public.** `src/data-plane/index.ts:21-28` value exports `DataPlane`, `getDataPlane`, `DataValidationError`; reached via `src/index.ts:24`                                                       | **extract-optional**                                               | non-breaking if kept; **breaking** if removed                                                            | Same as `ControlPlane`: facade-only, no run-loop consumer, but a published named surface.                                                                                                                                                                                                                                      |
+| SQLite scratchpad backend                                                  | Reachable via config — `BackendFactory.create` `case 'sqlite'` (`src/scratchpad/backends/BackendFactory.ts:64`)                                                                                                                              | **Public.** `src/scratchpad/index.ts:168` `export { SQLiteBackend }`, `:171` `export { BackendFactory }`; reached via `src/index.ts:24` (data-plane re-exports scratchpad)                        | **keep-wire**                                                      | non-breaking                                                                                             | Selectable backend (#873 routed `Scratchpad` through `BackendFactory`). Backed by optional `better-sqlite3` peerDep. Keep.                                                                                                                                                                                                     |
+| Redis scratchpad backend                                                   | Reachable via config — `BackendFactory.create` `case 'redis'` (`src/scratchpad/backends/BackendFactory.ts:70`)                                                                                                                               | **Public.** `src/scratchpad/index.ts:169` `export { RedisBackend }`, `:171` `BackendFactory`                                                                                                      | **keep-wire**                                                      | non-breaking                                                                                             | Same as SQLite. Backed by optional `ioredis` peerDep. Keep.                                                                                                                                                                                                                                                                    |
+| TS V&V stack (`StageVerifierAgent`, `RtmBuilderAgent`, compliance writers) | **Partial/live.** #877 wires `StageVerifierAgent` after every completed stage; strict `haltOnVerificationFailure` stops the scheduler. Compliance document slots execute through their SDK definitions; `RtmBuilderAgent` remains auxiliary. | **NOT public via `src/index.ts`.** Module barrels remain absent from `dist/index.d.ts`.                                                                                                           | **keep-wire** the stage verifier; keep RTM as an auxiliary builder | none                                                                                                     | The enforced verifier uses the deterministic TS rules while document-producing agents continue through the single SDK adapter seam.                                                                                                                                                                                            |
+| `src/utils` vs `src/utilities` dual-root                                   | Both live                                                                                                                                                                                                                                    | `utilities/` is public via `src/index.ts:38`; `utils/` is internal (imported, not re-exported on the public barrel)                                                                               | **defer / keep** (consolidation, not keep-or-kill)                 | non-breaking if internal `utils/` is merged carefully                                                    | ~18 internal importers of `utils/index`, ~1 of `utilities/index` (verified counts). This is a naming-consolidation question, better handled with the doc/ADR-tree consolidation in #872 than as a keep-or-kill verdict. Defer.                                                                                                 |
+| `useSdkForWorker` / `AD_SDLC_USE_SDK_FOR_WORKER` flag                      | Live in `config/featureFlags.ts:39,53-55`; default `false`                                                                                                                                                                                   | Public (exported from `config`)                                                                                                                                                                   | **keep** (do not retire yet)                                       | non-breaking                                                                                             | CHANGELOG `[0.1.0]` says all 33 cutover stages route through `ExecutionAdapter` "independent of" this flag (#823-#827, #795). The flag is therefore **inert for the migrated stages** but still a documented config surface; retiring it is a follow-up cleanup, not a keep-or-kill. Keep until a dedicated retire-flag issue. |
 
 ### Version / SemVer reconciliation (executed in this PR)
 
@@ -150,10 +150,12 @@ disposition bumps from:
 delete it.
 
 **Pros:**
+
 - Simple, single-axis rule.
 - Largest immediate LOC reduction.
 
 **Cons:**
+
 - Silently breaks the published `ad-sdlc` library API — `monitoring/`,
   `controller/`, and both facades are reachable from `dist/index.d.ts` via
   `src/index.ts` `export *`.
@@ -170,12 +172,14 @@ deletion assumptions precisely on this point.
 SemVer accordingly in one sweep.
 
 **Pros:**
+
 - Removes ~21k LOC of unconsumed surface.
 - One coordinated breaking release rather than a staged extraction.
 
 **Cons:**
+
 - Pre-1.0 breaking-change tolerance is the owner's call, not the contributor's.
-- A hard delete forecloses the optional-capability path; consumers who *do* want
+- A hard delete forecloses the optional-capability path; consumers who _do_ want
   monitoring or alternate backends lose them entirely instead of moving to a
   subpath.
 - Higher blast radius with no rollback granularity.
@@ -191,9 +195,11 @@ surface, which is the conservative default in #866. Deletion remains available a
 dispositions.
 
 **Pros:**
+
 - Zero risk now.
 
 **Cons:**
+
 - Leaves the speculative infrastructure built ahead of its consumers in place
   indefinitely, with no path to either wire or remove it.
 - Does not resolve the `0.0.1` / `0.1.0` version disagreement.

--- a/docs/architecture/dual-layer-design.md
+++ b/docs/architecture/dual-layer-design.md
@@ -104,11 +104,16 @@ the same `ExecutionAdapter` request/result contract.
 ## Verification and validation boundary
 
 The `validation-agent` is a real pipeline stage in all three modes. The
-TypeScript `StageVerifierAgent` and `RtmBuilderAgent` modules and their prompt
-definitions also exist, but they are not currently invoked as blocking stages
-by the orchestrator. Their enforce-or-demote decision is tracked by issue #877.
-Documentation must not describe those auxiliary modules as enforced runtime
-gates until the run loop proves that behavior.
+TypeScript `StageVerifierAgent` is also wired into the scheduler after every
+completed stage. Its result is retained on `PipelineResult.verificationResults`;
+with `vnv.rigor: strict` and `vnv.haltOnVerificationFailure: true`, a failed
+verification marks the stage failed, cancels further scheduling, and makes the
+pipeline fail. In standard and minimal modes, failed checks remain advisory.
+
+`RtmBuilderAgent` remains an auxiliary traceability builder rather than a
+blocking scheduler component. The document-producing SDP/SVP/threat-model/
+technology-decision slots execute through their checked-in SDK agent
+definitions, like every other live pipeline stage.
 
 ## Extension guide
 

--- a/docs/reference/agents/ad-sdlc-orchestrator.md
+++ b/docs/reference/agents/ad-sdlc-orchestrator.md
@@ -446,23 +446,29 @@ None - This is the top-level orchestration agent.
 ### Optional Configuration File
 
 ```yaml
-# .ad-sdlc/config/orchestrator.yaml
-orchestration:
-  retry_limits:
-    default: 2
-    timeout: 3
+# .ad-sdlc/config/workflow.yaml
+global:
+  vnv:
+    rigor: strict
+    halt_on_verification_failure: true
+```
 
-  approval_gates:
-    enabled: true
-    auto_approve: false # Set true for CI/CD mode
+The CLI maps these workflow V&V gate fields into the live orchestrator. A
+failed per-stage verification is advisory by default. It becomes a blocking
+gate only when rigor is `strict` and `halt_on_verification_failure` is `true`.
 
-  parallelization:
-    enabled: true
-    max_concurrent: 3
+Programmatic callers can additionally cap concurrent DAG stages. The same
+execution adapter is reused for every stage in one pipeline and disposed once
+when that pipeline finishes.
 
-  logging:
-    level: info
-    output: scratchpad
+```typescript
+const orchestrator = new AdsdlcOrchestratorAgent({
+  maxParallelAgents: 3,
+  vnv: {
+    rigor: 'strict',
+    haltOnVerificationFailure: true,
+  },
+});
 ```
 
 ## CLI Usage

--- a/docs/system-architecture.kr.md
+++ b/docs/system-architecture.kr.md
@@ -494,20 +494,21 @@ sequenceDiagram
 
 ## 8. Verification & Validation (V&V) Pipeline
 
-현재 V&V 경로는 최종 구현을 검증합니다. 추가 verifier 및 추적성 모듈도
-존재하지만 현재 run loop에서 강제되지는 않습니다.
+현재 V&V 경로는 최종 구현 검증과 stage별 scheduler gate를 결합합니다.
+검증 결과는 pipeline result에 포함됩니다.
 
 ### Stage Verifier
 
-Stage Verifier 모듈은 파이프라인 출력의 완전성과 추적성을 검사할 수 있지만,
-현재 라이브 오케스트레이터에서 차단 stage로 호출되지는 않습니다.
-enforce-or-demote 결정은 #877에서 추적합니다.
+Scheduler는 완료 또는 degraded 상태의 각 stage 뒤에 `StageVerifierAgent`를
+호출합니다. standard/minimal rigor에서는 실패한 check를 advisory warning으로
+유지합니다. strict rigor에서 `haltOnVerificationFailure`를 활성화하면 실패한
+check가 해당 stage를 실패 처리하고 미실행 stage를 건너뛰며 pipeline을 실패시킵니다.
 
 ### RTM Builder
 
 RTM (Requirements Traceability Matrix) Builder는 PRD, SRS, SDS, 이슈,
-구현을 연결하는 추적성 매트릭스를 생성할 수 있습니다. Stage Verifier와
-마찬가지로 현재는 강제 run-loop stage가 아닌 보조 모듈/정의입니다(#877).
+구현을 연결하는 추적성 매트릭스를 생성할 수 있습니다. RTM Builder는 여전히
+강제 run-loop component가 아닌 보조 추적성 builder입니다.
 
 ### Validation Agent
 

--- a/docs/system-architecture.md
+++ b/docs/system-architecture.md
@@ -494,21 +494,21 @@ sequenceDiagram
 
 ## 8. Verification & Validation (V&V) Pipeline
 
-The live V&V path validates the final implementation. Additional verifier and
-traceability modules exist but are not currently enforced by the run loop.
+The live V&V path combines final implementation validation with a per-stage
+scheduler gate. Verification outcomes are included in the pipeline result.
 
 ### Stage Verifier
 
-The Stage Verifier module can check pipeline outputs for completeness and
-traceability, but it is not currently invoked as a blocking stage by the live
-orchestrator. Enforce-or-demote is tracked in #877.
+The scheduler invokes `StageVerifierAgent` after every completed or degraded
+stage. Standard and minimal rigor retain failed checks as advisory warnings.
+With strict rigor and `haltOnVerificationFailure` enabled, a failed check marks
+the stage failed, skips all unprocessed stages, and fails the pipeline.
 
 ### RTM Builder
 
 The RTM (Requirements Traceability Matrix) Builder can create a traceability
-matrix linking PRD, SRS, SDS, issues, and implementation. Like Stage Verifier,
-it currently remains an auxiliary module/definition rather than an enforced
-run-loop stage (#877).
+matrix linking PRD, SRS, SDS, issues, and implementation. It remains an
+auxiliary traceability builder rather than a blocking run-loop component.
 
 ### Validation Agent
 

--- a/examples/config/workflow.yaml
+++ b/examples/config/workflow.yaml
@@ -63,6 +63,12 @@ global:
     implementation: 1800 # Code implementation (min: 300)
     pr_review: 300 # PR review phase (min: 60)
 
+  # Per-stage verification. Strict + halt=true turns failed checks into a
+  # blocking scheduler gate; other modes retain failures as advisories.
+  vnv:
+    rigor: 'standard' # strict | standard | minimal
+    halt_on_verification_failure: false
+
 # -----------------------------------------------------------------------------
 # Pipeline Configuration
 # -----------------------------------------------------------------------------

--- a/schemas/workflow.schema.json
+++ b/schemas/workflow.schema.json
@@ -146,6 +146,23 @@
             "implementation": { "type": "integer", "minimum": 300, "default": 1800 },
             "pr_review": { "type": "integer", "minimum": 60, "default": 300 }
           }
+        },
+        "vnv": {
+          "type": "object",
+          "description": "Per-stage verification and validation policy",
+          "properties": {
+            "rigor": {
+              "type": "string",
+              "enum": ["strict", "standard", "minimal"],
+              "default": "standard"
+            },
+            "halt_on_verification_failure": { "type": "boolean", "default": false },
+            "generate_vnv_plan": { "type": "boolean", "default": true },
+            "generate_vnv_report": { "type": "boolean", "default": true },
+            "generate_rtm": { "type": "boolean", "default": true },
+            "cross_document_consistency": { "type": "boolean", "default": true },
+            "acceptance_criteria_validation": { "type": "boolean", "default": true }
+          }
         }
       }
     },

--- a/src/ad-sdlc-orchestrator/AdsdlcOrchestratorAgent.ts
+++ b/src/ad-sdlc-orchestrator/AdsdlcOrchestratorAgent.ts
@@ -25,6 +25,8 @@ import {
 import { SdkExecutionAdapter } from '../execution/index.js';
 import { getLogger } from '../logging/index.js';
 import { ENV_USE_SDK_FOR_WORKER } from '../config/featureFlags.js';
+import { StageVerifierAgent } from '../stage-verifier/StageVerifierAgent.js';
+import type { StageVerificationResult } from '../stage-verifier/types.js';
 import { PipelineCheckpointManager } from './PipelineCheckpointManager.js';
 import type {
   ApprovalDecision,
@@ -38,6 +40,7 @@ import type {
   PipelineStageDefinition,
   PipelineStageStatus,
   PipelineStatus,
+  ResolvedOrchestratorConfig,
   StageName,
   StageResult,
   StageSummary,
@@ -93,11 +96,15 @@ export class AdsdlcOrchestratorAgent implements IAgent {
   readonly agentId = ADSDLC_ORCHESTRATOR_AGENT_ID;
   readonly name = 'AD-SDLC Pipeline Orchestrator';
 
-  private config: Required<OrchestratorConfig>;
+  private config: ResolvedOrchestratorConfig;
   private session: OrchestratorSession | null = null;
   private initialized = false;
   private stageTimers = new Map<StageName, ReturnType<typeof setTimeout>>();
   private abortController: AbortController | null = null;
+  private executionAdapter: ExecutionAdapter | null = null;
+  private stageVerifier: StageVerifierAgent | null = null;
+  private stageVerifierInitialized = false;
+  private verificationResults: StageVerificationResult[] = [];
   private readonly checkpointManager: PipelineCheckpointManager | null;
   /**
    * One-shot SDK session id used to resume the FIRST stage of a session
@@ -107,12 +114,22 @@ export class AdsdlcOrchestratorAgent implements IAgent {
   private pendingResumeSdkSessionId: string | undefined = undefined;
 
   constructor(config: OrchestratorConfig = {}) {
+    const requestedParallelism =
+      config.maxParallelAgents ?? DEFAULT_ORCHESTRATOR_CONFIG.maxParallelAgents;
+    const maxParallelAgents = Number.isFinite(requestedParallelism)
+      ? Math.max(1, Math.floor(requestedParallelism))
+      : DEFAULT_ORCHESTRATOR_CONFIG.maxParallelAgents;
     this.config = {
       ...DEFAULT_ORCHESTRATOR_CONFIG,
       ...config,
       timeouts: {
         ...DEFAULT_ORCHESTRATOR_CONFIG.timeouts,
         ...config.timeouts,
+      },
+      maxParallelAgents,
+      vnv: {
+        ...DEFAULT_ORCHESTRATOR_CONFIG.vnv,
+        ...config.vnv,
       },
     };
     const ckptConfig: CheckpointConfig = this.config.checkpoint;
@@ -179,7 +196,7 @@ export class AdsdlcOrchestratorAgent implements IAgent {
    * Dispose of the orchestrator and release resources
    * @returns A promise that resolves when all resources are released
    */
-  dispose(): Promise<void> {
+  async dispose(): Promise<void> {
     for (const timer of this.stageTimers.values()) {
       clearTimeout(timer);
     }
@@ -188,9 +205,15 @@ export class AdsdlcOrchestratorAgent implements IAgent {
       this.abortController.abort();
       this.abortController = null;
     }
+    await this.disposeExecutionAdapter();
+    if (this.stageVerifier !== null && this.stageVerifierInitialized) {
+      await this.stageVerifier.dispose();
+    }
+    this.stageVerifier = null;
+    this.stageVerifierInitialized = false;
+    this.verificationResults = [];
     this.session = null;
     this.initialized = false;
-    return Promise.resolve();
   }
 
   /**
@@ -329,6 +352,7 @@ export class AdsdlcOrchestratorAgent implements IAgent {
 
     const startTime = Date.now();
     this.session = { ...session, status: 'running' };
+    this.verificationResults = [];
 
     try {
       const stages = this.getStagesForMode(session.mode);
@@ -362,7 +386,13 @@ export class AdsdlcOrchestratorAgent implements IAgent {
       // Merge prior + new results
       const stageResults = [...priorResults, ...newResults];
       const failedStages = stageResults.filter((s) => s.status === 'failed');
-      const overallStatus = this.determineOverallStatus(stageResults);
+      const verificationGateFailed =
+        this.config.vnv.rigor === 'strict' &&
+        this.config.vnv.haltOnVerificationFailure &&
+        this.verificationResults.some((verification) => !verification.passed);
+      const overallStatus = verificationGateFailed
+        ? 'failed'
+        : this.determineOverallStatus(stageResults);
 
       // Add warnings for partial completion (graceful degradation)
       const warnings: string[] = [];
@@ -382,6 +412,9 @@ export class AdsdlcOrchestratorAgent implements IAgent {
         durationMs: Date.now() - startTime,
         artifacts: stageResults.flatMap((s) => s.artifacts),
         warnings,
+        ...(this.verificationResults.length > 0
+          ? { verificationResults: [...this.verificationResults] }
+          : {}),
       };
 
       this.session = { ...this.session, status: overallStatus, stageResults };
@@ -415,6 +448,8 @@ export class AdsdlcOrchestratorAgent implements IAgent {
       }
       this.session = { ...this.session, status: 'failed' };
       throw error;
+    } finally {
+      await this.disposeExecutionAdapter();
     }
   }
 
@@ -571,10 +606,14 @@ export class AdsdlcOrchestratorAgent implements IAgent {
       abortController: this.abortController,
       stageTimers: this.stageTimers,
       maxRetries: this.config.maxRetries,
+      maxParallelAgents: this.config.maxParallelAgents,
+      haltOnVerificationFailure:
+        this.config.vnv.rigor === 'strict' && this.config.vnv.haltOnVerificationFailure,
       checkpointManager: this.checkpointManager,
       getTimeoutForStage: (name) => this.getTimeoutForStage(name),
       createArtifactValidator: (projectDir) => this.createArtifactValidator(projectDir),
-      invokeAgent: (stage, session) => this.invokeAgent(stage, session),
+      invokeAgent: (stage, session, signal) => this.invokeAgent(stage, session, signal),
+      verifyStage: (stage, result, session) => this.verifyStage(stage, result, session),
       checkApprovalGate: (stage, prior) => this.checkApprovalGate(stage, prior),
       sleep: (ms) => this.sleep(ms),
     };
@@ -588,12 +627,14 @@ export class AdsdlcOrchestratorAgent implements IAgent {
    * execution.
    * @param stage
    * @param session
+   * @param signal
    */
   protected async invokeAgent(
     stage: PipelineStageDefinition,
-    session: OrchestratorSession
+    session: OrchestratorSession,
+    signal?: AbortSignal
   ): Promise<string> {
-    return this.executeViaAdapter(stage, session);
+    return this.executeViaAdapter(stage, session, signal);
   }
 
   /**
@@ -604,25 +645,18 @@ export class AdsdlcOrchestratorAgent implements IAgent {
    *
    * @param stage
    * @param session
+   * @param signal
    * @throws Error when the adapter reports a non-success status.
    */
   protected async executeViaAdapter(
     stage: PipelineStageDefinition,
-    session: OrchestratorSession
+    session: OrchestratorSession,
+    signal?: AbortSignal
   ): Promise<string> {
-    const adapter = this.createExecutionAdapter(session);
-    try {
-      const request = this.buildStageExecutionRequest(stage, session);
-      const result = await adapter.execute(request);
-      return this.toStageOutput(stage, result);
-    } finally {
-      await adapter.dispose().catch((error: unknown) => {
-        getLogger().debug('ExecutionAdapter dispose failed', {
-          agent: 'AdsdlcOrchestratorAgent',
-          error: error instanceof Error ? error.message : String(error),
-        });
-      });
-    }
+    this.executionAdapter ??= this.createExecutionAdapter(session);
+    const request = this.buildStageExecutionRequest(stage, session, signal);
+    const result = await this.executionAdapter.execute(request);
+    return this.toStageOutput(stage, result);
   }
 
   /**
@@ -649,20 +683,93 @@ export class AdsdlcOrchestratorAgent implements IAgent {
   }
 
   /**
+   * Dispose the pipeline-scoped adapter without allowing cleanup failures to
+   * replace the pipeline's real outcome.
+   */
+  private async disposeExecutionAdapter(): Promise<void> {
+    const adapter = this.executionAdapter;
+    this.executionAdapter = null;
+    if (adapter === null) return;
+
+    try {
+      await adapter.dispose();
+    } catch (error: unknown) {
+      getLogger().debug('ExecutionAdapter dispose failed', {
+        agent: 'AdsdlcOrchestratorAgent',
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  /** Create the verifier used by the live scheduler. Tests may override it. */
+  protected createStageVerifier(): StageVerifierAgent {
+    return new StageVerifierAgent();
+  }
+
+  /**
+   * Verify one completed stage and retain the outcome for the final pipeline
+   * result. Unexpected verifier errors are converted into failed verification
+   * records so strict mode cannot fail open.
+   * @param stage
+   * @param result
+   * @param session
+   */
+  protected async verifyStage(
+    stage: PipelineStageDefinition,
+    result: StageResult,
+    session: OrchestratorSession
+  ): Promise<StageVerificationResult> {
+    const startedAt = Date.now();
+    let verification: StageVerificationResult;
+
+    try {
+      this.stageVerifier ??= this.createStageVerifier();
+      if (!this.stageVerifierInitialized) {
+        await this.stageVerifier.initialize();
+        this.stageVerifierInitialized = true;
+      }
+      verification = await this.stageVerifier.verifyStage(stage.name, result, {
+        projectDir: session.projectDir,
+        projectId: path.basename(session.projectDir),
+        pipelineMode: session.mode,
+        rigor: this.config.vnv.rigor,
+        pipelineId: session.sessionId,
+      });
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : String(error);
+      verification = {
+        stageName: stage.name,
+        passed: false,
+        rigor: this.config.vnv.rigor,
+        checks: [],
+        warnings: [],
+        errors: [`Stage verifier failed: ${message}`],
+        timestamp: new Date().toISOString(),
+        durationMs: Date.now() - startedAt,
+      };
+    }
+
+    this.verificationResults.push(verification);
+    return verification;
+  }
+
+  /**
    * Translate orchestrator state into a {@link StageExecutionRequest}.
    * Maps `session.userRequest` to `workOrder` and accumulated completed
    * stage outputs to `priorOutputs`. The system prompt is sourced by
    * the SDK from `.claude/agents/<agentType>.md`.
    * @param stage
    * @param session
+   * @param signal
    */
   protected buildStageExecutionRequest(
     stage: PipelineStageDefinition,
-    session: OrchestratorSession
+    session: OrchestratorSession,
+    signal?: AbortSignal
   ): StageExecutionRequest {
     const priorOutputs: Record<string, string> = {};
     for (const result of session.stageResults) {
-      if (result.status === 'completed' && result.output) {
+      if ((result.status === 'completed' || result.status === 'degraded') && result.output) {
         priorOutputs[result.name] = result.output;
       }
     }
@@ -691,7 +798,11 @@ export class AdsdlcOrchestratorAgent implements IAgent {
       ...(stage.maxTurns !== undefined ? { maxTurns: stage.maxTurns } : {}),
       ...(stage.permissionMode !== undefined ? { permissionMode: stage.permissionMode } : {}),
       ...(resumeId !== undefined ? { resume: resumeId } : {}),
-      ...(this.abortController !== null ? { signal: this.abortController.signal } : {}),
+      ...(signal !== undefined
+        ? { signal }
+        : this.abortController !== null
+          ? { signal: this.abortController.signal }
+          : {}),
     };
     return request;
   }
@@ -857,6 +968,7 @@ export class AdsdlcOrchestratorAgent implements IAgent {
         completedStages: result.stages.filter((s) => s.status === 'completed').length,
         failedStages: result.stages.filter((s) => s.status === 'failed').length,
         artifacts: result.artifacts,
+        verificationResults: result.verificationResults ?? [],
         stages: result.stages.map((s) => ({
           name: s.name,
           agentType: s.agentType,

--- a/src/ad-sdlc-orchestrator/StageScheduler.ts
+++ b/src/ad-sdlc-orchestrator/StageScheduler.ts
@@ -2,7 +2,7 @@
  * Stage scheduling logic for the AD-SDLC orchestrator.
  *
  * Hosts the dependency-aware DAG executor (`runStages`), the
- * `Promise.allSettled`-backed parallel-group runner, and the
+ * bounded-concurrency parallel-group runner, and the
  * timeout/retry wrapper around a single stage's agent invocation.
  * Extracted from `AdsdlcOrchestratorAgent` in issue #799 to keep the
  * orchestrator file at or below the 950 LoC budget.
@@ -15,6 +15,7 @@
 
 import { getLogger } from '../logging/index.js';
 import { RetryExecutor } from '../error-handler/RetryExecutor.js';
+import type { StageVerificationResult } from '../stage-verifier/types.js';
 import { StageTimeoutError } from './errors.js';
 import type { ArtifactValidator } from './ArtifactValidator.js';
 import type { PipelineCheckpointManager } from './PipelineCheckpointManager.js';
@@ -43,10 +44,21 @@ export interface SchedulerHost {
   readonly abortController: AbortController | null;
   readonly stageTimers: Map<StageName, ReturnType<typeof setTimeout>>;
   readonly maxRetries: number;
+  readonly maxParallelAgents: number;
+  readonly haltOnVerificationFailure: boolean;
   readonly checkpointManager: PipelineCheckpointManager | null;
   getTimeoutForStage(name: StageName): number;
   createArtifactValidator(projectDir: string): ArtifactValidator;
-  invokeAgent(stage: PipelineStageDefinition, session: OrchestratorSession): Promise<string>;
+  invokeAgent(
+    stage: PipelineStageDefinition,
+    session: OrchestratorSession,
+    signal: AbortSignal
+  ): Promise<string>;
+  verifyStage(
+    stage: PipelineStageDefinition,
+    result: StageResult,
+    session: OrchestratorSession
+  ): Promise<StageVerificationResult>;
   checkApprovalGate(
     stage: PipelineStageDefinition,
     priorResults: readonly StageResult[]
@@ -183,25 +195,70 @@ function runStageAgentWithTimeout(
   timeoutMs: number
 ): Promise<string> {
   return new Promise<string>((resolve, reject) => {
+    const attemptController = new AbortController();
+    const pipelineSignal = host.abortController?.signal;
+    let settled = false;
+
+    const cleanup = (): void => {
+      clearTimeout(timer);
+      host.stageTimers.delete(stage.name);
+      pipelineSignal?.removeEventListener('abort', abortFromPipeline);
+    };
+    const settle = (operation: () => void): void => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      operation();
+    };
+    const abortFromPipeline = (): void => {
+      attemptController.abort(pipelineSignal?.reason);
+    };
     const timer = setTimeout(() => {
-      reject(new StageTimeoutError(stage.name, timeoutMs));
+      const error = new StageTimeoutError(stage.name, timeoutMs);
+      attemptController.abort(error);
+      settle(() => {
+        reject(error);
+      });
     }, timeoutMs);
 
     host.stageTimers.set(stage.name, timer);
+    if (pipelineSignal?.aborted === true) {
+      abortFromPipeline();
+    } else {
+      pipelineSignal?.addEventListener('abort', abortFromPipeline, { once: true });
+    }
 
     host
-      .invokeAgent(stage, session)
+      .invokeAgent(stage, session, attemptController.signal)
       .then((output) => {
-        clearTimeout(timer);
-        host.stageTimers.delete(stage.name);
-        resolve(output);
+        settle(() => {
+          resolve(output);
+        });
       })
       .catch((error: unknown) => {
-        clearTimeout(timer);
-        host.stageTimers.delete(stage.name);
-        reject(error instanceof Error ? error : new Error(String(error)));
+        settle(() => {
+          reject(error instanceof Error ? error : new Error(String(error)));
+        });
       });
   });
+}
+
+/**
+ * Extract artifact paths from the adapter's JSON stage summary.
+ * @param output
+ */
+function extractArtifactPaths(output: string): string[] {
+  try {
+    const parsed = JSON.parse(output) as { artifacts?: unknown };
+    if (!Array.isArray(parsed.artifacts)) return [];
+    return parsed.artifacts.flatMap((artifact) => {
+      if (typeof artifact !== 'object' || artifact === null || !('path' in artifact)) return [];
+      const artifactPath = (artifact as { path?: unknown }).path;
+      return typeof artifactPath === 'string' && artifactPath !== '' ? [artifactPath] : [];
+    });
+  } catch {
+    return [];
+  }
 }
 
 /**
@@ -265,7 +322,7 @@ export async function executeStageWithRetry(
       status: 'completed',
       durationMs: Date.now() - attemptStartTime,
       output: execution.value,
-      artifacts: [],
+      artifacts: extractArtifactPaths(execution.value),
       error: null,
       retryCount: Math.max(0, attempt - 1),
     };
@@ -284,9 +341,9 @@ export async function executeStageWithRetry(
 }
 
 /**
- * Execute multiple stages concurrently via `Promise.allSettled`. A
- * single stage failing does not abort siblings — the failure is
- * surfaced as a `failed` `StageResult` instead of a rejection.
+ * Execute multiple stages with a bounded worker pool. A single stage failing
+ * does not abort siblings — the failure is surfaced as a `failed`
+ * `StageResult` instead of a rejection.
  * @param host
  * @param stages
  * @param session
@@ -296,26 +353,35 @@ async function executeParallelStages(
   stages: readonly PipelineStageDefinition[],
   session: OrchestratorSession
 ): Promise<StageResult[]> {
-  const promises = stages.map((stage) => executeStageWithRetry(host, stage, session));
-  const settled = await Promise.allSettled(promises);
+  const results = new Array<StageResult>(stages.length);
+  const concurrency = Math.min(stages.length, Math.max(1, host.maxParallelAgents));
+  let nextIndex = 0;
 
-  return settled.map((outcome, index) => {
-    if (outcome.status === 'fulfilled') {
-      return outcome.value;
+  const worker = async (): Promise<void> => {
+    while (nextIndex < stages.length) {
+      const index = nextIndex++;
+      const stage = stages[index];
+      if (stage === undefined) return;
+
+      try {
+        results[index] = await executeStageWithRetry(host, stage, session);
+      } catch (error: unknown) {
+        results[index] = {
+          name: stage.name,
+          agentType: stage.agentType,
+          status: 'failed',
+          durationMs: 0,
+          output: '',
+          artifacts: [],
+          error: error instanceof Error ? error.message : String(error),
+          retryCount: 0,
+        };
+      }
     }
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- index is guaranteed valid
-    const stage = stages[index]!;
-    return {
-      name: stage.name,
-      agentType: stage.agentType,
-      status: 'failed' as const,
-      durationMs: 0,
-      output: '',
-      artifacts: [],
-      error: outcome.reason instanceof Error ? outcome.reason.message : String(outcome.reason),
-      retryCount: 0,
-    };
-  });
+  };
+
+  await Promise.all(Array.from({ length: concurrency }, worker));
+  return results;
 }
 
 /**
@@ -360,6 +426,100 @@ async function applyContentValidation(
       error: err instanceof Error ? err.message : String(err),
     });
     return result;
+  }
+}
+
+/**
+ * Apply content validation followed by the live V&V gate. In non-blocking
+ * modes a failed verification is retained as a warning; strict mode with
+ * `haltOnVerificationFailure` converts the stage into a hard failure.
+ * @param host
+ * @param stage
+ * @param session
+ * @param result
+ */
+async function finalizeStageResult(
+  host: SchedulerHost,
+  stage: PipelineStageDefinition,
+  session: OrchestratorSession,
+  result: StageResult
+): Promise<{ result: StageResult; halt: boolean }> {
+  const contentValidated = await applyContentValidation(host, stage, session, result);
+  if (contentValidated.status !== 'completed' && contentValidated.status !== 'degraded') {
+    return { result: contentValidated, halt: false };
+  }
+
+  const verification = await host.verifyStage(stage, contentValidated, session);
+  if (verification.passed) {
+    return { result: contentValidated, halt: false };
+  }
+
+  const details =
+    verification.errors.length > 0
+      ? verification.errors
+      : [`Stage '${stage.name}' did not pass verification`];
+  if (host.haltOnVerificationFailure) {
+    return {
+      result: {
+        ...contentValidated,
+        status: 'failed',
+        error: `Verification failed: ${details.join('; ')}`,
+        warnings: [...(contentValidated.warnings ?? []), ...verification.warnings],
+      },
+      halt: true,
+    };
+  }
+
+  return {
+    result: {
+      ...contentValidated,
+      warnings: [
+        ...(contentValidated.warnings ?? []),
+        ...details.map((message) => `Verification advisory: ${message}`),
+      ],
+    },
+    halt: false,
+  };
+}
+
+/**
+ * Return a session snapshot containing every result available to this stage.
+ * @param session
+ * @param results
+ */
+function withStageResults(
+  session: OrchestratorSession,
+  results: readonly StageResult[]
+): OrchestratorSession {
+  return {
+    ...session,
+    stageResults: [...session.stageResults, ...results],
+  };
+}
+
+/**
+ * Append skipped results for every stage not already processed.
+ * @param stages
+ * @param results
+ * @param completedStages
+ * @param reason
+ */
+function skipUnprocessedStages(
+  stages: readonly PipelineStageDefinition[],
+  results: StageResult[],
+  completedStages: ReadonlySet<StageName>,
+  reason: string
+): void {
+  const processed = new Set<StageName>([
+    ...completedStages,
+    ...results.map((result) => result.name),
+  ]);
+  for (const stage of stages) {
+    if (processed.has(stage.name)) continue;
+    results.push({
+      ...createSkippedResult(stage),
+      error: reason,
+    });
   }
 }
 
@@ -420,36 +580,46 @@ export async function runStages(
     const sequentialGroup = ready.filter((s) => !s.parallel);
 
     if (parallelGroup.length > 1) {
-      const parallelResults = await executeParallelStages(host, parallelGroup, session);
-      for (const result of parallelResults) {
-        results.push(result);
-        if (result.status === 'completed') {
-          completedStages.add(result.name);
+      const executionSession = withStageResults(session, results);
+      const parallelResults = await executeParallelStages(host, parallelGroup, executionSession);
+      let verificationHaltStage: StageName | null = null;
+      for (let index = 0; index < parallelResults.length; index++) {
+        const stage = parallelGroup[index];
+        const rawResult = parallelResults[index];
+        if (stage === undefined || rawResult === undefined) continue;
+
+        const finalized = await finalizeStageResult(host, stage, executionSession, rawResult);
+        results.push(finalized.result);
+        if (finalized.result.status === 'completed' || finalized.result.status === 'degraded') {
+          completedStages.add(finalized.result.name);
+        }
+        if (finalized.halt && verificationHaltStage === null) {
+          verificationHaltStage = stage.name;
         }
       }
       await saveCheckpoint(host, session, results, [...completedStages]);
+
+      if (verificationHaltStage !== null) {
+        skipUnprocessedStages(
+          stages,
+          results,
+          completedStages,
+          `Skipped: verification gate failed after '${verificationHaltStage}'`
+        );
+        return results;
+      }
 
       // Stop the pipeline if stopAfterStage was in the parallel group
       if (
         session.stopAfterStage !== undefined &&
         parallelGroup.some((s) => s.name === session.stopAfterStage)
       ) {
-        const processedSoFar = new Set(results.map((r) => r.name));
-        const toSkip = [...remaining, ...sequentialGroup].filter(
-          (s) => !processedSoFar.has(s.name)
+        skipUnprocessedStages(
+          stages,
+          results,
+          completedStages,
+          `Skipped: pipeline halted after '${session.stopAfterStage}'`
         );
-        for (const skipped of toSkip) {
-          results.push({
-            name: skipped.name,
-            agentType: skipped.agentType,
-            status: 'skipped',
-            durationMs: 0,
-            output: '',
-            artifacts: [],
-            error: `Skipped: pipeline halted after '${session.stopAfterStage}'`,
-            retryCount: 0,
-          });
-        }
         return results;
       }
     } else if (parallelGroup.length === 1) {
@@ -482,8 +652,10 @@ export async function runStages(
         }
       }
 
-      let result = await executeStageWithRetry(host, stage, session);
-      result = await applyContentValidation(host, stage, session, result);
+      const executionSession = withStageResults(session, results);
+      let result = await executeStageWithRetry(host, stage, executionSession);
+      const finalized = await finalizeStageResult(host, stage, executionSession, result);
+      result = finalized.result;
       results.push(result);
 
       if (result.status === 'completed' || result.status === 'degraded') {
@@ -492,21 +664,24 @@ export async function runStages(
 
       await saveCheckpoint(host, session, results, [...completedStages]);
 
+      if (finalized.halt) {
+        skipUnprocessedStages(
+          stages,
+          results,
+          completedStages,
+          `Skipped: verification gate failed after '${stage.name}'`
+        );
+        return results;
+      }
+
       // Stop the pipeline after this stage if stopAfterStage is set
       if (session.stopAfterStage !== undefined && stage.name === session.stopAfterStage) {
-        const remainingToSkip = remaining.filter((s) => !results.some((r) => r.name === s.name));
-        for (const skipped of remainingToSkip) {
-          results.push({
-            name: skipped.name,
-            agentType: skipped.agentType,
-            status: 'skipped',
-            durationMs: 0,
-            output: '',
-            artifacts: [],
-            error: `Skipped: pipeline halted after '${session.stopAfterStage}'`,
-            retryCount: 0,
-          });
-        }
+        skipUnprocessedStages(
+          stages,
+          results,
+          completedStages,
+          `Skipped: pipeline halted after '${session.stopAfterStage}'`
+        );
         return results;
       }
     }

--- a/src/ad-sdlc-orchestrator/index.ts
+++ b/src/ad-sdlc-orchestrator/index.ts
@@ -57,6 +57,7 @@ export type {
   OrchestratorSession,
   // Configuration types
   OrchestratorConfig,
+  ResolvedOrchestratorConfig,
   StageTimeoutConfig,
   CheckpointConfig,
   // Checkpoint types

--- a/src/ad-sdlc-orchestrator/types.ts
+++ b/src/ad-sdlc-orchestrator/types.ts
@@ -7,6 +7,7 @@
 
 import type { McpServerConfig } from '../execution/types.js';
 import type { StageVerificationResult } from '../stage-verifier/types.js';
+import { DEFAULT_VNV_CONFIG, type VnvConfig } from '../vnv/types.js';
 
 /**
  * Pipeline execution mode
@@ -330,6 +331,8 @@ export interface OrchestratorConfig {
   readonly maxRetries?: number;
   /** Maximum number of agents that can execute in parallel (default: 3) */
   readonly maxParallelAgents?: number;
+  /** Stage-verification policy applied by the live scheduler */
+  readonly vnv?: Partial<VnvConfig>;
   /** Log level */
   readonly logLevel?: 'DEBUG' | 'INFO' | 'WARN' | 'ERROR';
   /** Checkpoint configuration for mid-stage persistence */
@@ -349,6 +352,11 @@ export interface OrchestratorConfig {
   readonly featureFlagsBaseDir?: string;
 }
 
+/** Fully-resolved orchestrator configuration used at runtime. */
+export type ResolvedOrchestratorConfig = Omit<Required<OrchestratorConfig>, 'vnv'> & {
+  readonly vnv: Readonly<VnvConfig>;
+};
+
 /**
  * Checkpoint configuration for the orchestrator
  */
@@ -362,7 +370,7 @@ export interface CheckpointConfig {
 /**
  * Default orchestrator configuration
  */
-export const DEFAULT_ORCHESTRATOR_CONFIG: Required<OrchestratorConfig> = {
+export const DEFAULT_ORCHESTRATOR_CONFIG: ResolvedOrchestratorConfig = {
   scratchpadDir: '.ad-sdlc/scratchpad',
   outputDocsDir: 'docs',
   approvalMode: 'auto',
@@ -372,6 +380,7 @@ export const DEFAULT_ORCHESTRATOR_CONFIG: Required<OrchestratorConfig> = {
   },
   maxRetries: 3,
   maxParallelAgents: 3,
+  vnv: DEFAULT_VNV_CONFIG,
   logLevel: 'INFO',
   checkpoint: {
     enabled: true,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -23,6 +23,7 @@ import {
   validateConfigFile,
   watchConfigWithLogging,
   configFilesExist,
+  loadWorkflowConfig,
   CONFIG_SCHEMA_VERSION,
   type ValidationReport,
   type FileValidationResult,
@@ -56,6 +57,7 @@ import { resolve } from 'node:path';
 import { getCompletionGenerator, SUPPORTED_SHELLS, type ShellType } from './completion/index.js';
 import { getTelemetry, PRIVACY_POLICY, PRIVACY_POLICY_VERSION } from './telemetry/index.js';
 import { getCLIOutput } from './cli/CLIOutput.js';
+import type { VnvConfig } from './vnv/types.js';
 
 const output = getCLIOutput();
 const program = new Command();
@@ -1082,7 +1084,7 @@ program
     const mode = modeInput as PipelineMode;
 
     // Check .ad-sdlc/ directory exists
-    const exists = configFilesExist();
+    const exists = configFilesExist(projectDir);
     if (!exists.workflow && !exists.agents) {
       output.error(chalk.red('\n❌ No AD-SDLC configuration found.'));
       output.info(chalk.dim('Run "ad-sdlc init" to initialize a project first.\n'));
@@ -1149,7 +1151,7 @@ program
       output.blank();
 
       try {
-        const report = await validateAllConfigs();
+        const report = await validateAllConfigs(projectDir);
         if (report.valid) {
           output.info(chalk.green('Configuration valid. Pipeline is ready to execute.\n'));
         } else {
@@ -1197,8 +1199,29 @@ program
     }
     output.blank();
 
+    let vnv: Pick<VnvConfig, 'rigor' | 'haltOnVerificationFailure'> | undefined;
+    if (exists.workflow) {
+      try {
+        const workflow = await loadWorkflowConfig({ baseDir: projectDir });
+        const configuredVnv = workflow.global?.vnv;
+        if (configuredVnv !== undefined) {
+          vnv = {
+            rigor: configuredVnv.rigor,
+            haltOnVerificationFailure: configuredVnv.halt_on_verification_failure,
+          };
+        }
+      } catch (error: unknown) {
+        output.error(
+          `${chalk.red('\nError:')} ${error instanceof Error ? error.message : String(error)}`
+        );
+        process.exit(1);
+        return;
+      }
+    }
+
     const agent = getAdsdlcOrchestratorAgent({
       approvalMode,
+      ...(vnv !== undefined ? { vnv } : {}),
       featureFlagsCli:
         useSdkForWorkerCli === undefined ? {} : { useSdkForWorker: useSdkForWorkerCli },
       featureFlagsBaseDir: projectDir,

--- a/tests/ad-sdlc-orchestrator/AdsdlcOrchestratorAgent.test.ts
+++ b/tests/ad-sdlc-orchestrator/AdsdlcOrchestratorAgent.test.ts
@@ -20,6 +20,13 @@ import {
   SessionCorruptedError,
 } from '../../src/ad-sdlc-orchestrator/errors.js';
 import { ArtifactValidator } from '../../src/ad-sdlc-orchestrator/ArtifactValidator.js';
+import { StageVerifierAgent } from '../../src/stage-verifier/StageVerifierAgent.js';
+import type { StageVerificationResult } from '../../src/stage-verifier/types.js';
+import type {
+  ExecutionAdapter,
+  StageExecutionRequest,
+  StageExecutionResult,
+} from '../../src/execution/types.js';
 
 /**
  * ArtifactValidator subclass that treats all stages as valid.
@@ -600,6 +607,206 @@ describe('AdsdlcOrchestratorAgent', () => {
       expect(executionOrder.indexOf('codebase_analysis')).toBeLessThan(comparisonIdx);
       expect(executionOrder.indexOf('code_reading')).toBeLessThan(comparisonIdx);
       await trackingAgent.dispose();
+    });
+
+    it('should never exceed maxParallelAgents', async () => {
+      let active = 0;
+      let maxActive = 0;
+
+      class LimitedOrchestrator extends AdsdlcOrchestratorAgent {
+        protected override async invokeAgent(
+          stage: PipelineStageDefinition,
+          _session: OrchestratorSession,
+          _signal?: AbortSignal
+        ): Promise<string> {
+          active++;
+          maxActive = Math.max(maxActive, active);
+          await new Promise((resolve) => setTimeout(resolve, 5));
+          active--;
+          return `Stage "${stage.name}" completed`;
+        }
+      }
+
+      const limitedAgent = new LimitedOrchestrator({ maxParallelAgents: 2 });
+      await limitedAgent.startSession({
+        projectDir: tempDir,
+        userRequest: 'test',
+        overrideMode: 'enhancement',
+      });
+
+      await limitedAgent.executePipeline(tempDir, 'test');
+      expect(maxActive).toBe(2);
+      await limitedAgent.dispose();
+    });
+  });
+
+  describe('production execution boundaries', () => {
+    const successResult: StageExecutionResult = {
+      status: 'success',
+      artifacts: [],
+      sessionId: 'shared-sdk-session',
+      toolCallCount: 1,
+      tokenUsage: { input: 1, output: 1, cache: 0 },
+    };
+
+    it('reuses one adapter for the pipeline and forwards accumulated prior outputs', async () => {
+      const calls: StageExecutionRequest[] = [];
+      let adapterCreations = 0;
+      let adapterDisposals = 0;
+
+      const adapter: ExecutionAdapter = {
+        execute: (request) => {
+          calls.push(request);
+          return Promise.resolve(successResult);
+        },
+        dispose: () => {
+          adapterDisposals++;
+          return Promise.resolve();
+        },
+      };
+
+      class ReusingOrchestrator extends AdsdlcOrchestratorAgent {
+        protected override createExecutionAdapter(_session: OrchestratorSession): ExecutionAdapter {
+          adapterCreations++;
+          return adapter;
+        }
+      }
+
+      const reusingAgent = new ReusingOrchestrator({ maxRetries: 0 });
+      await reusingAgent.startSession({
+        projectDir: tempDir,
+        userRequest: 'test',
+        overrideMode: 'import',
+        stopAfterStage: 'orchestration',
+      });
+
+      await reusingAgent.executePipeline(tempDir, 'test');
+
+      expect(adapterCreations).toBe(1);
+      expect(adapterDisposals).toBe(1);
+      expect(calls).toHaveLength(2);
+      expect(calls[1]?.priorOutputs['issue_reading']).toContain('execution-adapter');
+      await reusingAgent.dispose();
+    });
+
+    it('aborts in-flight adapter work when a stage times out', async () => {
+      let observedSignal: AbortSignal | undefined;
+      let abortObserved = false;
+      let adapterDisposals = 0;
+
+      const adapter: ExecutionAdapter = {
+        execute: (request) => {
+          observedSignal = request.signal;
+          return new Promise<StageExecutionResult>((resolve) => {
+            request.signal?.addEventListener(
+              'abort',
+              () => {
+                abortObserved = true;
+                resolve({
+                  ...successResult,
+                  status: 'aborted',
+                  sessionId: 'aborted-sdk-session',
+                });
+              },
+              { once: true }
+            );
+          });
+        },
+        dispose: () => {
+          adapterDisposals++;
+          return Promise.resolve();
+        },
+      };
+
+      class TimeoutOrchestrator extends AdsdlcOrchestratorAgent {
+        protected override createExecutionAdapter(_session: OrchestratorSession): ExecutionAdapter {
+          return adapter;
+        }
+      }
+
+      const timeoutAgent = new TimeoutOrchestrator({
+        maxRetries: 0,
+        timeouts: { default: 10 },
+      });
+      await timeoutAgent.startSession({
+        projectDir: tempDir,
+        userRequest: 'test',
+        overrideMode: 'import',
+      });
+
+      await expect(timeoutAgent.executePipeline(tempDir, 'test')).rejects.toBeInstanceOf(
+        PipelineFailedError
+      );
+
+      expect(abortObserved).toBe(true);
+      expect(observedSignal?.aborted).toBe(true);
+      expect(adapterDisposals).toBe(1);
+      expect(timeoutAgent.getStatus().stages[0]?.error).toContain('timed out');
+      await timeoutAgent.dispose();
+    });
+
+    it('halts the real stage DAG when strict verification fails', async () => {
+      const invokedStages: string[] = [];
+
+      class FailingVerifier extends StageVerifierAgent {
+        override verifyStage(
+          stageName: PipelineStageDefinition['name']
+        ): Promise<StageVerificationResult> {
+          return Promise.resolve({
+            stageName,
+            passed: false,
+            rigor: 'strict',
+            checks: [],
+            warnings: [],
+            errors: ['intentional verification failure'],
+            timestamp: new Date().toISOString(),
+            durationMs: 0,
+          });
+        }
+      }
+
+      class VerifiedOrchestrator extends AdsdlcOrchestratorAgent {
+        protected override invokeAgent(
+          stage: PipelineStageDefinition,
+          _session: OrchestratorSession,
+          _signal?: AbortSignal
+        ): Promise<string> {
+          invokedStages.push(stage.name);
+          return Promise.resolve(`Stage "${stage.name}" completed`);
+        }
+
+        protected override createStageVerifier(): StageVerifierAgent {
+          return new FailingVerifier();
+        }
+      }
+
+      const verifiedAgent = new VerifiedOrchestrator({
+        maxRetries: 0,
+        vnv: { rigor: 'strict', haltOnVerificationFailure: true },
+      });
+      await verifiedAgent.startSession({
+        projectDir: tempDir,
+        userRequest: 'test',
+        overrideMode: 'import',
+      });
+
+      await expect(verifiedAgent.executePipeline(tempDir, 'test')).rejects.toBeInstanceOf(
+        PipelineFailedError
+      );
+
+      expect(invokedStages).toEqual(['issue_reading']);
+      expect(verifiedAgent.getStatus().stages[0]).toMatchObject({
+        name: 'issue_reading',
+        status: 'failed',
+        error: expect.stringContaining('intentional verification failure'),
+      });
+      expect(
+        verifiedAgent
+          .getStatus()
+          .stages.slice(1)
+          .every((stage) => stage.status === 'skipped')
+      ).toBe(true);
+      await verifiedAgent.dispose();
     });
   });
 
@@ -1858,6 +2065,7 @@ describe('stopAfterStage — #868 regression', () => {
 
     const skippedNames = result.stages.filter((s) => s.status === 'skipped').map((s) => s.name);
     expect(skippedNames).toContain('implementation');
+    expect(skippedNames).not.toContain('issue_reading');
 
     await agent.dispose();
   });

--- a/tests/config/validation.test.ts
+++ b/tests/config/validation.test.ts
@@ -122,6 +122,30 @@ describe('Config Validation', () => {
       expect(result.data?.name).toBe('Test Workflow');
     });
 
+    it('should parse the workflow V&V gate configuration', () => {
+      const result = validateWorkflowConfig({
+        version: '1.0.0',
+        global: {
+          vnv: {
+            rigor: 'strict',
+            halt_on_verification_failure: true,
+          },
+        },
+        pipeline: { stages: [] },
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.data?.global?.vnv).toEqual({
+        rigor: 'strict',
+        halt_on_verification_failure: true,
+        generate_vnv_plan: true,
+        generate_vnv_report: true,
+        generate_rtm: true,
+        cross_document_consistency: true,
+        acceptance_criteria_validation: true,
+      });
+    });
+
     it('should reject invalid version format', () => {
       const config = {
         version: 'invalid',
@@ -234,9 +258,7 @@ describe('Config Validation', () => {
           dependencies: {
             'prd-writer': { requires: ['collector'] },
           },
-          data_flow: [
-            { from: 'collector', to: 'prd-writer', data: 'collected_info.yaml' },
-          ],
+          data_flow: [{ from: 'collector', to: 'prd-writer', data: 'collected_info.yaml' }],
         },
         models: {
           sonnet: {

--- a/tests/e2e/orchestration.e2e.test.ts
+++ b/tests/e2e/orchestration.e2e.test.ts
@@ -23,11 +23,14 @@ import {
   WorkerPoolManager,
   PriorityAnalyzer,
   type IssueNode,
-  type AnalyzedIssue,
   type WorkOrder,
   type WorkOrderResult,
   type RawDependencyGraph,
 } from '../../src/controller/index.js';
+import { AdsdlcOrchestratorAgent } from '../../src/ad-sdlc-orchestrator/AdsdlcOrchestratorAgent.js';
+import { IMPORT_STAGES, type OrchestratorSession } from '../../src/ad-sdlc-orchestrator/types.js';
+import { MockExecutionAdapter } from '../../src/execution/MockExecutionAdapter.js';
+import type { ExecutionAdapter } from '../../src/execution/types.js';
 
 describe('Multi-Agent Orchestration', () => {
   let env: TestEnvironment;
@@ -70,31 +73,12 @@ describe('Multi-Agent Orchestration', () => {
   }
 
   /**
-   * Helper to create a mock AnalyzedIssue
-   */
-  function createAnalyzedIssue(
-    id: string,
-    priority: 'P0' | 'P1' | 'P2' | 'P3' = 'P1',
-    priorityScore: number = 75,
-    dependencies: string[] = [],
-    dependenciesResolved: boolean = true
-  ): AnalyzedIssue {
-    return {
-      node: createIssueNode(id, priority),
-      dependencies,
-      dependents: [],
-      transitiveDependencies: [],
-      depth: dependencies.length,
-      priorityScore,
-      isOnCriticalPath: false,
-      dependenciesResolved,
-    };
-  }
-
-  /**
    * Helper to create a mock dependency graph
    */
-  function createDependencyGraph(issues: IssueNode[], edges: [string, string][]): RawDependencyGraph {
+  function createDependencyGraph(
+    issues: IssueNode[],
+    edges: [string, string][]
+  ): RawDependencyGraph {
     return {
       nodes: issues,
       edges: edges.map(([from, to]) => ({ from, to })),
@@ -496,10 +480,10 @@ describe('Multi-Agent Orchestration', () => {
       });
 
       // Enqueue items with different priorities (out of order)
-      manager.enqueue('ISS-LOW', 25);     // P3
+      manager.enqueue('ISS-LOW', 25); // P3
       manager.enqueue('ISS-CRITICAL', 100); // P0
-      manager.enqueue('ISS-MEDIUM', 50);  // P2
-      manager.enqueue('ISS-HIGH', 75);    // P1
+      manager.enqueue('ISS-MEDIUM', 50); // P2
+      manager.enqueue('ISS-HIGH', 75); // P1
 
       // When: Dequeuing items
       const dequeueOrder: string[] = [];
@@ -664,7 +648,10 @@ describe('Multi-Agent Orchestration', () => {
 
       // When: Some succeed, some fail
       await manager.completeWork('worker-1', createSuccessResult(orders[0]!.orderId));
-      await manager.completeWork('worker-2', createFailureResult(orders[1]!.orderId, 'Test failed'));
+      await manager.completeWork(
+        'worker-2',
+        createFailureResult(orders[1]!.orderId, 'Test failed')
+      );
       await manager.completeWork('worker-3', createSuccessResult(orders[2]!.orderId));
 
       // Then: Should track correctly
@@ -843,75 +830,47 @@ describe('Multi-Agent Orchestration', () => {
   });
 
   describe('End-to-End Orchestration Flow', () => {
-    it('should complete full orchestration cycle with multiple workers', async () => {
-      // Given: A complete orchestration setup
-      const analyzer = new PriorityAnalyzer();
-      const manager = new WorkerPoolManager({
-        maxWorkers: 3,
-        workOrdersPath: testDir,
-      });
+    it('runs the production DAG and persists its real pipeline result', async () => {
+      const adapter = new MockExecutionAdapter();
 
-      // Create a realistic issue set
-      const issues: IssueNode[] = [
-        { id: 'ISS-001', title: 'Setup project structure', priority: 'P0', effort: 2, status: 'pending' },
-        { id: 'ISS-002', title: 'Implement core module', priority: 'P0', effort: 4, status: 'pending' },
-        { id: 'ISS-003', title: 'Add API endpoints', priority: 'P1', effort: 4, status: 'pending' },
-        { id: 'ISS-004', title: 'Write unit tests', priority: 'P1', effort: 4, status: 'pending' },
-        { id: 'ISS-005', title: 'Add documentation', priority: 'P2', effort: 2, status: 'pending' },
-      ];
-
-      const graph = createDependencyGraph(issues, [
-        ['ISS-002', 'ISS-001'], // Core depends on setup
-        ['ISS-003', 'ISS-002'], // API depends on core
-        ['ISS-004', 'ISS-002'], // Tests depend on core
-        ['ISS-005', 'ISS-003'], // Docs depend on API
-        ['ISS-005', 'ISS-004'], // Docs depend on tests
-      ]);
-
-      const graphPath = path.join(testDir, 'e2e-graph.json');
-      fs.writeFileSync(graphPath, JSON.stringify(graph, null, 2));
-
-      // When: Running the orchestration
-      const loadedGraph = await analyzer.loadGraph(graphPath);
-      const analysis = analyzer.analyze(loadedGraph);
-
-      const completedIssues: string[] = [];
-      const processingLog: string[] = [];
-
-      // Process in execution order
-      for (const issueId of analysis.executionOrder) {
-        const analyzedIssue = analysis.issues.get(issueId)!;
-
-        // Wait for dependencies
-        const depsResolved = analyzedIssue.dependencies.every((dep) =>
-          completedIssues.includes(dep)
-        );
-        expect(depsResolved).toBe(true);
-
-        // Get available worker
-        const slot = manager.getAvailableSlot();
-        if (slot !== null) {
-          const order = await manager.createWorkOrder(analyzedIssue);
-          manager.assignWork(slot, order);
-          processingLog.push(`${slot} started ${issueId}`);
-
-          // Simulate work completion
-          await manager.completeWork(slot, createSuccessResult(order.orderId, [`src/${issueId}.ts`]));
-          processingLog.push(`${slot} completed ${issueId}`);
-          completedIssues.push(issueId);
+      class E2EOrchestrator extends AdsdlcOrchestratorAgent {
+        protected override createExecutionAdapter(_session: OrchestratorSession): ExecutionAdapter {
+          return adapter;
         }
       }
 
-      // Then: All issues should be completed
-      expect(completedIssues.length).toBe(5);
-      expect(manager.getCompletedOrders().length).toBe(5);
+      const orchestrator = new E2EOrchestrator({ maxRetries: 0 });
+      await orchestrator.startSession({
+        projectDir: env.rootDir,
+        userRequest: 'Implement the imported issues',
+        overrideMode: 'import',
+      });
 
-      // Verify order respects dependencies
-      expect(completedIssues.indexOf('ISS-001')).toBeLessThan(completedIssues.indexOf('ISS-002'));
-      expect(completedIssues.indexOf('ISS-002')).toBeLessThan(completedIssues.indexOf('ISS-003'));
-      expect(completedIssues.indexOf('ISS-002')).toBeLessThan(completedIssues.indexOf('ISS-004'));
-      expect(completedIssues.indexOf('ISS-003')).toBeLessThan(completedIssues.indexOf('ISS-005'));
-      expect(completedIssues.indexOf('ISS-004')).toBeLessThan(completedIssues.indexOf('ISS-005'));
+      const result = await orchestrator.executePipeline(
+        env.rootDir,
+        'Implement the imported issues'
+      );
+
+      expect(result.overallStatus).toBe('completed');
+      expect(result.stages.map((stage) => stage.name)).toEqual(
+        IMPORT_STAGES.map((stage) => stage.name)
+      );
+      expect(adapter.calls.map((request) => request.agentType)).toEqual(
+        IMPORT_STAGES.map((stage) => stage.agentType)
+      );
+      expect(Object.keys(adapter.calls.at(-1)?.priorOutputs ?? {})).toEqual(
+        IMPORT_STAGES.slice(0, -1).map((stage) => stage.name)
+      );
+
+      const persistedState = path.join(
+        env.rootDir,
+        '.ad-sdlc',
+        'scratchpad',
+        'pipeline',
+        `${result.pipelineId}.yaml`
+      );
+      expect(fs.existsSync(persistedState)).toBe(true);
+      await orchestrator.dispose();
     });
   });
 });

--- a/tests/e2e/pipeline.e2e.test.ts
+++ b/tests/e2e/pipeline.e2e.test.ts
@@ -19,6 +19,14 @@ import {
   COMPLEX_FEATURE_INPUT,
   FIXTURE_EXPECTATIONS,
 } from './helpers/fixtures.js';
+import { AdsdlcOrchestratorAgent } from '../../src/ad-sdlc-orchestrator/AdsdlcOrchestratorAgent.js';
+import { PipelineFailedError } from '../../src/ad-sdlc-orchestrator/errors.js';
+import {
+  GREENFIELD_STAGES,
+  type OrchestratorSession,
+} from '../../src/ad-sdlc-orchestrator/types.js';
+import { MockExecutionAdapter } from '../../src/execution/MockExecutionAdapter.js';
+import type { ExecutionAdapter } from '../../src/execution/types.js';
 
 describe('E2E Pipeline Integration', () => {
   let env: TestEnvironment;
@@ -37,37 +45,50 @@ describe('E2E Pipeline Integration', () => {
   });
 
   describe('Simple Feature Flow', () => {
-    it('should complete full pipeline for single feature request', async () => {
-      // Given: A simple feature request
-      const input = SIMPLE_FEATURE_INPUT;
-
-      // When: Running the complete pipeline
-      const result = await runPipeline(env, input, {
-        projectName: 'Login Feature',
-        projectDescription: 'User login functionality',
-        skipClarification: true,
-        generateIssues: true,
+    it('runs the production pipeline for a single feature request', async () => {
+      const adapter = new MockExecutionAdapter({
+        handlers: [
+          {
+            match: () => true,
+            respond: (request) => ({
+              status: 'success',
+              artifacts: [{ path: `artifacts/${request.agentType}.md` }],
+              sessionId: `session-${request.agentType}`,
+              toolCallCount: 1,
+              tokenUsage: { input: 10, output: 5, cache: 0 },
+            }),
+          },
+        ],
       });
 
-      // Then: Pipeline should complete successfully
-      expect(result.success).toBe(true);
-      expect(result.projectId).toBeDefined();
-      expect(result.projectId.length).toBeGreaterThan(0);
+      class PipelineOrchestrator extends AdsdlcOrchestratorAgent {
+        protected override createExecutionAdapter(_session: OrchestratorSession): ExecutionAdapter {
+          return adapter;
+        }
+      }
 
-      // Verify all stages completed
-      expect(result.collection).toBeDefined();
-      expect(result.collection?.success).toBe(true);
-      expect(result.prd).toBeDefined();
-      expect(result.prd?.success).toBe(true);
-      expect(result.srs).toBeDefined();
-      expect(result.srs?.success).toBe(true);
-      expect(result.sds).toBeDefined();
-      expect(result.sds?.success).toBe(true);
+      const orchestrator = new PipelineOrchestrator({ maxRetries: 0, maxParallelAgents: 2 });
+      await orchestrator.startSession({
+        projectDir: env.rootDir,
+        userRequest: SIMPLE_FEATURE_INPUT,
+        overrideMode: 'greenfield',
+      });
 
-      // Verify timing is reasonable
-      expect(result.totalTimeMs).toBeLessThan(FIXTURE_EXPECTATIONS.simple.maxTimeMs);
+      const result = await orchestrator.executePipeline(env.rootDir, SIMPLE_FEATURE_INPUT);
+
+      expect(result.overallStatus).toBe('completed');
+      expect(result.stages.map((stage) => stage.name)).toEqual(
+        GREENFIELD_STAGES.map((stage) => stage.name)
+      );
+      expect(result.artifacts).toEqual(
+        GREENFIELD_STAGES.map((stage) => `artifacts/${stage.agentType}.md`)
+      );
+      expect(Object.keys(adapter.calls.at(-1)?.priorOutputs ?? {})).toEqual(
+        GREENFIELD_STAGES.slice(0, -1).map((stage) => stage.name)
+      );
+      expect(result.verificationResults).toHaveLength(GREENFIELD_STAGES.length);
+      await orchestrator.dispose();
     }, 60000);
-
 
     it('should generate valid issues from simple feature', async () => {
       // Given: A simple feature request
@@ -97,7 +118,6 @@ describe('E2E Pipeline Integration', () => {
   });
 
   describe('Medium Feature Flow', () => {
-
     it('should handle multiple requirements with dependency chain', async () => {
       // Given: A medium complexity feature request
       const input = MEDIUM_FEATURE_INPUT;
@@ -127,7 +147,6 @@ describe('E2E Pipeline Integration', () => {
       }
     }, 90000);
 
-
     it('should maintain document traceability for medium feature', async () => {
       // Given: A medium complexity feature request
       const input = MEDIUM_FEATURE_INPUT;
@@ -148,7 +167,6 @@ describe('E2E Pipeline Integration', () => {
   });
 
   describe('Complex Feature Flow', () => {
-
     it('should process complex requirements with many components', async () => {
       // Given: A complex feature request
       const input = COMPLEX_FEATURE_INPUT;
@@ -174,7 +192,6 @@ describe('E2E Pipeline Integration', () => {
       expect(result.totalTimeMs).toBeLessThan(FIXTURE_EXPECTATIONS.complex.maxTimeMs);
     }, 120000);
 
-
     it('should generate appropriate number of issues for complex feature', async () => {
       // Given: A complex feature request
       const input = COMPLEX_FEATURE_INPUT;
@@ -198,7 +215,6 @@ describe('E2E Pipeline Integration', () => {
   });
 
   describe('Document Pipeline Only', () => {
-
     it('should generate documents without issues', async () => {
       // Given: A simple feature request
       const input = SIMPLE_FEATURE_INPUT;
@@ -219,8 +235,47 @@ describe('E2E Pipeline Integration', () => {
     }, 60000);
   });
 
-  describe('Pipeline Timing Benchmarks', () => {
+  describe('Production Orchestrator Path', () => {
+    it('halts the production DAG when the real strict verifier rejects a stage', async () => {
+      const adapter = new MockExecutionAdapter();
 
+      class StrictOrchestrator extends AdsdlcOrchestratorAgent {
+        protected override createExecutionAdapter(_session: OrchestratorSession): ExecutionAdapter {
+          return adapter;
+        }
+      }
+
+      const orchestrator = new StrictOrchestrator({
+        maxRetries: 0,
+        vnv: { rigor: 'strict', haltOnVerificationFailure: true },
+      });
+      await orchestrator.startSession({
+        projectDir: env.rootDir,
+        userRequest: 'Execute imported work',
+        overrideMode: 'import',
+      });
+
+      await expect(
+        orchestrator.executePipeline(env.rootDir, 'Execute imported work')
+      ).rejects.toBeInstanceOf(PipelineFailedError);
+
+      expect(adapter.calls.map((request) => request.agentType)).toEqual([
+        'issue-reader',
+        'controller',
+        'worker',
+      ]);
+      expect(orchestrator.getStatus().stages).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ name: 'implementation', status: 'failed' }),
+          expect.objectContaining({ name: 'validation-agent', status: 'skipped' }),
+          expect.objectContaining({ name: 'review', status: 'skipped' }),
+        ])
+      );
+      await orchestrator.dispose();
+    });
+  });
+
+  describe('Pipeline Timing Benchmarks', () => {
     it('should complete simple pipeline within benchmark time', async () => {
       const input = SIMPLE_FEATURE_INPUT;
 


### PR DESCRIPTION
## What

Completes the remaining runtime and E2E work in #877. The performance-gate and secret-masking sub-streams already landed through #891/#895 and #890.

- Enforce `maxParallelAgents` with a bounded DAG worker pool.
- Give every stage attempt its own `AbortController`; a timeout now aborts in-flight SDK work before surfacing `StageTimeoutError`.
- Reuse one `ExecutionAdapter` for the pipeline and dispose it once at pipeline completion.
- Propagate accumulated prior stage outputs and adapter artifact paths to downstream stages.
- Invoke the real `StageVerifierAgent` after every completed/degraded stage.
- Map workflow `global.vnv.rigor` and `halt_on_verification_failure` into the live CLI orchestrator.
- In strict blocking mode, mark a failed verification as a stage failure and skip the unprocessed DAG.
- Persist and return per-stage verification results.
- Replace the two test-local E2E simulations with production orchestrator/DAG assertions.
- Reconcile architecture and agent documentation with the enforced verifier boundary.

## Why

The scheduler exposed concurrency and V&V controls that were not enforced, timed-out SDK requests continued running, adapters were rebuilt for every stage, and the E2E suite could pass without exercising the production orchestration path. This patch closes those production-readiness gaps without changing the published root API.

## Validation

- `npm run build`
- Full unit suite in a clean APFS clone: 238 files passed, 3 skipped; 6,582 tests passed, 71 skipped
- Focused orchestrator/config: 138 passed
- Integration: 6 passed
- Full E2E: 237 passed, 1 skipped
- Documentation symbol/inventory checks passed
- Changed-source ESLint: 0 errors
- Prettier and whitespace checks passed

Closes #877
Relates to #866