### PR TITLE
fix(init): generate schema-valid project configuration

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -266,6 +266,53 @@ claude "Add OAuth2 authentication with Google and GitHub providers"
 
 ## Troubleshooting
 
+### Existing agents.yaml Fails Validation for Missing id or name
+
+Older initialized projects may report missing `agents.<key>.id` or
+`agents.<key>.name` fields. Back up `.ad-sdlc/config/agents.yaml` first (for example,
+copy it to `agents.yaml.bak`), then edit the original file manually. For each
+affected agent, add only the missing `id` (its registry key) and/or `name` (a
+readable, nonempty label).
+
+Before:
+
+```yaml
+version: 1.0.0
+agents:
+  collector:
+    description: Collects our team's requirements
+    model: opus # Keep this customization
+    definition: .claude/agents/our-collector.md
+    x-team: platform
+```
+
+After:
+
+```yaml
+version: 1.0.0
+agents:
+  collector:
+    id: collector
+    name: Collector Agent
+    description: Collects our team's requirements
+    model: opus # Keep this customization
+    definition: .claude/agents/our-collector.md
+    x-team: platform
+```
+
+Keep existing IDs, names, descriptions, models, definition paths, custom agents,
+extension fields, and comments unchanged. Repeat for other agents with missing
+fields, then run from the project directory:
+
+```bash
+ad-sdlc validate --format json
+```
+
+Initialization rejects targets that already contain `.ad-sdlc`; do not delete that
+directory or regenerate configuration to repair missing fields.
+`--skip-validation` skips prerequisite checks only. Newly generated configuration
+is always validated before scaffold directories or files are created.
+
 ### Pipeline Stuck?
 
 ```bash

--- a/src/project-initializer/ProjectInitializer.ts
+++ b/src/project-initializer/ProjectInitializer.ts
@@ -14,12 +14,15 @@ import { tryGetProjectRoot } from '../utils/index.js';
 
 import * as yaml from 'js-yaml';
 
-import { FileSystemError, ProjectExistsError } from './errors.js';
+import { validateAgentsConfig, validateWorkflowConfig } from '../config/validation.js';
+import type { AgentsConfig } from '../config/types.js';
+
+import { ConfigurationError, FileSystemError, ProjectExistsError } from './errors.js';
+import { generateAgentsConfig, generateWorkflowConfig } from './generatedConfig.js';
 import { getPrerequisiteValidator } from './PrerequisiteValidator.js';
 import type {
   InitOptions,
   InitResult,
-  QualityGateConfig,
   TemplateConfig,
   TemplateType,
   WorkflowConfig,
@@ -105,6 +108,24 @@ export class ProjectInitializer {
         }
       }
 
+      // Always validate generated configuration, even when prerequisites are skipped.
+      const templateConfig = TEMPLATE_CONFIGS[this.options.template];
+      const qualityGateConfig = QUALITY_GATE_CONFIGS[templateConfig.qualityGates];
+      const workflowContent = generateWorkflowConfig(templateConfig, qualityGateConfig);
+      const agentsContent = generateAgentsConfig();
+      const validations = [
+        { filename: 'workflow.yaml', result: validateWorkflowConfig(workflowContent) },
+        { filename: 'agents.yaml', result: validateAgentsConfig(agentsContent) },
+      ];
+      for (const { filename, result } of validations) {
+        if (!result.success) {
+          const reason = result.errors
+            ?.map((error) => `${error.path}: ${error.message}`)
+            .join('\n');
+          throw new ConfigurationError(filename, reason ?? 'Generated configuration is invalid');
+        }
+      }
+
       // Create directory structure
       const directories = this.getDirectoryStructure(projectPath);
       for (const dir of directories) {
@@ -113,7 +134,11 @@ export class ProjectInitializer {
       }
 
       // Generate configuration files
-      const configFiles = await this.generateConfigFiles(projectPath);
+      const configFiles = await this.generateConfigFiles(
+        projectPath,
+        workflowContent,
+        agentsContent
+      );
       createdFiles.push(...configFiles);
 
       // Generate template files
@@ -207,112 +232,30 @@ export class ProjectInitializer {
   }
 
   /**
-   * Generate configuration files
+   * Write the original validated objects, preserving settings stripped by schema parsing.
    * @param projectPath - The root path of the project
+   * @param workflowContent - The validated workflow configuration
+   * @param agentsContent - The validated agents configuration
    * @returns Array of created configuration file paths
    */
-  private async generateConfigFiles(projectPath: string): Promise<string[]> {
+  private async generateConfigFiles(
+    projectPath: string,
+    workflowContent: WorkflowConfig,
+    agentsContent: AgentsConfig
+  ): Promise<string[]> {
     const createdFiles: string[] = [];
-    const templateConfig = TEMPLATE_CONFIGS[this.options.template];
-    const qualityGateConfig = QUALITY_GATE_CONFIGS[templateConfig.qualityGates];
 
     // Generate workflow.yaml
     const workflowPath = path.join(projectPath, '.ad-sdlc', 'config', 'workflow.yaml');
-    const workflowContent = this.generateWorkflowConfig(templateConfig, qualityGateConfig);
     await this.writeFile(workflowPath, yaml.dump(workflowContent, { lineWidth: 100 }));
     createdFiles.push(workflowPath);
 
     // Generate agents.yaml
     const agentsPath = path.join(projectPath, '.ad-sdlc', 'config', 'agents.yaml');
-    const agentsContent = this.generateAgentsConfig();
     await this.writeFile(agentsPath, yaml.dump(agentsContent, { lineWidth: 100 }));
     createdFiles.push(agentsPath);
 
     return createdFiles;
-  }
-
-  /**
-   * Generate workflow configuration
-   * @param templateConfig - The template configuration to use
-   * @param qualityGates - The quality gate configuration to apply
-   * @returns Generated workflow configuration object
-   */
-  private generateWorkflowConfig(
-    templateConfig: TemplateConfig,
-    qualityGates: QualityGateConfig
-  ): WorkflowConfig {
-    return {
-      version: '1.0.0',
-      pipeline: {
-        stages: [
-          { name: 'collect', agent: 'collector', timeout_ms: 300000 },
-          { name: 'prd', agent: 'prd-writer', timeout_ms: 300000 },
-          { name: 'srs', agent: 'srs-writer', timeout_ms: 300000 },
-          { name: 'sds', agent: 'sds-writer', timeout_ms: 300000 },
-          { name: 'issues', agent: 'issue-generator', timeout_ms: 300000 },
-          { name: 'implement', agent: 'controller', timeout_ms: 600000 },
-          { name: 'review', agent: 'pr-reviewer', timeout_ms: 300000 },
-        ],
-      },
-      quality_gates: qualityGates,
-      execution: {
-        max_parallel_workers: templateConfig.parallelWorkers,
-        retry_attempts: 3,
-        retry_delay_ms: 5000,
-      },
-    };
-  }
-
-  /**
-   * Generate agents configuration
-   * @returns Agent configuration object with definitions
-   */
-  private generateAgentsConfig(): Record<string, unknown> {
-    return {
-      version: '1.0.0',
-      agents: {
-        collector: {
-          description: 'Collects and organizes project requirements',
-          model: 'sonnet',
-          definition: '.claude/agents/collector.md',
-        },
-        'prd-writer': {
-          description: 'Generates Product Requirements Document',
-          model: 'sonnet',
-          definition: '.claude/agents/prd-writer.md',
-        },
-        'srs-writer': {
-          description: 'Generates Software Requirements Specification',
-          model: 'sonnet',
-          definition: '.claude/agents/srs-writer.md',
-        },
-        'sds-writer': {
-          description: 'Generates Software Design Specification',
-          model: 'sonnet',
-          definition: '.claude/agents/sds-writer.md',
-        },
-        'issue-generator': {
-          description: 'Generates GitHub issues from SDS',
-          model: 'sonnet',
-          definition: '.claude/agents/issue-generator.md',
-        },
-        controller: {
-          description: 'Orchestrates parallel implementation',
-          model: 'sonnet',
-          definition: '.claude/agents/controller.md',
-        },
-        worker: {
-          description: 'Implements individual issues',
-          model: 'sonnet',
-          definition: '.claude/agents/worker.md',
-        },
-        'pr-reviewer': {
-          description: 'Reviews pull requests',
-          model: 'sonnet',
-          definition: '.claude/agents/pr-reviewer.md',
-        },
-      },
-    };
   }
 
   /**

--- a/src/project-initializer/generatedConfig.ts
+++ b/src/project-initializer/generatedConfig.ts
@@ -1,0 +1,108 @@
+/**
+ * Internal configuration builders for project initialization.
+ *
+ * @packageDocumentation
+ */
+
+import type { AgentsConfig } from '../config/types.js';
+import type { QualityGateConfig, TemplateConfig, WorkflowConfig } from './types.js';
+
+/**
+ * Generate workflow configuration
+ * @param templateConfig - The template configuration to use
+ * @param qualityGates - The quality gate configuration to apply
+ * @returns Generated workflow configuration object
+ */
+export function generateWorkflowConfig(
+  templateConfig: TemplateConfig,
+  qualityGates: QualityGateConfig
+): WorkflowConfig {
+  return {
+    version: '1.0.0',
+    pipeline: {
+      stages: [
+        { name: 'collect', agent: 'collector', timeout_ms: 300000 },
+        { name: 'prd', agent: 'prd-writer', timeout_ms: 300000 },
+        { name: 'srs', agent: 'srs-writer', timeout_ms: 300000 },
+        { name: 'sds', agent: 'sds-writer', timeout_ms: 300000 },
+        { name: 'issues', agent: 'issue-generator', timeout_ms: 300000 },
+        { name: 'implement', agent: 'controller', timeout_ms: 600000 },
+        { name: 'review', agent: 'pr-reviewer', timeout_ms: 300000 },
+      ],
+    },
+    quality_gates: qualityGates,
+    execution: {
+      max_parallel_workers: templateConfig.parallelWorkers,
+      retry_attempts: 3,
+      retry_delay_ms: 5000,
+    },
+  };
+}
+
+/**
+ * Generate agents configuration
+ * @returns Agent configuration object with definitions
+ */
+export function generateAgentsConfig(): AgentsConfig {
+  return {
+    version: '1.0.0',
+    agents: {
+      collector: {
+        id: 'collector',
+        name: 'Collector Agent',
+        description: 'Collects and organizes project requirements',
+        model: 'sonnet',
+        definition: '.claude/agents/collector.md',
+      },
+      'prd-writer': {
+        id: 'prd-writer',
+        name: 'PRD Writer Agent',
+        description: 'Generates Product Requirements Document',
+        model: 'sonnet',
+        definition: '.claude/agents/prd-writer.md',
+      },
+      'srs-writer': {
+        id: 'srs-writer',
+        name: 'SRS Writer Agent',
+        description: 'Generates Software Requirements Specification',
+        model: 'sonnet',
+        definition: '.claude/agents/srs-writer.md',
+      },
+      'sds-writer': {
+        id: 'sds-writer',
+        name: 'SDS Writer Agent',
+        description: 'Generates Software Design Specification',
+        model: 'sonnet',
+        definition: '.claude/agents/sds-writer.md',
+      },
+      'issue-generator': {
+        id: 'issue-generator',
+        name: 'Issue Generator Agent',
+        description: 'Generates GitHub issues from SDS',
+        model: 'sonnet',
+        definition: '.claude/agents/issue-generator.md',
+      },
+      controller: {
+        id: 'controller',
+        name: 'Controller Agent',
+        description: 'Orchestrates parallel implementation',
+        model: 'sonnet',
+        definition: '.claude/agents/controller.md',
+      },
+      worker: {
+        id: 'worker',
+        name: 'Worker Agent',
+        description: 'Implements individual issues',
+        model: 'sonnet',
+        definition: '.claude/agents/worker.md',
+      },
+      'pr-reviewer': {
+        id: 'pr-reviewer',
+        name: 'PR Reviewer Agent',
+        description: 'Reviews pull requests',
+        model: 'sonnet',
+        definition: '.claude/agents/pr-reviewer.md',
+      },
+    },
+  };
+}

--- a/tests/cli/initValidation.test.ts
+++ b/tests/cli/initValidation.test.ts
@@ -1,0 +1,194 @@
+/**
+ * Offline init-to-validate regression tests. Run the source CLI so ordinary
+ * npm test covers initialization even before dist/cli.js has been built.
+ */
+
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import * as yaml from 'js-yaml';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  clearConfigCache,
+  ConfigValidationError,
+  loadAgentsConfig,
+  loadWorkflowConfig,
+} from '../../src/config/index.js';
+import type { ValidationReport } from '../../src/config/types.js';
+import type { TemplateType } from '../../src/project-initializer/types.js';
+
+const cliPath = fileURLToPath(new URL('../../src/cli.ts', import.meta.url));
+const require = createRequire(new URL('../../package.json', import.meta.url));
+// A file URL keeps the absolute loader path usable by --import on Windows too.
+const tsxLoader = pathToFileURL(require.resolve('tsx')).href;
+
+function runCli(args: string[], cwd: string) {
+  const result = spawnSync(process.execPath, ['--import', tsxLoader, cliPath, ...args], {
+    cwd,
+    encoding: 'utf-8',
+    timeout: 30_000,
+    env: { ...process.env, NO_COLOR: '1' },
+  });
+  expect(result.error).toBeUndefined();
+  expect(result.signal).toBeNull();
+  return result;
+}
+
+const expectedAgents = {
+  collector: ['Collector Agent', 'Collects and organizes project requirements'],
+  'prd-writer': ['PRD Writer Agent', 'Generates Product Requirements Document'],
+  'srs-writer': ['SRS Writer Agent', 'Generates Software Requirements Specification'],
+  'sds-writer': ['SDS Writer Agent', 'Generates Software Design Specification'],
+  'issue-generator': ['Issue Generator Agent', 'Generates GitHub issues from SDS'],
+  controller: ['Controller Agent', 'Orchestrates parallel implementation'],
+  worker: ['Worker Agent', 'Implements individual issues'],
+  'pr-reviewer': ['PR Reviewer Agent', 'Reviews pull requests'],
+};
+
+describe('CLI initialization configuration validation', () => {
+  let tempDir: string;
+  let projectDir: string;
+
+  beforeEach(() => {
+    // Spaces exercise subprocess argument handling without shell quoting.
+    tempDir = realpathSync(mkdtempSync(join(tmpdir(), 'ad-sdlc init validation ')));
+    projectDir = join(tempDir, 'project');
+  });
+
+  afterEach(() => {
+    clearConfigCache();
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  function initialize(template: TemplateType = 'standard') {
+    const result = runCli(
+      [
+        'init',
+        'project',
+        '--template',
+        template,
+        '--tech-stack',
+        'typescript',
+        '--quick',
+        '--skip-validation',
+      ],
+      tempDir
+    );
+    expect(result.status, result.stdout + result.stderr).toBe(0);
+  }
+
+  it.each([
+    { template: 'minimal', workers: 2, coverage: 50, complexity: 20, requireReview: false },
+    { template: 'standard', workers: 3, coverage: 70, complexity: 15, requireReview: true },
+    { template: 'enterprise', workers: 5, coverage: 80, complexity: 10, requireReview: true },
+  ] as const)('initializes and validates the $template template', async (settings) => {
+    initialize(settings.template);
+
+    const validation = runCli(['validate', '--format', 'json'], projectDir);
+    expect(validation.status, validation.stdout + validation.stderr).toBe(0);
+    const report: ValidationReport = JSON.parse(validation.stdout);
+    expect(report.valid).toBe(true);
+    expect(report.totalErrors).toBe(0);
+    expect(report.files).toHaveLength(2);
+    for (const filename of ['workflow.yaml', 'agents.yaml']) {
+      expect(report.files).toContainEqual(
+        expect.objectContaining({
+          filePath: join(projectDir, '.ad-sdlc', 'config', filename),
+          valid: true,
+          errors: [],
+        })
+      );
+    }
+
+    const options = { baseDir: projectDir, environment: false } as const;
+    const workflow = await loadWorkflowConfig(options);
+    const agents = await loadAgentsConfig(options);
+    expect(workflow.version).toBe('1.0.0');
+    expect(workflow.pipeline.stages.map(({ name, agent }) => [name, agent])).toEqual([
+      ['collect', 'collector'],
+      ['prd', 'prd-writer'],
+      ['srs', 'srs-writer'],
+      ['sds', 'sds-writer'],
+      ['issues', 'issue-generator'],
+      ['implement', 'controller'],
+      ['review', 'pr-reviewer'],
+    ]);
+    expect(agents.version).toBe('1.0.0');
+    expect(Object.keys(agents.agents)).toEqual(Object.keys(expectedAgents));
+    for (const [id, [name, description]] of Object.entries(expectedAgents)) {
+      expect(agents.agents[id]).toEqual({
+        id,
+        name,
+        description,
+        model: 'sonnet',
+        definition: `.claude/agents/${id}.md`,
+      });
+      expect(agents.agents[id]?.name.trim().length).toBeGreaterThan(0);
+    }
+
+    // The loader's schema strips these legacy settings. Check the saved YAML
+    // directly to ensure initialization preserves each template's original data.
+    const savedWorkflow = yaml.load(
+      readFileSync(join(projectDir, '.ad-sdlc', 'config', 'workflow.yaml'), 'utf-8')
+    );
+    expect(savedWorkflow).toMatchObject({
+      execution: {
+        max_parallel_workers: settings.workers,
+        retry_attempts: 3,
+        retry_delay_ms: 5000,
+      },
+      quality_gates: {
+        coverage: settings.coverage,
+        complexity: settings.complexity,
+        requireReview: settings.requireReview,
+        requireTests: true,
+      },
+      pipeline: {
+        stages: workflow.pipeline.stages.map(({ name, agent }) => ({
+          name,
+          agent,
+          timeout_ms: agent === 'controller' ? 600000 : 300000,
+        })),
+      },
+    });
+  });
+
+  it.each([
+    { field: 'id', value: 'missing' },
+    { field: 'name', value: 'missing' },
+    { field: 'id', value: 'empty' },
+    { field: 'name', value: 'empty' },
+  ])('rejects an agent with $value $field in both CLI and loader', async ({ field, value }) => {
+    initialize();
+    const agentsPath = join(projectDir, '.ad-sdlc', 'config', 'agents.yaml');
+    const original = readFileSync(agentsPath, 'utf-8');
+    const malformed = original.replace(
+      new RegExp(`^    ${field}: .+\\n`, 'm'),
+      value === 'missing' ? '' : `    ${field}: ''\n`
+    );
+    expect(malformed).not.toBe(original);
+    writeFileSync(agentsPath, malformed);
+
+    const validation = runCli(['validate', '--format', 'json'], projectDir);
+    expect(validation.status, validation.stdout + validation.stderr).toBe(1);
+    const report: ValidationReport = JSON.parse(validation.stdout);
+    expect(report.valid).toBe(false);
+    expect(report.totalErrors).toBe(1);
+    const agentsReport = report.files.find((file) => file.filePath === agentsPath);
+    expect(agentsReport?.valid).toBe(false);
+    expect(agentsReport?.errors).toEqual([
+      expect.objectContaining({ path: `agents.collector.${field}`, message: expect.any(String) }),
+    ]);
+
+    const loading = loadAgentsConfig({ baseDir: projectDir, environment: false });
+    await expect(loading).rejects.toBeInstanceOf(ConfigValidationError);
+    await expect(loading).rejects.toMatchObject({
+      filePath: agentsPath,
+      errors: [expect.objectContaining({ path: `agents.collector.${field}` })],
+    });
+  });
+});

--- a/tests/config/agentsRepair.test.ts
+++ b/tests/config/agentsRepair.test.ts
@@ -1,0 +1,91 @@
+/** Tests the manual missing-field repair documented in the quickstart. */
+
+import { copyFileSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  clearConfigCache,
+  ConfigValidationError,
+  loadAgentsConfig,
+} from '../../src/config/index.js';
+
+describe('documented agents.yaml repair', () => {
+  let projectDir: string;
+
+  beforeEach(() => {
+    projectDir = mkdtempSync(join(tmpdir(), 'agents-repair-'));
+    mkdirSync(join(projectDir, '.ad-sdlc', 'config'), { recursive: true });
+  });
+
+  afterEach(() => {
+    clearConfigCache();
+    rmSync(projectDir, { recursive: true, force: true });
+  });
+
+  it('adds only missing fields while preserving custom values, agents, extensions, and comments', async () => {
+    const quickstart = readFileSync(new URL('../../docs/quickstart.md', import.meta.url), 'utf-8');
+    const repairSection = quickstart
+      .split('### Existing agents.yaml Fails Validation for Missing id or name')[1]
+      ?.split('\n### ')[0];
+    const examples = [...(repairSection ?? '').matchAll(/```yaml\r?\n([\s\S]*?)```/g)];
+    expect(examples).toHaveLength(2);
+    const before = examples[0]?.[1];
+    const after = examples[1]?.[1];
+    if (before === undefined || after === undefined) {
+      throw new Error('Quickstart must include before and after YAML repair examples');
+    }
+    // Include an existing custom agent with its own ID and name, plus extension
+    // fields and comments beyond the example. None should change during repair.
+    const customizations = `  team-helper:
+    id: existing-team-id
+    name: Our Team Helper
+    description: Keep our custom agent
+    model: haiku # Keep the cost preference
+    definition: prompts/team-helper.md
+    x-policy:
+      review: manual
+# Keep this registry extension too
+x-owner: platform-team
+`;
+    const original = before + customizations;
+    const agentsPath = join(projectDir, '.ad-sdlc', 'config', 'agents.yaml');
+    const backupPath = `${agentsPath}.bak`;
+    writeFileSync(agentsPath, original);
+    copyFileSync(agentsPath, backupPath);
+    const options = { baseDir: projectDir, environment: false } as const;
+    await expect(loadAgentsConfig(options)).rejects.toBeInstanceOf(ConfigValidationError);
+
+    // Simulate manual insertion without parsing and reserializing the YAML.
+    const newline = original.includes('\r\n') ? '\r\n' : '\n';
+    const addedFields = `    id: collector${newline}    name: Collector Agent${newline}`;
+    const repaired = original.replace(
+      `  collector:${newline}`,
+      `  collector:${newline}${addedFields}`
+    );
+    expect(repaired).toBe(after + customizations);
+    expect(repaired.replace(addedFields, '')).toBe(original);
+    writeFileSync(agentsPath, repaired);
+    clearConfigCache();
+
+    const loaded = await loadAgentsConfig(options);
+    expect(loaded.agents.collector).toMatchObject({
+      id: 'collector',
+      name: 'Collector Agent',
+      description: "Collects our team's requirements",
+      model: 'opus',
+      definition: '.claude/agents/our-collector.md',
+      'x-team': 'platform',
+    });
+    expect(loaded.agents['team-helper']).toEqual({
+      id: 'existing-team-id',
+      name: 'Our Team Helper',
+      description: 'Keep our custom agent',
+      model: 'haiku',
+      definition: 'prompts/team-helper.md',
+      'x-policy': { review: 'manual' },
+    });
+    expect(readFileSync(agentsPath, 'utf-8')).toBe(repaired);
+    expect(readFileSync(backupPath)).toEqual(Buffer.from(original));
+  });
+});

--- a/tests/config/validation.test.ts
+++ b/tests/config/validation.test.ts
@@ -273,19 +273,34 @@ describe('Config Validation', () => {
       expect(result.success).toBe(true);
     });
 
-    it('should reject missing agent id', () => {
+    it.each(['id', 'name'] as const)('should reject missing agent %s', (field) => {
+      const agent: { id?: string; name?: string } = { id: 'test', name: 'Test Agent' };
+      delete agent[field];
       const config = {
         version: '1.0.0',
-        agents: {
-          test: {
-            name: 'Test Agent',
-            // missing id
-          },
-        },
+        agents: { test: agent },
       };
 
       const result = validateAgentsConfig(config);
       expect(result.success).toBe(false);
+      expect(result.errors).toEqual([
+        expect.objectContaining({ path: `agents.test.${field}`, message: expect.any(String) }),
+      ]);
+    });
+
+    it.each(['id', 'name'] as const)('should reject empty agent %s', (field) => {
+      const result = validateAgentsConfig({
+        version: '1.0.0',
+        agents: { test: { id: 'test', name: 'Test Agent', [field]: '' } },
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.errors).toEqual([
+        expect.objectContaining({
+          path: `agents.test.${field}`,
+          suggestion: 'Provide a non-empty value',
+        }),
+      ]);
     });
 
     it('should reject invalid category', () => {

--- a/tests/project-initializer/ProjectInitializer.test.ts
+++ b/tests/project-initializer/ProjectInitializer.test.ts
@@ -6,15 +6,22 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as yaml from 'js-yaml';
 
 import {
   createProjectInitializer,
   ProjectInitializer,
   resetProjectInitializer,
 } from '../../src/project-initializer/ProjectInitializer.js';
-import { resetPrerequisiteValidator } from '../../src/project-initializer/PrerequisiteValidator.js';
+import {
+  getPrerequisiteValidator,
+  resetPrerequisiteValidator,
+} from '../../src/project-initializer/PrerequisiteValidator.js';
+import { ConfigurationError } from '../../src/project-initializer/errors.js';
+import * as generatedConfig from '../../src/project-initializer/generatedConfig.js';
 import type { InitOptions } from '../../src/project-initializer/types.js';
+import { QUALITY_GATE_CONFIGS, TEMPLATE_CONFIGS } from '../../src/project-initializer/types.js';
 
 describe('ProjectInitializer', () => {
   let testDir: string;
@@ -38,6 +45,7 @@ describe('ProjectInitializer', () => {
   });
 
   afterEach(() => {
+    vi.restoreAllMocks();
     // Clean up temp directory
     if (fs.existsSync(testDir)) {
       fs.rmSync(testDir, { recursive: true });
@@ -172,6 +180,73 @@ describe('ProjectInitializer', () => {
       expect(result.error).toContain('already exists');
     });
 
+    it('should preserve all customized project files when initialization is repeated', async () => {
+      await new ProjectInitializer(defaultOptions).initialize();
+      const customizations = {
+        '.ad-sdlc/config/workflow.yaml': '# Custom workflow\nversion: 1.0.0\ncustom: keep\n',
+        '.ad-sdlc/config/agents.yaml': '# Custom registry\ncustom-agent: keep\n',
+        '.claude/agents/collector.md': '# Custom Collector\r\nKeep my instructions.\r\n',
+        '.claude/agents/custom-agent.md': '# Custom Agent\nKeep this agent too.\n',
+        '.gitignore': '# Custom ignore rules\nprivate/\n',
+        'README.md': '# Custom documentation\n',
+      };
+      for (const [filename, content] of Object.entries(customizations)) {
+        fs.writeFileSync(path.join(testProjectPath, filename), content);
+      }
+      const snapshot = () => {
+        const files = fs.readdirSync(testProjectPath, { recursive: true, encoding: 'utf-8' });
+        return files.sort().map((filename) => {
+          const filePath = path.join(testProjectPath, filename);
+          return [filename, fs.statSync(filePath).isFile() ? fs.readFileSync(filePath) : null];
+        });
+      };
+      const before = snapshot();
+      const workflowBuilder = vi.spyOn(generatedConfig, 'generateWorkflowConfig');
+      const agentsBuilder = vi.spyOn(generatedConfig, 'generateAgentsConfig');
+
+      const result = await new ProjectInitializer({
+        ...defaultOptions,
+        template: 'enterprise',
+      }).initialize();
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('already exists');
+      expect(result.createdFiles).toEqual([]);
+      expect(snapshot()).toEqual(before);
+      expect(workflowBuilder).not.toHaveBeenCalled();
+      expect(agentsBuilder).not.toHaveBeenCalled();
+    });
+
+    it('should build each configuration once and serialize the validated original objects', async () => {
+      const workflow = generatedConfig.generateWorkflowConfig(
+        TEMPLATE_CONFIGS.standard,
+        QUALITY_GATE_CONFIGS.standard
+      );
+      const agents = generatedConfig.generateAgentsConfig();
+      const workflowBuilder = vi
+        .spyOn(generatedConfig, 'generateWorkflowConfig')
+        .mockReturnValueOnce(workflow);
+      const agentsBuilder = vi
+        .spyOn(generatedConfig, 'generateAgentsConfig')
+        .mockReturnValueOnce(agents);
+
+      const result = await new ProjectInitializer(defaultOptions).initialize();
+
+      expect(result.success).toBe(true);
+      expect(workflowBuilder).toHaveBeenCalledTimes(1);
+      expect(agentsBuilder).toHaveBeenCalledTimes(1);
+      for (const [filename, original] of [
+        ['workflow.yaml', workflow],
+        ['agents.yaml', agents],
+      ] as const) {
+        const saved = fs.readFileSync(
+          path.join(testProjectPath, '.ad-sdlc', 'config', filename),
+          'utf-8'
+        );
+        expect(yaml.load(saved)).toEqual(original);
+      }
+    });
+
     it('should apply minimal template settings', async () => {
       const options: InitOptions = {
         ...defaultOptions,
@@ -213,6 +288,60 @@ describe('ProjectInitializer', () => {
       expect(content).toContain('Test project description');
     });
   });
+
+  describe.each([true, false])(
+    'configuration preflight with skipValidation=%s',
+    (skipValidation) => {
+      beforeEach(() => {
+        vi.spyOn(getPrerequisiteValidator(), 'validate').mockResolvedValue({
+          valid: true,
+          checks: [],
+          warnings: 0,
+        });
+      });
+
+      it.each(['agents', 'workflow'] as const)(
+        'should reject invalid generated %s with diagnostics before any scaffold writes',
+        async (config) => {
+          const workflow = generatedConfig.generateWorkflowConfig(
+            TEMPLATE_CONFIGS.standard,
+            QUALITY_GATE_CONFIGS.standard
+          );
+          const expectedPaths =
+            config === 'agents'
+              ? ['agents.collector.id', 'agents.collector.name']
+              : ['pipeline.stages[0].name'];
+          if (config === 'agents') {
+            vi.spyOn(generatedConfig, 'generateAgentsConfig').mockReturnValue({
+              version: '1.0.0',
+              agents: { collector: { id: '', name: '' } },
+            });
+          } else {
+            vi.spyOn(generatedConfig, 'generateWorkflowConfig').mockReturnValue({
+              ...workflow,
+              pipeline: { stages: [{ name: '', agent: 'collector', timeout_ms: 300000 }] },
+            });
+          }
+
+          const initialization = new ProjectInitializer({
+            ...defaultOptions,
+            skipValidation,
+          }).initialize();
+
+          await expect(initialization).rejects.toBeInstanceOf(ConfigurationError);
+          await expect(initialization).rejects.toMatchObject({ configKey: `${config}.yaml` });
+          await expect(initialization).rejects.toThrow(`${config}.yaml`);
+          for (const fieldPath of expectedPaths) {
+            await expect(initialization).rejects.toThrow(`${fieldPath}:`);
+          }
+          await expect(initialization).rejects.toThrow('must be at least 1 character(s) long');
+          expect(fs.existsSync(testProjectPath)).toBe(false);
+          expect(fs.readdirSync(testDir)).toEqual([]);
+          expect(getPrerequisiteValidator().validate).toHaveBeenCalledTimes(skipValidation ? 0 : 1);
+        }
+      );
+    }
+  );
 
   describe('getTemplateConfig', () => {
     it('should return correct config for minimal template', () => {


### PR DESCRIPTION
## Summary

Newly initialized projects previously failed configuration validation because every generated agent lacked required `id` and `name` fields. Minimal, standard, and enterprise projects now pass CLI validation and load through the shared configuration loaders. Invalid generated configuration raises an actionable initialization error before scaffold writes.

## Related Issue

Closes #945

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update

## Changes Made

- Use an internal, schema-typed agent builder with stable registry IDs and explicit readable names, preserving existing descriptions, models, definition paths, and version.
- Build both configurations once and validate them with the shared validators before creating directories or files. Preserve prerequisite checks, the existing-project guard, and `ConfigurationError` diagnostics with filenames and field paths.
- Serialize the original validated objects so workflow execution and legacy quality-gate settings survive schema parsing. `--skip-validation` continues to skip prerequisites only.
- Add source-CLI regressions for all templates, missing and empty agent fields, loader rejection, preflight failures, and byte-for-byte customization preservation. Document and test manual missing-field repair with a backup and before/after YAML examples.

## Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed

### Test Results

- Focused initializer, configuration, and source-CLI suites: **302 passed**. Run through ordinary `npm test` before building, with `dist/cli.js` temporarily absent.
- Full `npm test`: **6,608 passed, 62 skipped** across 243 test files (242 passed, 1 skipped).
- `npm run build`, `npm run lint`, `npm run format:check`, and `npm run docs:check`: passed.
- Lint reported 457 existing warnings in unchanged files; the modified source files passed lint without warnings.
- Tested on macOS with Node.js 26.3.1. Windows/Linux execution was not performed; subprocess tests use argument arrays, explicit working directories, `process.execPath`, and absolute source/loader paths.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Screenshots

Not applicable.

## Additional Notes

Required schema fields and loader validation remain unchanged. Existing initialized projects are rejected without rewriting their files. Agent asset distribution remains tracked by #946, and workflow runtime mapping by #949; no automatic migration is introduced.
