### PR TITLE
fix(execution): select SDK agents in the target project

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
     "assets:check": "tsx scripts/agent-assets.ts",
     "assets:generate": "tsx scripts/agent-assets.ts --write",
     "prepack": "npm run clean && npm run build",
-    "test:package": "node tests/package/asset-delivery.smoke.mjs"
+    "test:package": "node tests/package/asset-delivery.smoke.mjs",
+    "test:sdk-contract": "tsc -p tsconfig.sdk-contract.json"
   },
   "keywords": [
     "claude",

--- a/src/ad-sdlc-orchestrator/AdsdlcOrchestratorAgent.ts
+++ b/src/ad-sdlc-orchestrator/AdsdlcOrchestratorAgent.ts
@@ -235,13 +235,17 @@ export class AdsdlcOrchestratorAgent implements IAgent {
       throw new PipelineInProgressError(this.session.sessionId);
     }
 
-    await this.validateProjectDir(request.projectDir);
+    if (request.projectDir.trim().length === 0) {
+      throw new InvalidProjectDirError(request.projectDir, 'Project directory must not be blank');
+    }
+    const projectDir = path.resolve(request.projectDir);
+    await this.validateProjectDir(projectDir);
 
     // Resume from prior session if requested
     if (request.resumeSessionId !== undefined && request.resumeSessionId !== '') {
       // Try checkpoint-based resume first (more recent than session YAML)
       if (this.checkpointManager !== null && this.checkpointManager.isEnabled()) {
-        const scratchpadDir = path.resolve(request.projectDir, this.config.scratchpadDir);
+        const scratchpadDir = path.resolve(projectDir, this.config.scratchpadDir);
         const checkpoint = await this.checkpointManager.loadLatestCheckpoint(
           request.resumeSessionId,
           scratchpadDir
@@ -255,7 +259,7 @@ export class AdsdlcOrchestratorAgent implements IAgent {
           });
           // Feed checkpoint's completed stages into the existing resume path
           // by overriding preCompletedStages after loadPriorSession resolves
-          const prior = await this.loadPriorSession(request.resumeSessionId, request.projectDir);
+          const prior = await this.loadPriorSession(request.resumeSessionId, projectDir);
           if (prior) {
             this.session = {
               ...prior,
@@ -277,7 +281,7 @@ export class AdsdlcOrchestratorAgent implements IAgent {
         }
       }
 
-      const prior = await this.loadPriorSession(request.resumeSessionId, request.projectDir);
+      const prior = await this.loadPriorSession(request.resumeSessionId, projectDir);
       if (prior) {
         this.session = {
           ...prior,
@@ -295,7 +299,7 @@ export class AdsdlcOrchestratorAgent implements IAgent {
     this.pendingResumeSdkSessionId = undefined;
 
     const mode = request.overrideMode ?? 'greenfield';
-    const scratchpadDir = path.resolve(request.projectDir, this.config.scratchpadDir);
+    const scratchpadDir = path.resolve(projectDir, this.config.scratchpadDir);
 
     // Build preCompletedStages from startFromStage if provided
     let preCompletedStages: StageName[] | null = null;
@@ -314,7 +318,7 @@ export class AdsdlcOrchestratorAgent implements IAgent {
 
     this.session = {
       sessionId: randomUUID(),
-      projectDir: request.projectDir,
+      projectDir,
       userRequest: request.userRequest,
       mode,
       startedAt: new Date().toISOString(),
@@ -755,8 +759,8 @@ export class AdsdlcOrchestratorAgent implements IAgent {
   /**
    * Translate orchestrator state into a {@link StageExecutionRequest}.
    * Maps `session.userRequest` to `workOrder` and accumulated completed
-   * stage outputs to `priorOutputs`. The system prompt is sourced by
-   * the SDK from `.claude/agents/<agentType>.md`.
+   * stage outputs to `priorOutputs`. The adapter resolves the system prompt
+   * from `<session.projectDir>/.claude/agents/<agentType>.md`.
    * @param stage
    * @param session
    * @param signal
@@ -789,6 +793,7 @@ export class AdsdlcOrchestratorAgent implements IAgent {
     }
 
     const request: StageExecutionRequest = {
+      projectDir: session.projectDir,
       agentType: stage.agentType,
       workOrder: session.userRequest,
       priorOutputs,
@@ -1053,7 +1058,8 @@ export class AdsdlcOrchestratorAgent implements IAgent {
 
     return {
       sessionId: (data['pipelineId'] ?? sessionId) as string,
-      projectDir: (data['projectDir'] ?? projectDir) as string,
+      // The explicitly selected project owns the resumed execution, even if moved.
+      projectDir: path.resolve(projectDir),
       userRequest: (data['userRequest'] ?? '') as string,
       mode: data['mode'] as PipelineMode,
       startedAt: (data['startedAt'] ?? new Date().toISOString()) as string,

--- a/src/ad-sdlc-orchestrator/types.ts
+++ b/src/ad-sdlc-orchestrator/types.ts
@@ -220,7 +220,7 @@ export interface AgentInvocation {
 export interface OrchestratorSession {
   /** Unique session identifier */
   readonly sessionId: string;
-  /** Project root directory */
+  /** Target project root, normalized to an absolute path at session creation. */
   readonly projectDir: string;
   /** User request text */
   readonly userRequest: string;
@@ -262,7 +262,7 @@ export interface OrchestratorSession {
  * Pipeline execution request
  */
 export interface PipelineRequest {
-  /** Project root directory */
+  /** Target project root, normalized to an absolute path at session creation. */
   readonly projectDir: string;
   /** User's project description or change request */
   readonly userRequest: string;
@@ -885,7 +885,7 @@ export interface PipelineCheckpoint {
   readonly sessionId: string;
   /** Pipeline mode */
   readonly mode: PipelineMode;
-  /** Project directory */
+  /** Target project root saved by the session. */
   readonly projectDir: string;
   /** User request text */
   readonly userRequest: string;

--- a/src/collector/CollectorAgent.ts
+++ b/src/collector/CollectorAgent.ts
@@ -13,6 +13,7 @@
  * - Implements IAgent interface for AgentFactory integration
  */
 
+import { resolve } from 'node:path';
 import { randomUUID } from 'node:crypto';
 import type { IAgent } from '../agents/types.js';
 import type { ExecutionAdapter } from '../execution/index.js';
@@ -47,6 +48,7 @@ import type {
  * Note: maxQuestionsPerRound is set to 5 per issue #13 requirements
  */
 const DEFAULT_CONFIG: Required<CollectorAgentConfig> = {
+  projectDir: '',
   confidenceThreshold: 0.7,
   maxQuestionsPerRound: 5,
   skipClarificationIfConfident: false,
@@ -78,7 +80,14 @@ export class CollectorAgent implements IAgent {
   private initialized = false;
 
   constructor(config: CollectorAgentConfig = {}, adapter?: ExecutionAdapter) {
-    this.config = { ...DEFAULT_CONFIG, ...config };
+    this.config = {
+      ...DEFAULT_CONFIG,
+      ...config,
+      projectDir:
+        config.projectDir === undefined || config.projectDir === ''
+          ? ''
+          : resolve(config.projectDir),
+    };
 
     const parserOptions: InputParserOptions = {};
     const extractorOptions: InformationExtractorOptions = {
@@ -96,7 +105,8 @@ export class CollectorAgent implements IAgent {
       this.llmExtractor = new LLMExtractor(
         effectiveAdapter,
         this.extractor,
-        this.config.scratchpadBasePath
+        this.config.scratchpadBasePath,
+        this.config.projectDir
       );
     } else {
       this.llmExtractor = null;
@@ -108,7 +118,9 @@ export class CollectorAgent implements IAgent {
         maxQuestionsPerRound: this.config.maxQuestionsPerRound,
         enableLLMQuestions: effectiveAdapter !== null,
       },
-      effectiveAdapter
+      effectiveAdapter,
+      undefined,
+      this.config.projectDir
     );
   }
 

--- a/src/collector/InvestigationEngine.ts
+++ b/src/collector/InvestigationEngine.ts
@@ -7,6 +7,7 @@
  * @module collector/InvestigationEngine
  */
 
+import { resolve } from 'node:path';
 import { promises as fs } from 'node:fs';
 import { z } from 'zod';
 import type { ExecutionAdapter, StageExecutionResult } from '../execution/index.js';
@@ -76,9 +77,15 @@ export class InvestigationEngine {
   constructor(
     config: Partial<InvestigationEngineConfig>,
     adapter: ExecutionAdapter | null,
-    templates?: InvestigationTemplates
+    templates?: InvestigationTemplates,
+    /** Target root is required for LLM question generation. */
+    private readonly projectDir: string = ''
   ) {
+    if (projectDir.length > 0) this.projectDir = resolve(projectDir);
     const parsed = InvestigationEngineConfigSchema.parse(config);
+    if (adapter !== null && parsed.enableLLMQuestions && projectDir.trim().length === 0) {
+      throw new Error('InvestigationEngine: projectDir is required for SDK execution');
+    }
     this.config = {
       depth: parsed.depth,
       maxQuestionsPerRound: parsed.maxQuestionsPerRound,
@@ -328,6 +335,7 @@ export class InvestigationEngine {
       }
 
       const result = await this.adapter.execute({
+        projectDir: this.projectDir,
         agentType: 'collector',
         workOrder: prompt,
         priorOutputs: {},
@@ -495,7 +503,7 @@ Rules:
       return first.description;
     }
     try {
-      return await fs.readFile(first.path, 'utf8');
+      return await fs.readFile(resolve(this.projectDir, first.path), 'utf8');
     } catch (error) {
       getLogger().warn('Failed to read investigation questions artifact from disk', {
         agent: 'InvestigationEngine',

--- a/src/collector/LLMExtractor.ts
+++ b/src/collector/LLMExtractor.ts
@@ -14,6 +14,7 @@
  */
 
 import { promises as fs } from 'node:fs';
+import { resolve } from 'node:path';
 import { z } from 'zod';
 import type { ExecutionAdapter, StageExecutionResult } from '../execution/index.js';
 import type { InformationExtractor } from './InformationExtractor.js';
@@ -54,8 +55,13 @@ export class LLMExtractor {
     private readonly adapter: ExecutionAdapter,
     private readonly fallback: InformationExtractor,
     private readonly scratchpadDir: string = '',
-    private readonly projectDir: string = ''
-  ) {}
+    /** Target root is required when using the SDK adapter. */
+    private readonly projectDir: string
+  ) {
+    if (projectDir.trim().length === 0)
+      throw new Error('LLMExtractor: projectDir is required for SDK execution');
+    this.projectDir = resolve(projectDir);
+  }
 
   /**
    * Extract structured information from parsed input using LLM analysis.
@@ -68,6 +74,7 @@ export class LLMExtractor {
   async extract(input: ParsedInput, projectContext?: string): Promise<ExtractionResult> {
     try {
       const result = await this.adapter.execute({
+        projectDir: this.projectDir,
         agentType: 'collector',
         workOrder: this.buildExtractionPrompt(input.combinedContent, projectContext),
         priorOutputs: this.buildPriorOutputs(projectContext),
@@ -115,7 +122,7 @@ export class LLMExtractor {
       return first.description;
     }
     try {
-      return await fs.readFile(first.path, 'utf8');
+      return await fs.readFile(resolve(this.projectDir, first.path), 'utf8');
     } catch (error) {
       getLogger().warn('Failed to read extraction artifact from disk', {
         agent: 'LLMExtractor',

--- a/src/collector/types.ts
+++ b/src/collector/types.ts
@@ -220,6 +220,8 @@ export interface CollectionSession {
  * Collector Agent configuration options
  */
 export interface CollectorAgentConfig {
+  /** Target project root, required for SDK extraction and investigation. */
+  readonly projectDir?: string;
   /** Minimum confidence threshold for auto-accepting extractions */
   readonly confidenceThreshold?: number;
   /** Maximum number of clarification questions to ask at once */

--- a/src/controller/WorkerPoolManager.ts
+++ b/src/controller/WorkerPoolManager.ts
@@ -32,7 +32,7 @@
 
 import { mkdir, writeFile, readFile } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
-import { join, dirname } from 'node:path';
+import { join, dirname, resolve } from 'node:path';
 import { randomUUID } from 'node:crypto';
 
 import type {
@@ -108,6 +108,7 @@ interface MutableWorkerInfo {
  * Internal configuration type with optional queueConfig
  */
 interface InternalWorkerPoolConfig {
+  readonly projectRoot: string | undefined;
   readonly maxWorkers: number;
   readonly workerTimeout: number;
   readonly workOrdersPath: string;
@@ -149,6 +150,9 @@ export class WorkerPoolManager {
   _processManager: import('./WorkerProcessManager.js').WorkerProcessManager | null = null;
 
   constructor(config: WorkerPoolConfig = {}, scratchpadOptions?: ScratchpadOptions) {
+    if (config.projectRoot !== undefined && config.projectRoot.trim().length === 0) {
+      throw new Error('WorkerPoolManager: projectRoot must not be blank');
+    }
     // Merge distributed lock options with defaults
     const distributedLockConfig: Required<DistributedLockOptions> = {
       enabled: config.distributedLock?.enabled ?? DEFAULT_DISTRIBUTED_LOCK_OPTIONS.enabled,
@@ -168,6 +172,7 @@ export class WorkerPoolManager {
     };
 
     this.config = {
+      projectRoot: config.projectRoot === undefined ? undefined : resolve(config.projectRoot),
       maxWorkers: config.maxWorkers ?? DEFAULT_WORKER_POOL_CONFIG.maxWorkers,
       workerTimeout: config.workerTimeout ?? DEFAULT_WORKER_POOL_CONFIG.workerTimeout,
       workOrdersPath: config.workOrdersPath ?? DEFAULT_WORKER_POOL_CONFIG.workOrdersPath,
@@ -523,7 +528,8 @@ export class WorkerPoolManager {
   /**
    * Execute a work order through the configured ExecutionAdapter.
    *
-   * Delegates execution to the adapter using the 'worker' agent type.
+   * Delegates execution using the 'worker' agent in the configured projectRoot.
+   * An explicit projectRoot is required when an adapter is configured.
    * Returns the structured stage execution result. When no adapter is
    * configured, returns a stubbed success result so callers can run
    * without a live SDK backend.
@@ -542,7 +548,12 @@ export class WorkerPoolManager {
       };
     }
 
+    if (this.config.projectRoot === undefined) {
+      throw new Error('WorkerPoolManager: projectRoot must be configured for SDK execution');
+    }
+
     const request: StageExecutionRequest = {
+      projectDir: this.config.projectRoot,
       agentType: 'worker',
       workOrder: workOrder.issueId,
       priorOutputs: {},

--- a/src/controller/types.ts
+++ b/src/controller/types.ts
@@ -288,6 +288,8 @@ export const DEFAULT_DISTRIBUTED_LOCK_OPTIONS: Required<DistributedLockOptions> 
  * Worker pool configuration
  */
 export interface WorkerPoolConfig {
+  /** Target project root. Required for SDK execution; normalized at construction. */
+  readonly projectRoot?: string;
   /** Maximum number of concurrent workers (default: 5) */
   readonly maxWorkers?: number;
   /** Worker timeout in milliseconds (default: 600000 = 10 minutes) */
@@ -306,7 +308,7 @@ export interface WorkerPoolConfig {
  * Default worker pool configuration
  */
 export const DEFAULT_WORKER_POOL_CONFIG: Required<
-  Omit<WorkerPoolConfig, 'queueConfig' | 'distributedLock' | 'metricsConfig'>
+  Omit<WorkerPoolConfig, 'projectRoot' | 'queueConfig' | 'distributedLock' | 'metricsConfig'>
 > = {
   maxWorkers: 5,
   workerTimeout: 600000, // 10 minutes

--- a/src/execution/README.md
+++ b/src/execution/README.md
@@ -58,16 +58,17 @@ export interface ExecutionAdapter {
 `StageExecutionRequest` carries everything a stage needs to run a single
 SDK call:
 
-| Field          | Required | Purpose                                                          |
-| -------------- | -------- | ---------------------------------------------------------------- |
-| `agentType`    | yes      | Identifies which `.claude/agents/*.md` to load (e.g. `'worker'`) |
-| `workOrder`    | yes      | Prompt body — the actual instruction the stage emits             |
-| `priorOutputs` | yes      | Verbatim outputs from upstream stages, keyed by stage name       |
-| `skills`       | no       | SDK skill names to enable for this call                          |
-| `mcpServers`   | no       | MCP server config map forwarded to the SDK                       |
-| `maxTurns`     | no       | Cap on agent turns; SDK aborts past this                         |
-| `resume`       | no       | SDK session id to continue                                       |
-| `signal`       | no       | `AbortSignal` for cancellation                                   |
+| Field          | Required | Purpose                                                                           |
+| -------------- | -------- | --------------------------------------------------------------------------------- |
+| `projectDir`   | yes      | Absolute target project directory; normalized at session/configuration boundaries |
+| `agentType`    | yes      | Identifies which `.claude/agents/*.md` to load (e.g. `'worker'`)                  |
+| `workOrder`    | yes      | Prompt body — the actual instruction the stage emits                              |
+| `priorOutputs` | yes      | Verbatim outputs from upstream stages, keyed by stage name                        |
+| `skills`       | no       | SDK skill names to enable for this call                                           |
+| `mcpServers`   | no       | MCP server config map forwarded to the SDK                                        |
+| `maxTurns`     | no       | Cap on agent turns; SDK aborts past this                                          |
+| `resume`       | no       | SDK session id to continue                                                        |
+| `signal`       | no       | `AbortSignal` for cancellation                                                    |
 
 ### Result
 
@@ -100,24 +101,63 @@ pass.
 Production adapter that drives `@anthropic-ai/claude-agent-sdk`. Defined in
 [`SdkExecutionAdapter.ts`](./SdkExecutionAdapter.ts).
 
-The SDK is loaded with a dynamic `import()` so this module compiles even in
-environments where the SDK is not yet installed (the dynamic import only
-runs when `execute()` is called). Tests inject a fake `loader` to avoid
-touching the real package.
+The SDK runtime loads lazily through a literal, typed dynamic `import()`.
+Production options use the installed SDK's `Options` and `AgentDefinition`;
+query input is derived from `Parameters<typeof query>[0]` and messages use
+`SDKMessage`. The package must be installed for TypeScript checks. Offline
+tests inject only `query()` returning an async iterable, without implementing
+unrelated `Query` methods.
+
+Before loading or calling the SDK, the adapter validates `agentType` and reads
+`<projectDir>/.claude/agents/<agentType>.md`. The resolver reuses AD-SDLC's
+frontmatter parser and required metadata schema, without ambient `agents.yaml`
+discovery. It requires a matching name, valid description/tools/model, and a
+nonempty Markdown prompt. Supported SDK metadata such as skills, disallowed
+tools, MCP servers, permissions, memory, and effort is preserved. The installed
+project definition is authoritative, including user edits; packaged checksums
+are not enforced and definitions are not cached.
+
+`projectDir` must be absolute and identify a directory at the adapter boundary.
+Relative roots are resolved once when configuring a worker or starting a session.
+Resumed sessions use the explicitly selected project, including when persisted
+state contains an old root. Worker pools require `WorkerPoolConfig.projectRoot`
+for SDK execution. Collector SDK callers require `CollectorAgentConfig.projectDir`
+(or an explicit project directory when constructing `LLMExtractor` or
+`InvestigationEngine`). No execution changes `process.cwd()`.
+
+Every query explicitly sets `cwd`, `agent`, and `agents[agentType]`, as well as
+`settingSources: ['user', 'project', 'local']`. Project support agents and skills
+remain discoverable and user/local plugin settings remain enabled. The required
+main agent is always validated in the target project. Local mode uses the same
+path for `local-reviewer` and `local-issue-reader`. The `# Stage: ...` prompt
+heading provides context; SDK options select the persona.
+
+Missing, unreadable, malformed, empty, or incorrectly named definitions produce
+a failed `StageExecutionResult` with the agent name, attempted path, and useful
+validation or I/O details, before `query()` is called. Invalid agent names and
+project roots are rejected before constructing an unsafe definition path.
 
 The adapter maps `StageExecutionRequest` → SDK options:
 
-| Request field         | SDK option           | Note                                           |
-| --------------------- | -------------------- | ---------------------------------------------- |
-| `agentType`           | (prompt prefix)      | Identifies which `.claude/agents/*.md` to load |
-| `workOrder`           | prompt body          |                                                |
-| `priorOutputs`        | prompt context       | Verbatim, labeled by key                       |
-| `skills`              | `options.skills`     |                                                |
-| `mcpServers`          | `options.mcpServers` |                                                |
-| `maxTurns`            | `options.maxTurns`   |                                                |
-| `resume`              | `options.resume`     | Continue an earlier session                    |
-| `signal`              | `options.signal`     | Forwarded to the SDK for cancellation          |
-| `hooks` (constructor) | `options.hooks`      | Optional hook pipeline; see below              |
+| Request field         | SDK option                        | Note                                                 |
+| --------------------- | --------------------------------- | ---------------------------------------------------- |
+| `projectDir`          | `options.cwd`                     | Absolute target project root                         |
+| `agentType`           | `options.agent`, `options.agents` | Explicit main-thread persona from the target project |
+| `workOrder`           | prompt body                       |                                                      |
+| `priorOutputs`        | prompt context                    | Verbatim, labeled by key                             |
+| `skills`              | `options.skills`                  |                                                      |
+| `mcpServers`          | `options.mcpServers`              |                                                      |
+| `maxTurns`            | `options.maxTurns`                |                                                      |
+| `resume`              | `options.resume`                  | Continue an earlier session                          |
+| `signal`              | `options.abortController`         | Per-execution bridge, preserving the abort reason    |
+| `hooks` (constructor) | `options.hooks`                   | Optional hook pipeline; see below                    |
+
+Readonly request skills and MCP stdio arguments are copied into mutable SDK
+arrays; other server settings are retained. Optional fields are omitted when
+unprovided. Pre-aborted requests do not load or query the SDK. The abort bridge
+removes its listener in `finally` on success, failure, and cancellation.
+Comprehensive active-query disposal and timeout/retry cleanup remain tracked
+separately in #948.
 
 #### Example: production wiring
 
@@ -129,6 +169,7 @@ const adapter = new SdkExecutionAdapter({
 });
 
 const result = await adapter.execute({
+  projectDir: '/absolute/path/to/project',
   agentType: 'worker',
   workOrder: 'Implement the login endpoint per the SRS.',
   priorOutputs: {
@@ -183,6 +224,7 @@ const adapter = new MockExecutionAdapter({
 });
 
 const result = await adapter.execute({
+  projectDir: '/absolute/path/to/project',
   agentType: 'worker',
   workOrder: 'Implement login',
   priorOutputs: { srs: 'SRS body' },
@@ -265,7 +307,7 @@ const adapter = new SdkExecutionAdapter({
 
 ## Testing Strategy
 
-The module is split into three test files, all under
+Offline execution tests live under
 [`tests/execution/`](../../tests/execution/):
 
 | File                                                                                 | Scope                                                                                                                                                               |
@@ -273,6 +315,21 @@ The module is split into three test files, all under
 | [`MockExecutionAdapter.test.ts`](../../tests/execution/MockExecutionAdapter.test.ts) | Mock semantics: default success, handler matching order, `calls[]` recording, `dispose` behaviour, abort handling                                                   |
 | [`SdkExecutionAdapter.test.ts`](../../tests/execution/SdkExecutionAdapter.test.ts)   | `renderPrompt` contract (including the `priorOutputs` verbatim guarantee), SDK message reduction (`session_id`, `toolCallCount`, `tokenUsage`), error / abort paths |
 | [`hooks.test.ts`](../../tests/execution/hooks.test.ts)                               | `buildHookPipeline` shape, `PostToolUse(Edit\|Write)` capture, error codes, end-to-end wiring through `SdkExecutionAdapter` with a fake SDK loader                  |
+
+The project-isolation test launches a separate Node process with cwd set to
+project A, then targets project B with conflicting same-named definitions. A
+query double writes sentinel files relative to the captured `options.cwd`.
+It also checks validation failures and overlapping A/B requests without mocking
+the resolver. `projectContext.test.ts` exercises the real orchestrator local-mode
+substitutions and resumed requests through the SDK adapter.
+
+These tests verify the SDK boundary contract. They do not verify live model
+persona behavior; live Import acceptance is a separate scenario.
+
+`npm run build` type-checks production SDK input. `npm run test:sdk-contract`
+invokes `tsc -p tsconfig.sdk-contract.json` to additionally check execution
+fixtures and doubles against official SDK types; Vitest transpilation alone
+does not establish compatibility.
 
 ### Recommended pattern: stages use the mock
 
@@ -321,8 +378,10 @@ npm test -- tests/execution
 
 1. Add the new entry type to `HookPipeline` in [`hooks.ts`](./hooks.ts) if
    the SDK exposes a new event family (otherwise reuse the existing keys).
-2. Build a `SdkHookEntry` with a `matcher` regex string and an async
-   `callback` that throws `AppError` on any failure path.
+2. Build a `SdkHookEntry` with a `matcher` regex string and `hooks: [callback]`.
+   Official callbacks receive `(input, toolUseID, { signal })` and return
+   `Promise<HookJSONOutput>`. Artifact capture awaits the sink and returns `{}`;
+   sink failures propagate to the adapter.
 3. Register the entry under the matching event key in the returned object.
 4. Add a focused test in `tests/execution/hooks.test.ts` that drives the
    callback directly (do not couple the test to the SDK's event loop).
@@ -354,6 +413,8 @@ export class BedrockExecutionAdapter implements ExecutionAdapter {
 
 Checklist when implementing a new adapter:
 
+- [ ] Resolves the required target-project agent and explicitly sets agent selection
+      and cwd without changing the process directory.
 - [ ] Forwards every `priorOutputs` entry verbatim into the prompt
       (mirror the existing contract test).
 - [ ] Returns the canonical `StageExecutionResult` shape, including a
@@ -370,7 +431,7 @@ Checklist when implementing a new adapter:
 
 ## What this module does NOT do (yet)
 
-- Wiring stages to actually call the adapter — see issue #793.
+- Comprehensive query disposal and timeout/retry cleanup — see issue #948.
 - Telemetry bridge (`Stop` finalisation) — Phase 3.
 - Bedrock / Vertex endpoint selection — Phase 4.
 

--- a/src/execution/SdkExecutionAdapter.ts
+++ b/src/execution/SdkExecutionAdapter.ts
@@ -1,97 +1,38 @@
 /**
- * SdkExecutionAdapter — real adapter that drives `@anthropic-ai/claude-agent-sdk`.
- *
- * Loads the SDK lazily via dynamic `import()` so this module compiles in
- * environments where the SDK is not yet installed. Tests inject a fake
- * `loader` to bypass the actual import.
- *
- * Maps {@link StageExecutionRequest} → SDK options as follows:
- *
- * | Request field   | SDK option       | Note                                           |
- * |-----------------|------------------|------------------------------------------------|
- * | `agentType`     | (prompt prefix)  | Identifies which `.claude/agents/*.md` to load |
- * | `workOrder`     | prompt body      |                                                |
- * | `priorOutputs`  | prompt context   | Verbatim, labeled by key                       |
- * | `skills`        | options.skills   |                                                |
- * | `mcpServers`    | options.mcpServers |                                              |
- * | `maxTurns`      | options.maxTurns |                                                |
- * | `permissionMode`| options.permissionMode | `'default' \| 'acceptEdits' \| 'plan'`   |
- * | `resume`        | options.resume   | Continue an earlier session                    |
- * | `signal`        | options.signal   |                                                |
- *
+ * SDK execution with an explicitly selected target-project agent and cwd.
+ * Runtime loading stays lazy; production query input and messages use the
+ * installed SDK types. Tests inject only query(), without unrelated Query APIs.
  * @packageDocumentation
  */
 
+import type { Options, SDKMessage, SDKResultMessage, query } from '@anthropic-ai/claude-agent-sdk';
+import { resolveProjectAgent } from './resolveProjectAgent.js';
 import { AppError } from '../errors/AppError.js';
 import { ErrorSeverity } from '../errors/types.js';
 import type { HookPipeline } from './hooks.js';
 import type {
   ArtifactRef,
   ExecutionAdapter,
-  McpServerConfig,
   StageExecutionRequest,
   StageExecutionResult,
   TokenUsage,
 } from './types.js';
 
-/**
- * Minimal subset of `@anthropic-ai/claude-agent-sdk` we depend on. We declare
- * it locally so tsc can compile this file without the package being installed.
- * Real SDK types are wider; we only consume what is documented here.
- */
-export interface SdkQueryOptions {
-  prompt: string;
-  options?: {
-    skills?: readonly string[];
-    mcpServers?: Record<string, McpServerConfig>;
-    maxTurns?: number;
-    permissionMode?: 'default' | 'acceptEdits' | 'plan';
-    resume?: string;
-    signal?: AbortSignal;
-    hooks?: HookPipeline;
-  };
-}
+/** Official query input, retained under the existing exported name. */
+export type SdkQueryOptions = Parameters<typeof query>[0];
 
-/**
- * Shape of messages the SDK yields. We pattern-match on `type`.
- */
-export interface SdkMessage {
-  readonly type: 'system' | 'assistant' | 'user' | 'result';
-  readonly subtype?: string;
-  readonly session_id?: string;
-  readonly result?: string;
-  readonly is_error?: boolean;
-  readonly num_turns?: number;
-  readonly usage?: {
-    readonly input_tokens?: number;
-    readonly output_tokens?: number;
-    readonly cache_read_input_tokens?: number;
-    readonly cache_creation_input_tokens?: number;
-  };
-}
+/** Official SDK messages; adapters narrow discriminated variants explicitly. */
+export type SdkMessage = SDKMessage;
 
+/** Injectable query boundary: offline doubles only implement async iteration. */
 export interface SdkLike {
   query(opts: SdkQueryOptions): AsyncIterable<SdkMessage>;
 }
 
-/**
- * Loader function for the SDK module. Defaults to a dynamic import of
- * `@anthropic-ai/claude-agent-sdk`. Tests pass a fake.
- */
+/** Lazy runtime loader, replaceable by an offline query double. */
 export type SdkLoader = () => Promise<SdkLike>;
 
-const defaultLoader: SdkLoader = async () => {
-  const moduleSpecifier = '@anthropic-ai/claude-agent-sdk';
-  const mod = (await import(/* @vite-ignore */ moduleSpecifier)) as Partial<SdkLike>;
-  if (typeof mod.query !== 'function') {
-    throw new AppError(
-      'EXEC-001',
-      '@anthropic-ai/claude-agent-sdk did not export a `query` function',
-      { severity: ErrorSeverity.CRITICAL }
-    );
-  }
-  return mod as SdkLike;
-};
+const defaultLoader: SdkLoader = async () => import('@anthropic-ai/claude-agent-sdk');
 
 export interface SdkExecutionAdapterOptions {
   /** Override the SDK loader for tests / alternative endpoints. */
@@ -132,19 +73,13 @@ export class SdkExecutionAdapter implements ExecutionAdapter {
       return abortedResult(req.resume);
     }
 
-    const sdk = await this.getSdk();
-    const prompt = renderPrompt(req);
-    // Build options with conditional spreads so undefined fields are absent
-    // entirely (required by tsconfig `exactOptionalPropertyTypes: true`).
-    const sdkOptions: NonNullable<SdkQueryOptions['options']> = {
-      ...(req.skills !== undefined && { skills: req.skills }),
-      ...(req.mcpServers !== undefined && { mcpServers: req.mcpServers }),
-      ...(req.maxTurns !== undefined && { maxTurns: req.maxTurns }),
-      ...(req.permissionMode !== undefined && { permissionMode: req.permissionMode }),
-      ...(req.resume !== undefined && { resume: req.resume }),
-      ...(req.signal !== undefined && { signal: req.signal }),
-      ...(this.hooks !== undefined && { hooks: this.hooks }),
+    const abortController = new AbortController();
+    const forwardAbort = (): void => {
+      abortController.abort(req.signal?.reason);
     };
+    // Read through a function because abort state can change across awaited SDK work.
+    const isAborted = (): boolean => abortController.signal.aborted;
+    req.signal?.addEventListener('abort', forwardAbort, { once: true });
 
     let sessionId = req.resume ?? 'unknown';
     let toolCallCount = 0;
@@ -153,27 +88,46 @@ export class SdkExecutionAdapter implements ExecutionAdapter {
     let isError = false;
 
     try {
+      const definition = await resolveProjectAgent(req.projectDir, req.agentType);
+      const sdk = await this.getSdk();
+      // Cancellation may have arrived while resolving the definition or loader.
+      if (isAborted()) return abortedResult(sessionId);
+      const prompt = renderPrompt(req);
+      const sdkOptions: Options = {
+        cwd: req.projectDir,
+        agent: req.agentType,
+        agents: { [req.agentType]: definition },
+        settingSources: ['user', 'project', 'local'],
+        ...(req.skills !== undefined && { skills: [...req.skills] }),
+        ...(req.mcpServers !== undefined && {
+          mcpServers: copyMcpServers(req.mcpServers),
+        }),
+        ...(req.maxTurns !== undefined && { maxTurns: req.maxTurns }),
+        ...(req.permissionMode !== undefined && { permissionMode: req.permissionMode }),
+        ...(req.resume !== undefined && { resume: req.resume }),
+        ...(req.signal !== undefined && { abortController }),
+        ...(this.hooks !== undefined && { hooks: this.hooks }),
+      };
       for await (const message of sdk.query({ prompt, options: sdkOptions })) {
-        if (message.session_id !== undefined && message.session_id !== '') {
+        if ('session_id' in message && message.session_id !== '') {
           sessionId = message.session_id;
         }
         if (message.type === 'assistant') toolCallCount += 1;
         if (message.type === 'result') {
-          resultText = message.result;
-          isError = message.is_error === true;
-          if (typeof message.num_turns === 'number') {
-            toolCallCount = Math.max(toolCallCount, message.num_turns);
-          }
-          if (message.usage !== undefined) tokenUsage = mapUsage(message.usage);
+          resultText = message.subtype === 'success' ? message.result : message.errors.join('\n');
+          isError = message.is_error || message.subtype !== 'success';
+          toolCallCount = Math.max(toolCallCount, message.num_turns);
+          tokenUsage = mapUsage(message.usage);
         }
       }
     } catch (err) {
-      // The signal may have flipped to aborted between the early-return guard
-      // above and this point; widen the type so TS does not collapse the check.
-      const signal: AbortSignal | undefined = req.signal;
-      if (signal?.aborted === true) return abortedResult(sessionId);
+      if (isAborted()) return abortedResult(sessionId);
       return failedResult(sessionId, err);
+    } finally {
+      req.signal?.removeEventListener('abort', forwardAbort);
     }
+
+    if (isAborted()) return abortedResult(sessionId);
 
     if (isError || resultText === undefined) {
       return failedResult(sessionId, new Error(resultText ?? 'SDK returned no result'));
@@ -221,11 +175,26 @@ export function renderPrompt(req: StageExecutionRequest): string {
   return blocks.join('\n');
 }
 
-function mapUsage(usage: NonNullable<SdkMessage['usage']>): TokenUsage {
-  const cache = (usage.cache_read_input_tokens ?? 0) + (usage.cache_creation_input_tokens ?? 0);
+function copyMcpServers(
+  servers: NonNullable<StageExecutionRequest['mcpServers']>
+): NonNullable<Options['mcpServers']> {
+  const copied: NonNullable<Options['mcpServers']> = {};
+  for (const [name, server] of Object.entries(servers)) {
+    if (server.type === 'stdio') {
+      const { args, ...config } = server;
+      copied[name] = { ...config, ...(args !== undefined ? { args: [...args] } : {}) };
+    } else {
+      copied[name] = { ...server };
+    }
+  }
+  return copied;
+}
+
+function mapUsage(usage: SDKResultMessage['usage']): TokenUsage {
+  const cache = usage.cache_read_input_tokens + usage.cache_creation_input_tokens;
   return {
-    input: usage.input_tokens ?? 0,
-    output: usage.output_tokens ?? 0,
+    input: usage.input_tokens,
+    output: usage.output_tokens,
     cache,
   };
 }

--- a/src/execution/hooks.ts
+++ b/src/execution/hooks.ts
@@ -22,6 +22,14 @@
  * @packageDocumentation
  */
 
+import type {
+  HookCallback,
+  HookCallbackMatcher,
+  HookInput,
+  HookJSONOutput,
+  Options,
+  PostToolUseHookInput,
+} from '@anthropic-ai/claude-agent-sdk';
 import { AppError } from '../errors/AppError.js';
 import { ErrorSeverity } from '../errors/types.js';
 
@@ -56,42 +64,17 @@ export interface ArtifactCaptureEntry {
   readonly sessionId?: string;
 }
 
-/**
- * Generic shape of a tool-use event the SDK forwards to a hook callback.
- * We intentionally accept a wide `tool_input` so callers do not need to
- * keep this in lockstep with the SDK's evolving tool catalog.
- */
-export interface SdkToolUseEvent {
-  readonly tool_name: string;
-  readonly tool_input?: Record<string, unknown>;
-  readonly session_id?: string;
-}
+/** Official SDK tool event retained under the existing exported name. */
+export type SdkToolUseEvent = PostToolUseHookInput;
 
-/**
- * Callback signature the SDK invokes for matched tool events. Return value
- * is intentionally `void | Promise<void>` so the hook can be async.
- */
-export type SdkHookCallback = (event: SdkToolUseEvent) => void | Promise<void>;
+/** Official callbacks return JSON output and receive tool ID and signal context. */
+export type SdkHookCallback = HookCallback;
 
-/**
- * Single hook entry: the `matcher` is a regex string the SDK applies to
- * `tool_name`; the `callback` runs when it matches.
- */
-export interface SdkHookEntry {
-  readonly matcher: string;
-  readonly callback: SdkHookCallback;
-}
+/** Official matcher entry: callbacks are supplied in `hooks: [callback]`. */
+export type SdkHookEntry = HookCallbackMatcher;
 
-/**
- * Hook pipeline shape consumed by {@link SdkExecutionAdapter}. Mirrors the
- * SDK's hook configuration: each top-level key is a hook event name, the
- * value is the list of (matcher, callback) entries.
- */
-export interface HookPipeline {
-  readonly PreToolUse?: readonly SdkHookEntry[];
-  readonly PostToolUse?: readonly SdkHookEntry[];
-  readonly Stop?: readonly SdkHookEntry[];
-}
+/** Official SDK hook configuration. Unprovided event keys remain absent. */
+export type HookPipeline = NonNullable<Options['hooks']>;
 
 /**
  * Options accepted by {@link buildHookPipeline}.
@@ -145,7 +128,12 @@ export function buildHookPipeline(
   const postToolUse: SdkHookEntry[] = [
     {
       matcher: ARTIFACT_TOOL_MATCHER,
-      callback: async (event): Promise<void> => captureEditOrWrite(event, sink, now),
+      hooks: [
+        async (event): Promise<HookJSONOutput> => {
+          await captureEditOrWrite(event, sink, now);
+          return {};
+        },
+      ],
     },
   ];
 
@@ -169,11 +157,11 @@ export function buildHookPipeline(
  * @param now Clock function used to stamp `capturedAt`.
  */
 async function captureEditOrWrite(
-  event: SdkToolUseEvent,
+  event: HookInput,
   sink: ArtifactSink,
   now: () => Date
 ): Promise<void> {
-  const toolName = event.tool_name;
+  const toolName = 'tool_name' in event ? event.tool_name : event.hook_event_name;
   if (!isArtifactToolName(toolName)) {
     // Defensive: matcher should have filtered, but never trust the SDK.
     throw new AppError(
@@ -183,7 +171,7 @@ async function captureEditOrWrite(
     );
   }
 
-  const filePath = readFilePath(event.tool_input);
+  const filePath = readFilePath('tool_input' in event ? event.tool_input : undefined);
   if (filePath === null) {
     throw new AppError('EXEC-103', `Hook PostToolUse(${toolName}) missing tool_input.file_path`, {
       severity: ErrorSeverity.HIGH,
@@ -195,7 +183,7 @@ async function captureEditOrWrite(
     filePath,
     toolName,
     capturedAt: now().toISOString(),
-    ...(event.session_id !== undefined ? { sessionId: event.session_id } : {}),
+    sessionId: event.session_id,
   };
 
   // Deliberate await: a sink failure must abort the stage.
@@ -206,8 +194,8 @@ function isArtifactToolName(name: string): name is ArtifactToolName {
   return (ARTIFACT_TOOL_NAMES as readonly string[]).includes(name);
 }
 
-function readFilePath(input: Record<string, unknown> | undefined): string | null {
-  if (!input) return null;
+function readFilePath(input: unknown): string | null {
+  if (typeof input !== 'object' || input === null || !('file_path' in input)) return null;
   const value = input.file_path;
   if (typeof value !== 'string' || value.length === 0) return null;
   return value;

--- a/src/execution/index.ts
+++ b/src/execution/index.ts
@@ -19,6 +19,8 @@ export type {
 export { MockExecutionAdapter } from './MockExecutionAdapter.js';
 export type { MockExecutionAdapterOptions, MockExecutionHandler } from './MockExecutionAdapter.js';
 
+export { resolveProjectAgent } from './resolveProjectAgent.js';
+
 export { SdkExecutionAdapter, renderPrompt } from './SdkExecutionAdapter.js';
 export type {
   SdkExecutionAdapterOptions,

--- a/src/execution/resolveProjectAgent.ts
+++ b/src/execution/resolveProjectAgent.ts
@@ -1,0 +1,167 @@
+/** Target-project agent resolution, independent of ambient project discovery. */
+import { readFile, stat } from 'node:fs/promises';
+import { isAbsolute, join } from 'node:path';
+import type {
+  AgentDefinition,
+  McpServerConfigForProcessTransport,
+} from '@anthropic-ai/claude-agent-sdk';
+import { z } from 'zod';
+import { AgentFrontmatterSchema } from '../agent-validator/schemas.js';
+import { parseFrontmatter } from '../agent-validator/validator.js';
+
+const nonemptyString = z.string().refine((value) => value.trim().length > 0, 'Must not be blank');
+const stringMap = z.record(z.string(), z.string());
+const serverOptions = z.object({
+  timeout: z.number().positive().optional(),
+  alwaysLoad: z.boolean().optional(),
+});
+const transportSchema = z
+  .union([
+    serverOptions.extend({
+      type: z.literal('stdio').optional(),
+      command: nonemptyString,
+      args: z.array(z.string()).optional(),
+      env: stringMap.optional(),
+    }),
+    serverOptions.extend({
+      type: z.enum(['http', 'sse']),
+      url: z.url(),
+      headers: stringMap.optional(),
+      tools: z
+        .array(
+          z.object({
+            name: nonemptyString,
+            permission_policy: z.enum(['always_allow', 'always_ask', 'always_deny']).optional(),
+            org_max_permission: z.enum(['allow', 'ask', 'blocked']).optional(),
+          })
+        )
+        .optional(),
+    }),
+    z.object({
+      type: z.literal('sdk'),
+      name: nonemptyString,
+      timeout: z.number().positive().optional(),
+    }),
+  ])
+  .transform((server): McpServerConfigForProcessTransport => {
+    const common = {
+      ...(server.timeout !== undefined ? { timeout: server.timeout } : {}),
+      ...('alwaysLoad' in server && server.alwaysLoad !== undefined
+        ? { alwaysLoad: server.alwaysLoad }
+        : {}),
+    };
+    if ('command' in server) {
+      return {
+        ...common,
+        ...(server.type !== undefined ? { type: server.type } : {}),
+        command: server.command,
+        ...(server.args !== undefined ? { args: server.args } : {}),
+        ...(server.env !== undefined ? { env: server.env } : {}),
+      };
+    }
+    if (server.type === 'sdk') return { ...common, type: server.type, name: server.name };
+    return {
+      ...common,
+      type: server.type,
+      url: server.url,
+      ...(server.headers !== undefined ? { headers: server.headers } : {}),
+      ...(server.tools !== undefined
+        ? {
+            tools: server.tools.map((tool) => ({
+              name: tool.name,
+              ...(tool.permission_policy !== undefined
+                ? { permission_policy: tool.permission_policy }
+                : {}),
+              ...(tool.org_max_permission !== undefined
+                ? { org_max_permission: tool.org_max_permission }
+                : {}),
+            })),
+          }
+        : {}),
+    };
+  });
+
+// Reuse AD-SDLC's required metadata rules, retaining optional fields understood
+// by the installed SDK. Parsing directly avoids validateAgentFile's ambient
+// agents.yaml lookup and reads each definition only once.
+const definitionSchema = AgentFrontmatterSchema.extend({
+  description: AgentFrontmatterSchema.shape.description.refine(
+    (value) => value.trim().length >= 10,
+    'Description must contain at least 10 non-padding characters'
+  ),
+  disallowedTools: z.array(nonemptyString).optional(),
+  skills: z.array(nonemptyString).optional(),
+  mcpServers: z.array(z.union([nonemptyString, z.record(z.string(), transportSchema)])).optional(),
+  criticalSystemReminder_EXPERIMENTAL: nonemptyString.optional(),
+  initialPrompt: nonemptyString.optional(),
+  maxTurns: z.number().int().positive().optional(),
+  background: z.boolean().optional(),
+  memory: z.enum(['user', 'project', 'local']).optional(),
+  effort: z.union([z.enum(['low', 'medium', 'high', 'xhigh', 'max']), z.number().int()]).optional(),
+  permissionMode: z
+    .enum(['default', 'acceptEdits', 'bypassPermissions', 'plan', 'dontAsk', 'auto'])
+    .optional(),
+  observer: nonemptyString.optional(),
+  observerMessage: z.string().optional(),
+});
+
+/**
+ * Load the requested project's installed, possibly customized agent definition.
+ * No registry discovery, packaged checksum enforcement, or definition cache.
+ * @param projectDir Absolute target project directory.
+ * @param agentType Lowercase agent name, validated before constructing its path.
+ * @returns The validated official SDK definition, including its Markdown prompt.
+ * @throws Error with agent name, attempted path, and validation or I/O details.
+ */
+export async function resolveProjectAgent(
+  projectDir: string,
+  agentType: string
+): Promise<AgentDefinition> {
+  const name = AgentFrontmatterSchema.shape.name.safeParse(agentType);
+  if (!name.success) {
+    throw new Error(`Invalid agentType ${JSON.stringify(agentType)}: ${name.error.message}`);
+  }
+  if (typeof projectDir !== 'string' || !isAbsolute(projectDir) || projectDir.includes('\0')) {
+    throw new Error(
+      `Agent "${agentType}": projectDir must be an absolute directory; received ${JSON.stringify(projectDir)}`
+    );
+  }
+  const definitionPath = join(projectDir, '.claude', 'agents', `${name.data}.md`);
+  try {
+    if (!(await stat(projectDir)).isDirectory()) throw new Error('projectDir is not a directory');
+    const { frontmatter, body } = parseFrontmatter(
+      await readFile(definitionPath, 'utf8'),
+      definitionPath
+    );
+    const metadata = definitionSchema.parse(frontmatter);
+    if (metadata.name !== agentType) {
+      throw new Error(`frontmatter.name must equal "${agentType}"; found "${metadata.name}"`);
+    }
+    if (body.trim().length === 0) throw new Error('Prompt body must not be empty');
+    const definition: AgentDefinition = {
+      description: metadata.description,
+      tools: metadata.tools,
+      model: metadata.model,
+      prompt: body,
+    };
+    if (metadata.disallowedTools !== undefined)
+      definition.disallowedTools = metadata.disallowedTools;
+    if (metadata.skills !== undefined) definition.skills = metadata.skills;
+    if (metadata.mcpServers !== undefined) definition.mcpServers = metadata.mcpServers;
+    if (metadata.criticalSystemReminder_EXPERIMENTAL !== undefined)
+      definition.criticalSystemReminder_EXPERIMENTAL = metadata.criticalSystemReminder_EXPERIMENTAL;
+    if (metadata.initialPrompt !== undefined) definition.initialPrompt = metadata.initialPrompt;
+    if (metadata.maxTurns !== undefined) definition.maxTurns = metadata.maxTurns;
+    if (metadata.background !== undefined) definition.background = metadata.background;
+    if (metadata.memory !== undefined) definition.memory = metadata.memory;
+    if (metadata.effort !== undefined) definition.effort = metadata.effort;
+    if (metadata.permissionMode !== undefined) definition.permissionMode = metadata.permissionMode;
+    if (metadata.observer !== undefined) definition.observer = metadata.observer;
+    if (metadata.observerMessage !== undefined)
+      definition.observerMessage = metadata.observerMessage;
+    return definition;
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    throw new Error(`Agent "${agentType}" at "${definitionPath}": ${detail}`, { cause: error });
+  }
+}

--- a/src/execution/types.ts
+++ b/src/execution/types.ts
@@ -8,6 +8,7 @@
  * @packageDocumentation
  */
 
+import type { McpStdioServerConfig, McpHttpServerConfig } from '@anthropic-ai/claude-agent-sdk';
 import type { SerializedError } from '../errors/types.js';
 
 /**
@@ -27,17 +28,11 @@ export interface ArtifactRef {
  * accepted by `@anthropic-ai/claude-agent-sdk` to keep the boundary thin.
  */
 export type McpServerConfig =
-  | {
+  | (Readonly<Omit<McpStdioServerConfig, 'args' | 'type'>> & {
       readonly type: 'stdio';
-      readonly command: string;
       readonly args?: readonly string[];
-      readonly env?: Record<string, string>;
-    }
-  | {
-      readonly type: 'http';
-      readonly url: string;
-      readonly headers?: Record<string, string>;
-    };
+    })
+  | Readonly<McpHttpServerConfig>;
 
 /**
  * Token usage breakdown returned by every adapter call.
@@ -62,6 +57,8 @@ export type StageExecutionStatus = 'success' | 'failed' | 'aborted';
  * test that asserts this.
  */
 export interface StageExecutionRequest {
+  /** Absolute root of the target project; never inferred by the SDK adapter. */
+  readonly projectDir: string;
   readonly agentType: string;
   readonly workOrder: string;
   readonly priorOutputs: Record<string, string>;

--- a/src/worker/WorkerAgent.ts
+++ b/src/worker/WorkerAgent.ts
@@ -148,9 +148,12 @@ export class WorkerAgent implements IAgent {
     testGeneratorConfig?: TestGeneratorConfig,
     checkpointConfig?: CheckpointManagerConfig
   ) {
+    if (config.projectRoot !== undefined && config.projectRoot.trim().length === 0) {
+      throw new Error('WorkerAgent: projectRoot must not be blank');
+    }
     const defaults = getDefaultWorkerAgentConfig();
     this.config = {
-      projectRoot: config.projectRoot ?? tryGetProjectRoot() ?? defaults.projectRoot,
+      projectRoot: resolve(config.projectRoot ?? tryGetProjectRoot() ?? defaults.projectRoot),
       resultsPath: config.resultsPath ?? defaults.resultsPath,
       maxRetries: config.maxRetries ?? defaults.maxRetries,
       testCommand: config.testCommand ?? defaults.testCommand,
@@ -775,6 +778,7 @@ export class WorkerAgent implements IAgent {
     // Delegate to ExecutionAdapter when available
     if (this.executionAdapter) {
       const request: StageExecutionRequest = {
+        projectDir: this.config.projectRoot,
         agentType: 'worker',
         workOrder: this.buildCodeGenPrompt(workOrder, codeContext),
         priorOutputs: {

--- a/src/worker/types.ts
+++ b/src/worker/types.ts
@@ -16,7 +16,7 @@ import { tryGetProjectRoot } from '../utils/index.js';
  * Worker Agent configuration
  */
 export interface WorkerAgentConfig {
-  /** Project root directory */
+  /** Project root directory, normalized to an absolute path at configuration. */
   readonly projectRoot?: string;
   /** Path to store results (default: '.ad-sdlc/scratchpad/progress') */
   readonly resultsPath?: string;

--- a/tests/ad-sdlc-orchestrator/AdsdlcOrchestratorAgent.test.ts
+++ b/tests/ad-sdlc-orchestrator/AdsdlcOrchestratorAgent.test.ts
@@ -685,6 +685,7 @@ describe('AdsdlcOrchestratorAgent', () => {
       expect(adapterCreations).toBe(1);
       expect(adapterDisposals).toBe(1);
       expect(calls).toHaveLength(2);
+      expect(calls.every((request) => request.projectDir === tempDir)).toBe(true);
       expect(calls[1]?.priorOutputs['issue_reading']).toContain('execution-adapter');
       await reusingAgent.dispose();
     });
@@ -1598,6 +1599,7 @@ describe('claude-config plugin skills preload', () => {
 
     const workerReq = orchestrator.probe(workerStage as PipelineStageDefinition, session);
     expect(workerReq.skills).toEqual(WORKER_SKILLS);
+    expect(workerReq.projectDir).toBe(session.projectDir);
 
     const reviewerReq = orchestrator.probe(reviewerStage as PipelineStageDefinition, session);
     expect(reviewerReq.skills).toEqual(PR_REVIEWER_SKILLS);

--- a/tests/ad-sdlc-orchestrator/projectContext.test.ts
+++ b/tests/ad-sdlc-orchestrator/projectContext.test.ts
@@ -1,0 +1,199 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { join, relative } from 'node:path';
+import { tmpdir } from 'node:os';
+import { dump } from 'js-yaml';
+import { AdsdlcOrchestratorAgent } from '../../src/ad-sdlc-orchestrator/AdsdlcOrchestratorAgent.js';
+import { PipelineCheckpointManager } from '../../src/ad-sdlc-orchestrator/PipelineCheckpointManager.js';
+import {
+  IMPORT_STAGES,
+  LOCAL_AGENT_SUBSTITUTIONS,
+  type OrchestratorSession,
+  type PipelineStageDefinition,
+  type StageResult,
+} from '../../src/ad-sdlc-orchestrator/types.js';
+import {
+  SdkExecutionAdapter,
+  type ExecutionAdapter,
+  type SdkQueryOptions,
+  type StageExecutionRequest,
+} from '../../src/execution/index.js';
+import { agentMarkdown, installAgent, sdkResult } from '../execution/fixtures/sdk.js';
+
+class ProbeOrchestrator extends AdsdlcOrchestratorAgent {
+  constructor(private readonly adapter: ExecutionAdapter) {
+    super({ maxRetries: 0 });
+  }
+  protected override createExecutionAdapter(): ExecutionAdapter {
+    return this.adapter;
+  }
+  request(stage: PipelineStageDefinition, session: OrchestratorSession): StageExecutionRequest {
+    return this.buildStageExecutionRequest(stage, session);
+  }
+}
+
+let projectDir: string;
+beforeEach(async () => {
+  projectDir = await mkdtemp(join(tmpdir(), 'orchestrator-context-'));
+});
+afterEach(async () => {
+  await rm(projectDir, { recursive: true, force: true });
+});
+
+function capturingAdapter(calls: SdkQueryOptions[]): SdkExecutionAdapter {
+  return new SdkExecutionAdapter({
+    loader: async () => ({
+      async *query(input) {
+        calls.push(input);
+        yield sdkResult();
+      },
+    }),
+  });
+}
+
+describe('orchestrator project and agent context at the SDK boundary', () => {
+  it('normalizes the root and executes real local-mode substitutions through the project resolver', async () => {
+    for (const stage of IMPORT_STAGES) {
+      const name = LOCAL_AGENT_SUBSTITUTIONS[stage.agentType] ?? stage.agentType;
+      await installAgent(
+        projectDir,
+        name,
+        agentMarkdown(name, `${name} customized for this project`)
+      );
+    }
+    const calls: SdkQueryOptions[] = [];
+    const orchestrator = new ProbeOrchestrator(capturingAdapter(calls));
+    try {
+      const session = await orchestrator.startSession({
+        projectDir: relative(process.cwd(), projectDir),
+        userRequest: 'Import local work',
+        overrideMode: 'import',
+        localMode: true,
+      });
+      expect(session.projectDir).toBe(projectDir);
+      await orchestrator.executePipeline(projectDir, 'Import local work');
+      expect(calls.map((call) => call.options?.agent)).toEqual([
+        'local-issue-reader',
+        'controller',
+        'worker',
+        'validation-agent',
+        'local-reviewer',
+      ]);
+      for (const call of calls) {
+        expect(call.options?.cwd).toBe(projectDir);
+        const name = call.options?.agent;
+        expect(name).toBeDefined();
+        expect(call.options?.agents?.[name!]?.prompt).toBe(`${name} customized for this project\n`);
+      }
+      expect(calls[1]?.prompt).toContain('### issue_reading');
+    } finally {
+      await orchestrator.dispose();
+    }
+  });
+
+  it.each(['checkpoint', 'legacy-checkpoint', 'session-only'] as const)(
+    'resumes %s in the selected project and consumes the SDK resume ID once',
+    async (mode) => {
+      await installAgent(projectDir, 'worker');
+      await installAgent(projectDir, 'local-reviewer');
+      const sessionId = 'resume-project-test';
+      const scratchpadDir = join(projectDir, '.ad-sdlc', 'scratchpad');
+      await mkdir(join(scratchpadDir, 'pipeline'), { recursive: true });
+      const priorResults: StageResult[] = [
+        {
+          name: 'issue_reading',
+          agentType: 'local-issue-reader',
+          status: 'completed',
+          durationMs: 1,
+          output: 'Imported local issue content',
+          artifacts: [],
+          error: null,
+          retryCount: 0,
+        },
+      ];
+      await writeFile(
+        join(scratchpadDir, 'pipeline', `${sessionId}.yaml`),
+        dump({
+          pipelineId: sessionId,
+          projectDir: 'stale-launch-directory',
+          mode: 'import',
+          userRequest: 'Continue local work',
+          localMode: true,
+          stages: priorResults,
+        })
+      );
+      if (mode !== 'session-only') {
+        const filename = await new PipelineCheckpointManager().saveCheckpoint(
+          sessionId,
+          'import',
+          '/stale/project',
+          'Continue local work',
+          scratchpadDir,
+          priorResults,
+          ['issue_reading'],
+          mode === 'checkpoint' ? 'sdk-resume-id' : undefined
+        );
+        if (mode === 'legacy-checkpoint') {
+          await writeFile(
+            join(scratchpadDir, 'pipeline', 'checkpoints', filename),
+            dump({
+              version: 1,
+              sessionId,
+              projectDir: 'stale-project',
+              mode: 'import',
+              userRequest: 'Continue local work',
+              createdAt: new Date().toISOString(),
+              completedStageResults: priorResults,
+              completedStageNames: ['issue_reading'],
+            })
+          );
+        }
+      }
+      const calls: SdkQueryOptions[] = [];
+      const adapter = capturingAdapter(calls);
+      const orchestrator = new ProbeOrchestrator(adapter);
+      try {
+        const session = await orchestrator.startSession({
+          projectDir: relative(process.cwd(), projectDir),
+          userRequest: 'Resume',
+          resumeSessionId: sessionId,
+        });
+        expect(session.projectDir).toBe(projectDir);
+        expect(session.scratchpadDir).toBe(scratchpadDir);
+        const first = orchestrator.request(
+          { ...IMPORT_STAGES[2]!, maxTurns: 7, permissionMode: 'plan' },
+          session
+        );
+        const second = orchestrator.request(
+          { ...IMPORT_STAGES[4]!, agentType: 'local-reviewer' },
+          session
+        );
+        expect(first.projectDir).toBe(projectDir);
+        expect(second.projectDir).toBe(projectDir);
+        expect(first.resume).toBe(mode === 'checkpoint' ? 'sdk-resume-id' : undefined);
+        expect(second).not.toHaveProperty('resume');
+        expect((await adapter.execute(first)).status).toBe('success');
+        expect((await adapter.execute(second)).status).toBe('success');
+        expect(calls[0]?.options).toMatchObject({
+          cwd: projectDir,
+          agent: 'worker',
+          maxTurns: 7,
+          permissionMode: 'plan',
+          skills: [...(IMPORT_STAGES[2]!.skills ?? [])],
+        });
+        expect(calls[0]?.options?.resume).toBe(mode === 'checkpoint' ? 'sdk-resume-id' : undefined);
+        expect(calls[1]?.options).toMatchObject({
+          cwd: projectDir,
+          agent: 'local-reviewer',
+          mcpServers: IMPORT_STAGES[4]!.mcpServers,
+        });
+        expect(calls[1]?.options).not.toHaveProperty('resume');
+        expect(calls[0]?.prompt).toContain('Imported local issue content');
+        expect(calls[0]?.prompt).toContain('Continue local work');
+      } finally {
+        await adapter.dispose();
+        await orchestrator.dispose();
+      }
+    }
+  );
+});

--- a/tests/collector/CollectorAgent.test.ts
+++ b/tests/collector/CollectorAgent.test.ts
@@ -9,6 +9,7 @@ import {
   SessionStateError,
   MissingInformationError,
 } from '../../src/collector/index.js';
+import { MockExecutionAdapter } from '../../src/execution/index.js';
 import { resetScratchpad } from '../../src/scratchpad/index.js';
 
 describe('CollectorAgent', () => {
@@ -30,6 +31,24 @@ describe('CollectorAgent', () => {
     fs.rmSync(testDir, { recursive: true, force: true });
     resetScratchpad();
     resetCollectorAgent();
+  });
+
+  it('threads its configured absolute project directory into LLM extraction', async () => {
+    const adapter = new MockExecutionAdapter();
+    const collector = new CollectorAgent(
+      {
+        projectDir: path.relative(process.cwd(), testDir),
+        scratchpadBasePath: path.join(testDir, '.ad-sdlc', 'scratchpad'),
+        skipClarificationIfConfident: true,
+        confidenceThreshold: 0,
+      },
+      adapter
+    );
+    await collector.collectFromText('Build a task app. The system must support login.', {
+      projectName: 'target-project',
+    });
+    expect(adapter.calls.length).toBeGreaterThan(0);
+    expect(adapter.calls.every((request) => request.projectDir === testDir)).toBe(true);
   });
 
   describe('startSession', () => {

--- a/tests/collector/InvestigationEngine.test.ts
+++ b/tests/collector/InvestigationEngine.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { resolve } from 'node:path';
+import { MockExecutionAdapter } from '../../src/execution/index.js';
 import { InvestigationEngine } from '../../src/collector/InvestigationEngine.js';
 import { InvestigationTemplates } from '../../src/collector/InvestigationTemplates.js';
 import { InvestigationError } from '../../src/collector/errors.js';
@@ -98,6 +100,21 @@ describe('InvestigationEngine', () => {
   // ===========================================================================
   // initialize()
   // ===========================================================================
+
+  it('normalizes and forwards the configured target root for LLM questions', async () => {
+    const adapter = new MockExecutionAdapter();
+    const engine = new InvestigationEngine(
+      { enableLLMQuestions: true },
+      adapter,
+      undefined,
+      'target-project'
+    );
+    engine.initialize();
+    await engine.generateNextRound(createMockExtraction(), []);
+    expect(adapter.calls).toHaveLength(1);
+    expect(adapter.calls[0]?.projectDir).toBe(resolve('target-project'));
+    expect(adapter.calls[0]?.agentType).toBe('collector');
+  });
 
   describe('initialize()', () => {
     it('should set up 6 phases for thorough depth', () => {

--- a/tests/collector/LLMExtractor.test.ts
+++ b/tests/collector/LLMExtractor.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest';
+import { resolve } from 'node:path';
 import { LLMExtractor } from '../../src/collector/LLMExtractor.js';
 import { InformationExtractor, InputParser } from '../../src/collector/index.js';
 import { MockExecutionAdapter } from '../../src/execution/MockExecutionAdapter.js';
@@ -164,8 +165,9 @@ describe('LLMExtractor', () => {
       expect(adapter.calls).toHaveLength(1);
       const request = adapter.calls[0]!;
       expect(request.priorOutputs['scratchpadDir']).toBe('/scratch');
-      expect(request.priorOutputs['projectDir']).toBe('/project');
-      expect(request.projectDir).toBe('/project');
+      // Root-relative paths include the current drive when resolved on Windows.
+      expect(request.priorOutputs['projectDir']).toBe(resolve('/project'));
+      expect(request.projectDir).toBe(resolve('/project'));
     });
   });
 

--- a/tests/collector/LLMExtractor.test.ts
+++ b/tests/collector/LLMExtractor.test.ts
@@ -95,7 +95,7 @@ describe('LLMExtractor', () => {
   describe('extract', () => {
     it('should return structured extraction from LLM response', async () => {
       const adapter = adapterReturning(validLLMResponse());
-      const extractor = new LLMExtractor(adapter, fallback);
+      const extractor = new LLMExtractor(adapter, fallback, '', '/project');
       const input = parser.combineInputs([
         parser.parseText('Build a task management app with user login'),
       ]);
@@ -117,7 +117,7 @@ describe('LLMExtractor', () => {
 
     it('should convert ambiguities to clarification questions', async () => {
       const adapter = adapterReturning(validLLMResponse());
-      const extractor = new LLMExtractor(adapter, fallback);
+      const extractor = new LLMExtractor(adapter, fallback, '', '/project');
       const input = parser.combineInputs([parser.parseText('Some text')]);
 
       const result = await extractor.extract(input);
@@ -131,7 +131,7 @@ describe('LLMExtractor', () => {
 
     it('should calculate overall confidence from requirements', async () => {
       const adapter = adapterReturning(validLLMResponse());
-      const extractor = new LLMExtractor(adapter, fallback);
+      const extractor = new LLMExtractor(adapter, fallback, '', '/project');
       const input = parser.combineInputs([parser.parseText('Text')]);
 
       const result = await extractor.extract(input);
@@ -142,7 +142,7 @@ describe('LLMExtractor', () => {
 
     it('should pass project context to the prompt and forward it via priorOutputs', async () => {
       const adapter = adapterReturning(validLLMResponse());
-      const extractor = new LLMExtractor(adapter, fallback);
+      const extractor = new LLMExtractor(adapter, fallback, '', '/project');
       const input = parser.combineInputs([parser.parseText('Build a task app')]);
 
       await extractor.extract(input, 'Enterprise environment');
@@ -165,13 +165,14 @@ describe('LLMExtractor', () => {
       const request = adapter.calls[0]!;
       expect(request.priorOutputs['scratchpadDir']).toBe('/scratch');
       expect(request.priorOutputs['projectDir']).toBe('/project');
+      expect(request.projectDir).toBe('/project');
     });
   });
 
   describe('fallback behavior', () => {
     it('should fall back to keyword extractor when adapter returns failure', async () => {
       const adapter = new MockExecutionAdapter({ defaultResult: failedResult() });
-      const extractor = new LLMExtractor(adapter, fallback);
+      const extractor = new LLMExtractor(adapter, fallback, '', '/project');
       const input = parser.combineInputs([
         parser.parseText('The system must support user authentication.'),
       ]);
@@ -196,7 +197,7 @@ describe('LLMExtractor', () => {
         ],
       });
 
-      const extractor = new LLMExtractor(adapter, fallback);
+      const extractor = new LLMExtractor(adapter, fallback, '', '/project');
       const input = parser.combineInputs([parser.parseText('The system must support login.')]);
 
       const result = await extractor.extract(input);
@@ -207,7 +208,7 @@ describe('LLMExtractor', () => {
 
     it('should fall back when LLM output is not valid JSON', async () => {
       const adapter = adapterReturning('This is not JSON at all');
-      const extractor = new LLMExtractor(adapter, fallback);
+      const extractor = new LLMExtractor(adapter, fallback, '', '/project');
       const input = parser.combineInputs([
         parser.parseText('The system must handle user requests.'),
       ]);
@@ -226,7 +227,7 @@ describe('LLMExtractor', () => {
       });
 
       const adapter = adapterReturning(invalidJson);
-      const extractor = new LLMExtractor(adapter, fallback);
+      const extractor = new LLMExtractor(adapter, fallback, '', '/project');
       const input = parser.combineInputs([parser.parseText('The system should process data.')]);
 
       const result = await extractor.extract(input);
@@ -244,7 +245,7 @@ describe('LLMExtractor', () => {
           tokenUsage: { input: 0, output: 0, cache: 0 },
         },
       });
-      const extractor = new LLMExtractor(adapter, fallback);
+      const extractor = new LLMExtractor(adapter, fallback, '', '/project');
       const input = parser.combineInputs([parser.parseText('Some content for analysis.')]);
 
       const result = await extractor.extract(input);
@@ -260,7 +261,7 @@ describe('LLMExtractor', () => {
       const wrappedOutput = `Here is the analysis:\n\n\`\`\`json\n${jsonContent}\n\`\`\`\n\nLet me know if you need more details.`;
 
       const adapter = adapterReturning(wrappedOutput);
-      const extractor = new LLMExtractor(adapter, fallback);
+      const extractor = new LLMExtractor(adapter, fallback, '', '/project');
       const input = parser.combineInputs([parser.parseText('Build a task app')]);
 
       const result = await extractor.extract(input);
@@ -274,7 +275,7 @@ describe('LLMExtractor', () => {
       const wrappedOutput = `Based on my analysis:\n${jsonContent}\nEnd of analysis.`;
 
       const adapter = adapterReturning(wrappedOutput);
-      const extractor = new LLMExtractor(adapter, fallback);
+      const extractor = new LLMExtractor(adapter, fallback, '', '/project');
       const input = parser.combineInputs([parser.parseText('Build a task app')]);
 
       const result = await extractor.extract(input);
@@ -301,7 +302,7 @@ describe('LLMExtractor', () => {
       });
 
       const adapter = adapterReturning(response);
-      const extractor = new LLMExtractor(adapter, fallback);
+      const extractor = new LLMExtractor(adapter, fallback, '', '/project');
       const input = parser.combineInputs([parser.parseText('Secure app')]);
 
       const result = await extractor.extract(input);
@@ -326,7 +327,7 @@ describe('LLMExtractor', () => {
       });
 
       const adapter = adapterReturning(response);
-      const extractor = new LLMExtractor(adapter, fallback);
+      const extractor = new LLMExtractor(adapter, fallback, '', '/project');
       const input = parser.combineInputs([parser.parseText('Budget app')]);
 
       const result = await extractor.extract(input);
@@ -351,7 +352,7 @@ describe('LLMExtractor', () => {
       });
 
       const adapter = adapterReturning(response);
-      const extractor = new LLMExtractor(adapter, fallback);
+      const extractor = new LLMExtractor(adapter, fallback, '', '/project');
       const input = parser.combineInputs([parser.parseText('App')]);
 
       const result = await extractor.extract(input);
@@ -376,7 +377,7 @@ describe('LLMExtractor', () => {
       });
 
       const adapter = adapterReturning(response);
-      const extractor = new LLMExtractor(adapter, fallback);
+      const extractor = new LLMExtractor(adapter, fallback, '', '/project');
       const input = parser.combineInputs([parser.parseText('App')]);
 
       const result = await extractor.extract(input);
@@ -394,7 +395,7 @@ describe('LLMExtractor', () => {
       });
 
       const adapter = adapterReturning(response);
-      const extractor = new LLMExtractor(adapter, fallback);
+      const extractor = new LLMExtractor(adapter, fallback, '', '/project');
       const input = parser.combineInputs([parser.parseText('Empty')]);
 
       const result = await extractor.extract(input);
@@ -427,7 +428,7 @@ describe('LLMExtractor', () => {
       });
 
       const adapter = adapterReturning(response);
-      const extractor = new LLMExtractor(adapter, fallback);
+      const extractor = new LLMExtractor(adapter, fallback, '', '/project');
       const input = parser.combineInputs([parser.parseText('App')]);
 
       const result = await extractor.extract(input);
@@ -440,7 +441,7 @@ describe('LLMExtractor', () => {
 
     it('should return empty assumptions and dependencies arrays', async () => {
       const adapter = adapterReturning(validLLMResponse());
-      const extractor = new LLMExtractor(adapter, fallback);
+      const extractor = new LLMExtractor(adapter, fallback, '', '/project');
       const input = parser.combineInputs([parser.parseText('App')]);
 
       const result = await extractor.extract(input);
@@ -466,7 +467,7 @@ describe('LLMExtractor', () => {
       });
 
       const adapter = adapterReturning(response);
-      const extractor = new LLMExtractor(adapter, fallback);
+      const extractor = new LLMExtractor(adapter, fallback, '', '/project');
       const input = parser.combineInputs([parser.parseText('Clear app')]);
 
       const result = await extractor.extract(input);

--- a/tests/controller/WorkerPoolManager.test.ts
+++ b/tests/controller/WorkerPoolManager.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { rm } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
-import { join } from 'node:path';
+import { join, relative } from 'node:path';
 import { tmpdir } from 'node:os';
 import {
   WorkerPoolManager,
@@ -29,6 +29,7 @@ describe('WorkerPoolManager', () => {
     manager = new WorkerPoolManager({
       maxWorkers: 3,
       workOrdersPath: testDir,
+      projectRoot: relative(process.cwd(), testDir),
     });
   });
 
@@ -1042,6 +1043,17 @@ describe('WorkerPoolManager', () => {
       expect(result.tokenUsage).toEqual({ input: 0, output: 0, cache: 0 });
     });
 
+    it('requires project configuration before delegating SDK work', async () => {
+      const unconfigured = new WorkerPoolManager();
+      const adapter = new MockExecutionAdapter();
+      unconfigured.setExecutionAdapter(adapter);
+      const order = await manager.createWorkOrder(createIssueNode('ISS-042'));
+      await expect(unconfigured.executeWithAdapter(order)).rejects.toThrow(
+        'projectRoot must be configured'
+      );
+      expect(adapter.calls).toHaveLength(0);
+    });
+
     it('delegates to the configured ExecutionAdapter with the worker agent type', async () => {
       const adapter = new MockExecutionAdapter();
       manager.setExecutionAdapter(adapter);
@@ -1052,6 +1064,7 @@ describe('WorkerPoolManager', () => {
       expect(adapter.calls).toHaveLength(1);
       const recorded = adapter.calls[0];
       expect(recorded?.agentType).toBe('worker');
+      expect(recorded?.projectDir).toBe(testDir);
       expect(recorded?.workOrder).toBe('ISS-042');
       expect(recorded?.priorOutputs).toEqual({});
       expect(result.status).toBe('success');

--- a/tests/execution/MockExecutionAdapter.test.ts
+++ b/tests/execution/MockExecutionAdapter.test.ts
@@ -3,6 +3,7 @@ import { MockExecutionAdapter } from '../../src/execution/MockExecutionAdapter.j
 import type { StageExecutionRequest, StageExecutionResult } from '../../src/execution/types.js';
 
 const baseRequest: StageExecutionRequest = {
+  projectDir: '/tmp/mock-project',
   agentType: 'worker',
   workOrder: 'implement issue #1',
   priorOutputs: {},

--- a/tests/execution/SdkExecutionAdapter.test.ts
+++ b/tests/execution/SdkExecutionAdapter.test.ts
@@ -1,4 +1,8 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { installAgent, sdkResult, sdkStatus, sdkAssistant } from './fixtures/sdk.js';
 import {
   renderPrompt,
   SdkExecutionAdapter,
@@ -22,29 +26,39 @@ function fakeSdk(
   };
 }
 
+const projectDir = await mkdtemp(join(tmpdir(), 'sdk-adapter-'));
+beforeAll(async () => {
+  await installAgent(projectDir);
+});
+afterAll(async () => {
+  await rm(projectDir, { recursive: true, force: true });
+});
+
 const baseRequest: StageExecutionRequest = {
+  projectDir,
   agentType: 'worker',
   workOrder: 'implement issue #42',
   priorOutputs: {},
 };
 
 const successMessages: SdkMessage[] = [
-  { type: 'system', session_id: 's-123' },
-  { type: 'assistant' },
-  {
+  sdkStatus('s-123'),
+  sdkAssistant('s-123'),
+  sdkResult({
     type: 'result',
     session_id: 's-123',
     result: 'src/foo.ts: implementation file\nsrc/foo.test.ts: unit test',
     is_error: false,
     num_turns: 4,
     usage: { input_tokens: 100, output_tokens: 50, cache_read_input_tokens: 30 },
-  },
+  }),
 ];
 
 describe('SdkExecutionAdapter', () => {
   describe('renderPrompt', () => {
     it('embeds every priorOutputs entry verbatim under labeled headers', () => {
       const prompt = renderPrompt({
+        projectDir,
         agentType: 'worker',
         workOrder: 'WORK',
         priorOutputs: { srs: 'SRS-CONTENT', sds: 'SDS-CONTENT' },
@@ -93,7 +107,9 @@ describe('SdkExecutionAdapter', () => {
       expect(captured?.options?.mcpServers).toEqual({ github: { type: 'stdio', command: 'gh' } });
       expect(captured?.options?.maxTurns).toBe(7);
       expect(captured?.options?.resume).toBe('prior-session');
-      expect(captured?.options?.signal).toBe(controller.signal);
+      expect(captured?.options?.abortController).toBeInstanceOf(AbortController);
+      expect(captured?.options?.abortController?.signal).not.toBe(controller.signal);
+      expect(captured?.options).not.toHaveProperty('signal');
     });
 
     it('forwards skills only when provided and omits the option otherwise', async () => {
@@ -189,7 +205,7 @@ describe('SdkExecutionAdapter', () => {
       const adapter = new SdkExecutionAdapter({
         loader: async () =>
           fakeSdk([
-            { type: 'result', session_id: 's-err', result: 'something went wrong', is_error: true },
+            sdkResult({ session_id: 's-err', result: 'something went wrong', is_error: true }),
           ]),
       });
       const result = await adapter.execute(baseRequest);
@@ -198,9 +214,23 @@ describe('SdkExecutionAdapter', () => {
       expect(result.error?.code).toBe('EXEC-003');
     });
 
+    it('reduces official error-result variants with useful SDK error details', async () => {
+      const { result: _result, subtype: _subtype, ...message } = sdkResult();
+      const failure: import('@anthropic-ai/claude-agent-sdk').SDKResultError = {
+        ...message,
+        subtype: 'error_max_turns',
+        is_error: true,
+        errors: ['Stage exceeded its turn limit'],
+      };
+      const adapter = new SdkExecutionAdapter({ loader: async () => fakeSdk([failure]) });
+      const result = await adapter.execute(baseRequest);
+      expect(result.status).toBe('failed');
+      expect(result.error?.message).toContain('Stage exceeded its turn limit');
+    });
+
     it('returns failed when no result message is emitted', async () => {
       const adapter = new SdkExecutionAdapter({
-        loader: async () => fakeSdk([{ type: 'system', session_id: 's-empty' }]),
+        loader: async () => fakeSdk([sdkStatus('s-empty')]),
       });
       const result = await adapter.execute(baseRequest);
       expect(result.status).toBe('failed');
@@ -250,5 +280,119 @@ describe('SdkExecutionAdapter', () => {
       await adapter.execute(baseRequest);
       expect(calls).toBe(1);
     });
+  });
+});
+
+describe('official SDK options and cancellation bridge', () => {
+  it('copies readonly skills and MCP args while preserving other server settings', async () => {
+    const skills = Object.freeze(['coding']);
+    const args = Object.freeze(['--offline']);
+    const stdio = {
+      type: 'stdio',
+      command: 'node',
+      args,
+      env: { MODE: 'offline' },
+      timeout: 2500,
+      alwaysLoad: true,
+    } as const;
+    const http = {
+      type: 'http',
+      url: 'https://example.invalid/mcp',
+      headers: { Authorization: 'test' },
+    } as const;
+    let captured: SdkQueryOptions | undefined;
+    const adapter = new SdkExecutionAdapter({
+      loader: async () =>
+        fakeSdk(successMessages, {
+          onCall: (q) => {
+            captured = q;
+          },
+        }),
+    });
+    await adapter.execute({ ...baseRequest, skills, mcpServers: { stdio, http } });
+    expect(captured?.options?.skills).toEqual(skills);
+    expect(captured?.options?.skills).not.toBe(skills);
+    expect(captured?.options?.mcpServers).toEqual({ stdio, http });
+    const server = captured?.options?.mcpServers?.stdio;
+    expect(server && 'args' in server ? server.args : undefined).not.toBe(args);
+    expect(captured?.options).not.toHaveProperty('resume');
+    expect(captured?.options).not.toHaveProperty('abortController');
+  });
+
+  it.each(['success', 'failure', 'aborted'] as const)(
+    'removes the bridge listener after %s',
+    async (outcome) => {
+      const controller = new AbortController();
+      const add = vi.spyOn(controller.signal, 'addEventListener');
+      const remove = vi.spyOn(controller.signal, 'removeEventListener');
+      let sdkController: AbortController | undefined;
+      const reason = new Error('cancel this stage');
+      const adapter = new SdkExecutionAdapter({
+        loader: async () => ({
+          async *query({ options }) {
+            sdkController = options?.abortController;
+            expect(sdkController).toBeInstanceOf(AbortController);
+            if (outcome === 'aborted') {
+              controller.abort(reason);
+              expect(sdkController?.signal.aborted).toBe(true);
+              expect(sdkController?.signal.reason).toBe(reason);
+              throw reason;
+            }
+            if (outcome === 'failure') throw new Error('SDK failure');
+            yield sdkResult();
+          },
+        }),
+      });
+      const result = await adapter.execute({ ...baseRequest, signal: controller.signal });
+      expect(result.status).toBe(outcome === 'failure' ? 'failed' : outcome);
+      expect(remove).toHaveBeenCalledWith('abort', add.mock.calls[0]?.[1]);
+      if (outcome !== 'aborted') {
+        controller.abort();
+        expect(sdkController?.signal.aborted).toBe(false);
+      }
+    }
+  );
+
+  it('does not load or query the SDK for pre-aborted requests', async () => {
+    const controller = new AbortController();
+    controller.abort('before execution');
+    const loader = vi.fn(async () => fakeSdk(successMessages));
+    const result = await new SdkExecutionAdapter({ loader }).execute({
+      ...baseRequest,
+      signal: controller.signal,
+      resume: 'prior-session',
+    });
+    expect(result.status).toBe('aborted');
+    expect(result.sessionId).toBe('prior-session');
+    expect(loader).not.toHaveBeenCalled();
+  });
+
+  it('does not query when aborted during SDK loading', async () => {
+    const controller = new AbortController();
+    const query = vi.fn(() => fakeSdk(successMessages).query({ prompt: '' }));
+    const adapter = new SdkExecutionAdapter({
+      loader: async () => {
+        controller.abort('loading');
+        return { query };
+      },
+    });
+    expect((await adapter.execute({ ...baseRequest, signal: controller.signal })).status).toBe(
+      'aborted'
+    );
+    expect(query).not.toHaveBeenCalled();
+  });
+
+  it('serializes loader errors and removes its abort listener', async () => {
+    const controller = new AbortController();
+    const remove = vi.spyOn(controller.signal, 'removeEventListener');
+    const adapter = new SdkExecutionAdapter({
+      loader: async () => {
+        throw new Error('load failed');
+      },
+    });
+    const result = await adapter.execute({ ...baseRequest, signal: controller.signal });
+    expect(result.status).toBe('failed');
+    expect(result.error?.message).toContain('load failed');
+    expect(remove).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/execution/fixtures/projectIsolation.ts
+++ b/tests/execution/fixtures/projectIsolation.ts
@@ -1,6 +1,6 @@
 // Executed by Node in project A, outside Vitest. Only the SDK boundary is injected.
 import assert from 'node:assert/strict';
-import { chmod, mkdir, readFile, writeFile } from 'node:fs/promises';
+import { chmod, mkdir, readFile, realpath, writeFile } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 import type { Options } from '@anthropic-ai/claude-agent-sdk';
@@ -159,6 +159,11 @@ assert.equal(
 );
 assert.equal(process.cwd(), projectA);
 await adapter.dispose();
+// Report the same canonical spelling as the parent, including Windows 8.3 aliases.
 process.stdout.write(
-  JSON.stringify({ cwd: process.cwd(), queries: captured.length, isolation: 'passed' })
+  JSON.stringify({
+    cwd: await realpath(process.cwd()),
+    queries: captured.length,
+    isolation: 'passed',
+  })
 );

--- a/tests/execution/fixtures/projectIsolation.ts
+++ b/tests/execution/fixtures/projectIsolation.ts
@@ -1,0 +1,164 @@
+// Executed by Node in project A, outside Vitest. Only the SDK boundary is injected.
+import assert from 'node:assert/strict';
+import { chmod, mkdir, readFile, writeFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import type { Options } from '@anthropic-ai/claude-agent-sdk';
+import { SdkExecutionAdapter, type SdkLike } from '../../../src/execution/SdkExecutionAdapter.js';
+import { agentMarkdown, installAgent, sdkResult } from './sdk.js';
+
+const projectA = process.cwd();
+const projectB = process.argv[2];
+assert.ok(projectB);
+const captured: Options[] = [];
+let concurrent = false;
+let arrivals = 0;
+let release: () => void = () => {};
+const rendezvous = new Promise<void>((resolve) => {
+  release = resolve;
+});
+const sdk: SdkLike = {
+  async *query({ options }) {
+    assert.ok(options?.cwd);
+    assert.ok(options.agent);
+    const definition = options.agents?.[options.agent];
+    assert.ok(definition);
+    captured.push(options);
+    if (concurrent) {
+      if (++arrivals === 2) release();
+      await rendezvous;
+    }
+    const artifact = `${concurrent ? 'concurrent' : 'sequential'}-${options.agent}.txt`;
+    await writeFile(join(options.cwd, artifact), definition.prompt);
+    yield sdkResult({ result: `${artifact}: sentinel` });
+  },
+};
+const adapter = new SdkExecutionAdapter({ loader: async () => sdk });
+const request = (projectDir: string, agentType = 'worker') => ({
+  projectDir,
+  agentType,
+  workOrder: 'Write a sentinel',
+  priorOutputs: {},
+});
+
+// Conflicting definitions and two named stages must select B's actual personas.
+await installAgent(
+  projectA,
+  'worker',
+  agentMarkdown('worker', 'A customized worker', ['Read'], 'haiku')
+);
+await installAgent(
+  projectB,
+  'worker',
+  agentMarkdown('worker', 'B customized worker', ['Write'], 'opus')
+);
+await installAgent(
+  projectB,
+  'reviewer',
+  agentMarkdown('reviewer', 'B customized reviewer', ['Read', 'Grep'], 'sonnet')
+);
+for (const [name, prompt, tools, model] of [
+  ['worker', 'B customized worker\n', ['Write'], 'opus'],
+  ['reviewer', 'B customized reviewer\n', ['Read', 'Grep'], 'sonnet'],
+] as const) {
+  const result = await adapter.execute(request(projectB, name));
+  assert.equal(result.status, 'success', result.error?.message ?? 'Unexpected result');
+  const options = captured.at(-1);
+  assert.equal(options?.cwd, projectB);
+  assert.equal(options.agent, name);
+  assert.deepEqual(options.agents, {
+    [name]: {
+      description: `Customized ${name} for this project`,
+      prompt,
+      tools: [...tools],
+      model,
+    },
+  });
+  assert.deepEqual(options.settingSources, ['user', 'project', 'local']);
+  assert.equal(await readFile(join(projectB, `sequential-${name}.txt`), 'utf8'), prompt);
+  assert.equal(existsSync(join(projectA, `sequential-${name}.txt`)), false);
+}
+
+// A valid same-named definition in A must never rescue a bad definition in B.
+const invalidDefinitions = [
+  ['missing', undefined, 'ENOENT'],
+  ['malformed', '---\nname: [\n---\nPrompt', 'parse'],
+  ['empty-file', '', 'frontmatter'],
+  ['empty-prompt', agentMarkdown('empty-prompt', ' \n\t'), 'Prompt body'],
+  ['mismatch', agentMarkdown('different-name'), 'frontmatter.name'],
+  ['bad-tools', agentMarkdown('bad-tools', 'Prompt', ['NotATool']), 'tools'],
+  ['bad-model', agentMarkdown('bad-model', 'Prompt', ['Read'], 'invalid-model'), 'model'],
+  [
+    'bad-description',
+    agentMarkdown('bad-description').replace('Customized bad-description for this project', '   '),
+    'description',
+  ],
+] as const;
+for (const [name, content, detail] of invalidDefinitions) {
+  await installAgent(projectA, name);
+  if (content !== undefined) await installAgent(projectB, name, content);
+  const before = captured.length;
+  const result = await adapter.execute(request(projectB, name));
+  assert.equal(result.status, 'failed');
+  assert.equal(captured.length, before);
+  assert.ok(result.error?.message.includes(name));
+  assert.ok(result.error?.message.includes(join(projectB, '.claude', 'agents', `${name}.md`)));
+  assert.ok(
+    result.error?.message.toLowerCase().includes(detail.toLowerCase()),
+    result.error?.message ?? 'Unexpected result'
+  );
+}
+// Reading a directory as a definition fails consistently, including privileged CI.
+await installAgent(projectA, 'unreadable');
+await mkdir(join(projectB, '.claude', 'agents', 'unreadable.md'));
+let before = captured.length;
+assert.equal((await adapter.execute(request(projectB, 'unreadable'))).status, 'failed');
+assert.equal(captured.length, before);
+// Also cover a real read-permission failure where the OS enforces mode bits.
+if (process.getuid?.() !== 0 && process.platform !== 'win32') {
+  await installAgent(projectA, 'restricted');
+  const path = await installAgent(projectB, 'restricted');
+  await chmod(path, 0);
+  try {
+    const result = await adapter.execute(request(projectB, 'restricted'));
+    assert.equal(result.status, 'failed');
+    assert.ok(result.error?.message.includes(path));
+    assert.ok(result.error?.message.includes('EACCES'));
+    assert.equal(captured.length, before);
+  } finally {
+    await chmod(path, 0o600);
+  }
+}
+
+// Overlapping requests share the adapter while retaining separate definitions/cwds.
+concurrent = true;
+before = captured.length;
+const results = await Promise.all([
+  adapter.execute(request(projectA)),
+  adapter.execute(request(projectB)),
+]);
+assert.deepEqual(
+  results.map((r) => r.status),
+  ['success', 'success']
+);
+assert.equal(arrivals, 2);
+const optionsA = captured.slice(before).find((o) => o.cwd === projectA);
+const optionsB = captured.slice(before).find((o) => o.cwd === projectB);
+assert.ok(optionsA && optionsB);
+assert.notEqual(optionsA, optionsB);
+assert.notEqual(optionsA.agents, optionsB.agents);
+assert.equal(optionsA.agents?.worker?.prompt, 'A customized worker\n');
+assert.equal(optionsB.agents?.worker?.prompt, 'B customized worker\n');
+assert.equal(
+  await readFile(join(projectA, 'concurrent-worker.txt'), 'utf8'),
+  'A customized worker\n'
+);
+assert.equal(
+  await readFile(join(projectB, 'concurrent-worker.txt'), 'utf8'),
+  'B customized worker\n'
+);
+assert.equal(process.cwd(), projectA);
+await adapter.dispose();
+process.stdout.write(
+  JSON.stringify({ cwd: process.cwd(), queries: captured.length, isolation: 'passed' })
+);

--- a/tests/execution/fixtures/sdk.ts
+++ b/tests/execution/fixtures/sdk.ts
@@ -1,0 +1,97 @@
+import type {
+  SDKAssistantMessage,
+  SDKResultSuccess,
+  SDKStatusMessage,
+} from '@anthropic-ai/claude-agent-sdk';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+export function sdkResult(
+  overrides: Partial<Omit<SDKResultSuccess, 'usage'>> & {
+    usage?: Partial<SDKResultSuccess['usage']>;
+  } = {}
+): SDKResultSuccess {
+  return {
+    type: 'result',
+    subtype: 'success',
+    session_id: 'sdk-session',
+    uuid: '00000000-0000-4000-8000-000000000001',
+    duration_ms: 0,
+    duration_api_ms: 0,
+    is_error: false,
+    num_turns: 1,
+    result: 'ok',
+    stop_reason: 'end_turn',
+    total_cost_usd: 0,
+    modelUsage: {},
+    permission_denials: [],
+    ...overrides,
+    usage: {
+      input_tokens: 0,
+      output_tokens: 0,
+      cache_read_input_tokens: 0,
+      cache_creation_input_tokens: 0,
+      cache_creation: { ephemeral_1h_input_tokens: 0, ephemeral_5m_input_tokens: 0 },
+      server_tool_use: { web_search_requests: 0, web_fetch_requests: 0 },
+      service_tier: 'standard',
+      inference_geo: 'not_available',
+      iterations: [],
+      speed: 'standard',
+      ...overrides.usage,
+    },
+  };
+}
+
+export function sdkStatus(sessionId: string): SDKStatusMessage {
+  return {
+    type: 'system',
+    subtype: 'status',
+    status: null,
+    session_id: sessionId,
+    uuid: '00000000-0000-4000-8000-000000000002',
+  };
+}
+
+export function sdkAssistant(sessionId: string): SDKAssistantMessage {
+  return {
+    type: 'assistant',
+    session_id: sessionId,
+    uuid: '00000000-0000-4000-8000-000000000003',
+    parent_tool_use_id: null,
+    message: {
+      id: 'msg-offline',
+      type: 'message',
+      role: 'assistant',
+      model: 'sonnet',
+      content: [],
+      stop_reason: 'end_turn',
+      stop_sequence: null,
+      usage: sdkResult().usage,
+      container: null,
+      context_management: null,
+      diagnostics: null,
+      stop_details: null,
+    },
+  };
+}
+
+export function agentMarkdown(
+  name = 'worker',
+  prompt = 'Project-specific worker prompt.',
+  tools = ['Read', 'Write'],
+  model = 'sonnet'
+): string {
+  return `---\nname: ${name}\ndescription: Customized ${name} for this project\ntools: [${tools.join(', ')}]\nmodel: ${model}\n---\n${prompt}\n`;
+}
+
+export async function installAgent(
+  projectDir: string,
+  name = 'worker',
+  content = agentMarkdown(name)
+): Promise<string> {
+  const directory = join(projectDir, '.claude', 'agents');
+  await mkdir(directory, { recursive: true });
+  const path = join(directory, `${name}.md`);
+  await writeFile(path, content);
+  return path;
+}

--- a/tests/execution/hooks.test.ts
+++ b/tests/execution/hooks.test.ts
@@ -1,9 +1,12 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { installAgent, sdkResult, sdkStatus } from './fixtures/sdk.js';
 import {
   buildHookPipeline,
   type ArtifactCaptureEntry,
   type ArtifactSink,
-  type SdkHookCallback,
   type SdkToolUseEvent,
 } from '../../src/execution/hooks.js';
 import {
@@ -15,6 +18,14 @@ import {
 import { MockExecutionAdapter } from '../../src/execution/MockExecutionAdapter.js';
 import type { StageExecutionRequest } from '../../src/execution/types.js';
 
+const projectDir = await mkdtemp(join(tmpdir(), 'sdk-hooks-'));
+beforeAll(async () => {
+  await installAgent(projectDir);
+});
+afterAll(async () => {
+  await rm(projectDir, { recursive: true, force: true });
+});
+
 /**
  * Pull the PostToolUse(Edit|Write) callback out of a built pipeline so each
  * test can drive it directly. Keeps assertions focused on capture behaviour
@@ -23,13 +34,30 @@ import type { StageExecutionRequest } from '../../src/execution/types.js';
 function getPostToolUseCallback(
   sink: ArtifactSink,
   options?: { now?: () => Date }
-): SdkHookCallback {
+): (
+  event: Pick<SdkToolUseEvent, 'tool_name' | 'tool_input'> &
+    Partial<Pick<SdkToolUseEvent, 'session_id'>>
+) => ReturnType<import('@anthropic-ai/claude-agent-sdk').HookCallback> {
   const pipeline = buildHookPipeline(sink, options);
   expect(pipeline.PostToolUse).toBeDefined();
   expect(pipeline.PostToolUse).toHaveLength(1);
-  const entry = pipeline.PostToolUse![0];
+  const entry = pipeline.PostToolUse![0]!;
   expect(entry.matcher).toBe('Edit|Write');
-  return entry.callback;
+  const callback = entry.hooks[0]!;
+  return (event) =>
+    callback(
+      {
+        hook_event_name: 'PostToolUse',
+        session_id: 'test-session',
+        transcript_path: '/tmp/transcript',
+        cwd: projectDir,
+        tool_response: {},
+        tool_use_id: 'tool-1',
+        ...event,
+      },
+      'tool-1',
+      { signal: new AbortController().signal }
+    );
 }
 
 function fakeSink(): ArtifactSink & { entries: ArtifactCaptureEntry[] } {
@@ -53,7 +81,7 @@ describe('buildHookPipeline', () => {
       const sink = fakeSink();
       const pipeline = buildHookPipeline(sink);
       expect(pipeline.PostToolUse).toHaveLength(1);
-      expect(pipeline.PostToolUse![0].matcher).toBe('Edit|Write');
+      expect(pipeline.PostToolUse![0]!.matcher).toBe('Edit|Write');
       // PreToolUse / Stop are TODO stubs — deliberately omitted from the
       // pipeline so the SDK skips them entirely.
       expect(pipeline.PreToolUse).toBeUndefined();
@@ -168,18 +196,19 @@ describe('SdkExecutionAdapter — hooks wiring', () => {
   }
 
   const successMessages: SdkMessage[] = [
-    { type: 'system', session_id: 'sess-A' },
-    {
+    sdkStatus('sess-A'),
+    sdkResult({
       type: 'result',
       session_id: 'sess-A',
       result: 'ok',
       is_error: false,
       num_turns: 1,
       usage: { input_tokens: 1, output_tokens: 1 },
-    },
+    }),
   ];
 
   const baseRequest: StageExecutionRequest = {
+    projectDir,
     agentType: 'worker',
     workOrder: 'do thing',
     priorOutputs: {},
@@ -240,6 +269,7 @@ describe('integration — MockExecutionAdapter + hook callback', () => {
     // tool call. We drive the hook callback ourselves to keep the test
     // independent of the real SDK.
     const result = await adapter.execute({
+      projectDir,
       agentType: 'worker',
       workOrder: 'implement integration',
       priorOutputs: { upstream: 'spec' },
@@ -257,7 +287,7 @@ describe('integration — MockExecutionAdapter + hook callback', () => {
 
     // MockExecutionAdapter recorded the stage call as expected.
     expect(adapter.calls).toHaveLength(1);
-    expect(adapter.calls[0].priorOutputs).toEqual({ upstream: 'spec' });
+    expect(adapter.calls[0]!.priorOutputs).toEqual({ upstream: 'spec' });
     expect(result.status).toBe('success');
 
     // The hook captured both tool events with the expected shape.
@@ -275,5 +305,62 @@ describe('integration — MockExecutionAdapter + hook callback', () => {
         sessionId: 'mock-int',
       },
     ]);
+  });
+});
+
+describe('SDK invokes official hook entries', () => {
+  it.each([false, true])('captures artifacts and propagates sink rejection=%s', async (reject) => {
+    const sink = fakeSink();
+    const error = new Error('artifact storage unavailable');
+    if (reject)
+      sink.recordArtifact = async () => {
+        throw error;
+      };
+    const outputs: unknown[] = [];
+    const adapter = new SdkExecutionAdapter({
+      hooks: buildHookPipeline(sink),
+      loader: async () => ({
+        async *query({ options }) {
+          for (const entry of options?.hooks?.PostToolUse ?? []) {
+            expect(entry).not.toHaveProperty('callback');
+            for (const callback of entry.hooks) {
+              outputs.push(
+                await callback(
+                  {
+                    hook_event_name: 'PostToolUse',
+                    tool_name: 'Write',
+                    tool_input: { file_path: 'sentinel.txt' },
+                    tool_response: {},
+                    tool_use_id: 'tool-offline',
+                    session_id: 'hook-session',
+                    transcript_path: join(projectDir, 'transcript.jsonl'),
+                    cwd: options?.cwd ?? '',
+                  },
+                  'tool-offline',
+                  { signal: new AbortController().signal }
+                )
+              );
+            }
+          }
+          yield sdkResult();
+        },
+      }),
+    });
+    const result = await adapter.execute({
+      projectDir,
+      agentType: 'worker',
+      workOrder: 'capture',
+      priorOutputs: {},
+    });
+    if (reject) {
+      expect(result.status).toBe('failed');
+      expect(result.error?.message).toContain(error.message);
+    } else {
+      expect(result.status).toBe('success');
+      expect(outputs).toEqual([{}]);
+      expect(sink.entries).toEqual([
+        expect.objectContaining({ filePath: 'sentinel.txt', sessionId: 'hook-session' }),
+      ]);
+    }
   });
 });

--- a/tests/execution/projectIsolation.test.ts
+++ b/tests/execution/projectIsolation.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { mkdtemp, mkdir, realpath, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const exec = promisify(execFile);
+let directory: string;
+beforeEach(async () => {
+  directory = await mkdtemp(join(tmpdir(), 'sdk-project-isolation-'));
+});
+afterEach(async () => {
+  await rm(directory, { recursive: true, force: true });
+});
+
+describe('offline SDK boundary project isolation (not live persona verification)', () => {
+  it('launches in A, selects and writes under B, rejects bad definitions, and isolates concurrent A/B requests', async () => {
+    const cwd = process.cwd();
+    const projectA = join(directory, 'A');
+    const projectB = join(directory, 'B');
+    await Promise.all([mkdir(projectA), mkdir(projectB)]);
+    const { stdout } = await exec(
+      process.execPath,
+      [
+        '--import',
+        import.meta.resolve('tsx'),
+        fileURLToPath(new URL('./fixtures/projectIsolation.ts', import.meta.url)),
+        projectB,
+      ],
+      { cwd: projectA, timeout: 20_000 }
+    );
+    expect(JSON.parse(stdout)).toEqual({
+      cwd: await realpath(projectA),
+      queries: 4,
+      isolation: 'passed',
+    });
+    expect(process.cwd()).toBe(cwd);
+  });
+});

--- a/tests/execution/resolveProjectAgent.test.ts
+++ b/tests/execution/resolveProjectAgent.test.ts
@@ -1,0 +1,185 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { resolveProjectAgent, SdkExecutionAdapter } from '../../src/execution/index.js';
+import { agentMarkdown, installAgent } from './fixtures/sdk.js';
+
+let projectDir: string;
+beforeEach(async () => {
+  projectDir = await mkdtemp(join(tmpdir(), 'resolve-agent-'));
+});
+afterEach(async () => {
+  await rm(projectDir, { recursive: true, force: true });
+});
+
+describe('real project agent resolver', () => {
+  it('preserves supported SDK metadata and customized CRLF prompts without consulting the registry', async () => {
+    const metadata = `skills: [custom-skill]
+disallowedTools: [Bash]
+maxTurns: 8
+permissionMode: acceptEdits
+memory: project
+effort: high
+background: false
+initialPrompt: Read the project guide.
+criticalSystemReminder_EXPERIMENTAL: Respect project conventions.
+observer: custom-observer
+observerMessage: Review changes.
+mcpServers:
+  - project-docs
+  - command:
+      command: node
+      args: [server.js]
+      env: {MODE: offline}
+      timeout: 5000
+      alwaysLoad: true
+  - remote:
+      type: http
+      url: https://example.invalid/mcp
+      headers: {X-Test: offline}
+      tools: [{name: lookup, permission_policy: always_ask, org_max_permission: ask}]
+`;
+    await installAgent(
+      projectDir,
+      'worker',
+      agentMarkdown()
+        .replace('model: sonnet\n', `model: sonnet\n${metadata}`)
+        .replace(/\n/g, '\r\n')
+    );
+    const definition = await resolveProjectAgent(projectDir, 'worker');
+    expect(definition).toMatchObject({
+      prompt: 'Project-specific worker prompt.\n',
+      description: 'Customized worker for this project',
+      tools: ['Read', 'Write'],
+      model: 'sonnet',
+      skills: ['custom-skill'],
+      disallowedTools: ['Bash'],
+      maxTurns: 8,
+      permissionMode: 'acceptEdits',
+      memory: 'project',
+      effort: 'high',
+      background: false,
+      initialPrompt: 'Read the project guide.',
+      criticalSystemReminder_EXPERIMENTAL: 'Respect project conventions.',
+      observer: 'custom-observer',
+      observerMessage: 'Review changes.',
+      mcpServers: [
+        'project-docs',
+        {
+          command: {
+            command: 'node',
+            args: ['server.js'],
+            env: { MODE: 'offline' },
+            timeout: 5000,
+            alwaysLoad: true,
+          },
+        },
+        {
+          remote: {
+            type: 'http',
+            url: 'https://example.invalid/mcp',
+            headers: { 'X-Test': 'offline' },
+            tools: [{ name: 'lookup', permission_policy: 'always_ask', org_max_permission: 'ask' }],
+          },
+        },
+      ],
+    });
+    expect(definition).not.toHaveProperty('name');
+  });
+
+  it.each(['description', 'tools', 'model'] as const)(
+    'rejects missing required %s metadata',
+    async (field) => {
+      const content = agentMarkdown()
+        .split('\n')
+        .filter((line) => !line.startsWith(`${field}:`))
+        .join('\n');
+      const path = await installAgent(projectDir, 'worker', content);
+      const loader = vi.fn();
+      const result = await new SdkExecutionAdapter({ loader }).execute({
+        projectDir,
+        agentType: 'worker',
+        workOrder: '',
+        priorOutputs: {},
+      });
+      expect(result.status).toBe('failed');
+      expect(result.error?.message).toContain(path);
+      expect(result.error?.message).toContain(field);
+      expect(loader).not.toHaveBeenCalled();
+    }
+  );
+
+  it('rereads user edits on subsequent executions', async () => {
+    const path = await installAgent(projectDir);
+    expect((await resolveProjectAgent(projectDir, 'worker')).prompt).toContain('Project-specific');
+    await writeFile(path, agentMarkdown('worker', 'New customization', ['Grep'], 'haiku'));
+    expect(await resolveProjectAgent(projectDir, 'worker')).toMatchObject({
+      prompt: 'New customization\n',
+      tools: ['Grep'],
+      model: 'haiku',
+    });
+  });
+
+  it.each([
+    '../worker',
+    '/worker',
+    'worker/other',
+    'worker\\other',
+    'Worker',
+    '',
+    'worker.md',
+    'worker\0',
+  ])('rejects unsafe agent name %j before query', async (agentType) => {
+    const loader = vi.fn();
+    const result = await new SdkExecutionAdapter({ loader }).execute({
+      projectDir,
+      agentType,
+      workOrder: '',
+      priorOutputs: {},
+    });
+    expect(result.status).toBe('failed');
+    expect(result.error?.message).toContain('Invalid agentType');
+    expect(loader).not.toHaveBeenCalled();
+  });
+
+  it('rejects non-absolute, nonexistent, and non-directory project roots before query', async () => {
+    const file = join(projectDir, 'file');
+    await writeFile(file, 'not a directory');
+    const loader = vi.fn();
+    const adapter = new SdkExecutionAdapter({ loader });
+    for (const invalid of [
+      '',
+      '.',
+      'relative/project',
+      '/bad\0path',
+      join(projectDir, 'missing'),
+      file,
+    ]) {
+      const result = await adapter.execute({
+        projectDir: invalid,
+        agentType: 'worker',
+        workOrder: '',
+        priorOutputs: {},
+      });
+      expect(result.status).toBe('failed');
+      expect(result.error?.message).toContain('worker');
+      expect(result.error?.message).toMatch(/absolute directory|ENOENT|not a directory/);
+    }
+    expect(loader).not.toHaveBeenCalled();
+  });
+
+  it('removes abort listeners when definition validation fails', async () => {
+    const controller = new AbortController();
+    const remove = vi.spyOn(controller.signal, 'removeEventListener');
+    const result = await new SdkExecutionAdapter().execute({
+      projectDir,
+      agentType: 'missing',
+      workOrder: '',
+      priorOutputs: {},
+      signal: controller.signal,
+    });
+    expect(result.status).toBe('failed');
+    expect(remove).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/worker/WorkerAgent.codeGen.test.ts
+++ b/tests/worker/WorkerAgent.codeGen.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { rm, mkdir } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
-import { join } from 'node:path';
+import { join, relative } from 'node:path';
 import { tmpdir } from 'node:os';
 import { WorkerAgent, CodeGenerationError } from '../../src/worker/index.js';
 import type { WorkOrder, CodeContext, ExecutionContext } from '../../src/worker/index.js';
@@ -97,7 +97,7 @@ describe('WorkerAgent - generateCode with ExecutionAdapter delegation', () => {
     await mkdir(testDir, { recursive: true });
 
     agent = new WorkerAgent({
-      projectRoot: testDir,
+      projectRoot: relative(process.cwd(), testDir),
       resultsPath: '.ad-sdlc/scratchpad/progress',
     });
   });
@@ -130,6 +130,7 @@ describe('WorkerAgent - generateCode with ExecutionAdapter delegation', () => {
       expect(adapter.calls).toHaveLength(1);
       const request = adapter.calls[0] as StageExecutionRequest;
       expect(request.agentType).toBe('worker');
+      expect(request.projectDir).toBe(testDir);
       expect(request.workOrder).toContain('ISS-001');
     });
 

--- a/tsconfig.sdk-contract.json
+++ b/tsconfig.sdk-contract.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "src/execution/**/*.ts",
+    "tests/execution/**/*.ts",
+    "tests/ad-sdlc-orchestrator/projectContext.test.ts"
+  ],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary

A pipeline launched from project A could use A's working directory and a default persona even when project B was selected. Each SDK call now validates the requested agent definition installed in B and explicitly supplies B's absolute `cwd`, the main-thread `agent`, and its programmatic `agents` definition.

## Related Issue

Closes #947

## Type of Change

- [x] Bug fix
- [x] Breaking API contract change
- [x] Documentation update

## Changes Made

- Require `StageExecutionRequest.projectDir` and normalize roots at session/configuration boundaries. Propagate the selected project through orchestration, checkpoint/session resume, worker code generation, worker pools, and the collector's additional SDK request builders.
- Resolve `<projectDir>/.claude/agents/<agentType>.md`, validating the name before path construction and requiring valid metadata, matching frontmatter name, and a nonempty prompt. Preserve supported SDK metadata and project customizations without ambient registry discovery, checksum enforcement, or definition caching. Definition failures return agent/path/validation details before `query()`.
- Replace the handwritten SDK invocation contract with official `Options`, `AgentDefinition`, and message types, retaining a literal lazy import and a narrow injectable query boundary. Enable `settingSources: ['user', 'project', 'local']` and use the existing local-agent substitutions through the same resolver.
- Preserve prompts, prior outputs, stage settings, and one-shot resume IDs. Copy readonly skills/MCP arguments, use official hook callback arrays and JSON results, and bridge request abort signals to per-execution SDK controllers with listener removal in `finally`.
- Document resolution and failure behavior. Add offline child-process A/B isolation, concurrent artifact writes, validation, local-mode, resume, hook, cancellation-bridge, and request-propagation coverage.

## Testing

- [x] Unit tests added/updated
- [x] Offline integration tests added/updated
- [ ] Live persona verification (separate acceptance scenario)

### Test Results

Validated against Claude Agent SDK **0.3.258**, from `develop@e91975f`:

| Check | Result |
| --- | --- |
| `npm run build` | Passed; asset check validated 40 assets |
| `npm run lint` | Passed; 0 errors, 457 warnings |
| `npm run test:sdk-contract` | Passed; invokes `tsc -p tsconfig.sdk-contract.json` for production code and SDK-boundary fixtures |
| Focused Vitest command below | 543 tests passed across 19 files |

```sh
npx vitest run tests/execution tests/ad-sdlc-orchestrator \
  tests/worker/WorkerAgent.codeGen.test.ts \
  tests/controller/WorkerPoolManager.test.ts \
  tests/collector/LLMExtractor.test.ts \
  tests/collector/InvestigationEngine.test.ts \
  tests/collector/CollectorAgent.test.ts
```

The isolation test starts an independent Node process in temporary project A, executes requests targeting B with conflicting same-named definitions, and checks sentinel artifacts written relative to actual SDK options. It also overlaps A/B requests and verifies that the process directory stays unchanged. Only the SDK boundary is injected; the project resolver is real.

## Checklist

- [x] Followed project style and reviewed the changes
- [x] Updated relevant API comments and execution documentation
- [x] Added regression coverage for the issue's acceptance criteria
- [x] Build, lint, SDK type-contract check, and focused tests pass locally

## Additional Notes

`StageExecutionRequest.projectDir` is now required. SDK worker-pool execution requires `WorkerPoolConfig.projectRoot`; collector SDK execution requires explicit project context. Exported SDK/hook type names are retained where practical, but callers and doubles must use the official SDK shapes.

This PR includes the abort-signal bridge needed by the official SDK contract. Comprehensive active-query disposal, timeout/retry cleanup, and preservation of partial usage on cancellation remain under **#948**; this PR does not resolve that issue. All validation here is offline and does not establish live Import persona behavior.
