### PR TITLE
fix(execution): await SDK cleanup before cancellation and retries

### DIFF
--- a/src/ad-sdlc-orchestrator/AdsdlcOrchestratorAgent.ts
+++ b/src/ad-sdlc-orchestrator/AdsdlcOrchestratorAgent.ts
@@ -8,6 +8,9 @@
  * Implements IAgent interface for unified agent instantiation through AgentFactory.
  */
 
+import { AppError } from '../errors/AppError.js';
+import { OperationAbortedError } from '../error-handler/errors.js';
+import { DEFAULT_CLEANUP_GRACE_MS } from '../execution/cleanup.js';
 import { randomUUID } from 'node:crypto';
 import * as fs from 'node:fs/promises';
 import * as os from 'node:os';
@@ -103,6 +106,8 @@ export class AdsdlcOrchestratorAgent implements IAgent {
   private stageTimers = new Map<StageName, ReturnType<typeof setTimeout>>();
   private abortController: AbortController | null = null;
   private executionAdapter: ExecutionAdapter | null = null;
+  private adapterDisposal: Promise<void> | null = null;
+  private disposal: Promise<void> | null = null;
   private stageVerifier: StageVerifierAgent | null = null;
   private stageVerifierInitialized = false;
   private verificationResults: StageVerificationResult[] = [];
@@ -197,24 +202,31 @@ export class AdsdlcOrchestratorAgent implements IAgent {
    * Dispose of the orchestrator and release resources
    * @returns A promise that resolves when all resources are released
    */
-  async dispose(): Promise<void> {
-    for (const timer of this.stageTimers.values()) {
-      clearTimeout(timer);
-    }
-    this.stageTimers.clear();
-    if (this.abortController) {
-      this.abortController.abort();
-      this.abortController = null;
-    }
-    await this.disposeExecutionAdapter();
-    if (this.stageVerifier !== null && this.stageVerifierInitialized) {
-      await this.stageVerifier.dispose();
-    }
-    this.stageVerifier = null;
-    this.stageVerifierInitialized = false;
-    this.verificationResults = [];
-    this.session = null;
-    this.initialized = false;
+  dispose(): Promise<void> {
+    if (this.disposal !== null) return this.disposal;
+    // Install the admission barrier before any await or verifier cleanup.
+    const adapterDisposal = this.disposeExecutionAdapter();
+    this.disposal = Promise.resolve().then(async (): Promise<void> => {
+      const results = await Promise.allSettled([
+        adapterDisposal,
+        this.stageVerifier !== null && this.stageVerifierInitialized
+          ? this.stageVerifier.dispose()
+          : Promise.resolve(),
+      ]);
+      this.stageVerifier = null;
+      this.stageVerifierInitialized = false;
+      this.verificationResults = [];
+      this.initialized = false;
+      const failures = results.filter((result) => result.status === 'rejected');
+      if (failures.length > 0)
+        throw new AggregateError(
+          failures.map((result): unknown => result.reason),
+          'Orchestrator disposal failed'
+        );
+      this.session = null;
+    });
+    this.abortController?.abort(new OperationAbortedError(undefined, 'Orchestrator disposed'));
+    return this.disposal;
   }
 
   /**
@@ -231,6 +243,12 @@ export class AdsdlcOrchestratorAgent implements IAgent {
    * @returns The newly created orchestrator session
    */
   async startSession(request: PipelineRequest): Promise<OrchestratorSession> {
+    this.assertNotDisposed();
+    if (this.adapterDisposal !== null) {
+      await this.adapterDisposal;
+      this.assertNotDisposed();
+      this.adapterDisposal = null;
+    }
     if (this.session?.status === 'running') {
       throw new PipelineInProgressError(this.session.sessionId);
     }
@@ -358,6 +376,7 @@ export class AdsdlcOrchestratorAgent implements IAgent {
     const startTime = Date.now();
     this.session = { ...session, status: 'running' };
     this.verificationResults = [];
+    let pipelineError: unknown;
 
     try {
       const stages = this.getStagesForMode(session.mode);
@@ -448,13 +467,14 @@ export class AdsdlcOrchestratorAgent implements IAgent {
 
       return result;
     } catch (error) {
+      pipelineError = error;
       if (error instanceof PipelineFailedError) {
         throw error;
       }
       this.session = { ...this.session, status: 'failed' };
       throw error;
     } finally {
-      await this.disposeExecutionAdapter();
+      await this.disposeAfterPipeline(pipelineError);
     }
   }
 
@@ -613,12 +633,13 @@ export class AdsdlcOrchestratorAgent implements IAgent {
       haltOnVerificationFailure:
         this.config.vnv.rigor === 'strict' && this.config.vnv.haltOnVerificationFailure,
       checkpointManager: this.checkpointManager,
+      getCleanupGraceMs: () => this.executionAdapter?.cleanupGraceMs ?? DEFAULT_CLEANUP_GRACE_MS,
       getTimeoutForStage: (name) => this.getTimeoutForStage(name),
       createArtifactValidator: (projectDir) => this.createArtifactValidator(projectDir),
       invokeAgent: (stage, session, signal) => this.invokeAgent(stage, session, signal),
       verifyStage: (stage, result, session) => this.verifyStage(stage, result, session),
       checkApprovalGate: (stage, prior) => this.checkApprovalGate(stage, prior),
-      sleep: (ms) => this.sleep(ms),
+      sleep: (ms, signal) => this.sleep(ms, signal),
     };
   }
 
@@ -656,6 +677,14 @@ export class AdsdlcOrchestratorAgent implements IAgent {
     session: OrchestratorSession,
     signal?: AbortSignal
   ): Promise<string> {
+    if (this.adapterDisposal !== null || this.disposal !== null) {
+      throw new AppError('EXEC-002', 'ExecutionAdapter pipeline shutdown has started', {
+        category: 'fatal',
+      });
+    }
+    if (signal?.aborted === true || this.abortController?.signal.aborted === true) {
+      throw new OperationAbortedError(stage.name, 'Pipeline cancelled');
+    }
     this.executionAdapter ??= this.createExecutionAdapter(session);
     const request = this.buildStageExecutionRequest(stage, session, signal);
     const result = await this.executionAdapter.execute(request);
@@ -685,23 +714,42 @@ export class AdsdlcOrchestratorAgent implements IAgent {
     return new SdkExecutionAdapter({ hooks });
   }
 
+  private assertNotDisposed(): void {
+    if (this.disposal !== null)
+      throw new AppError('EXEC-002', 'Orchestrator disposed', { category: 'fatal' });
+  }
+
+  private async disposeAfterPipeline(pipelineError: unknown): Promise<void> {
+    try {
+      await this.disposeExecutionAdapter();
+    } catch (cleanupError) {
+      getLogger().error(
+        'ExecutionAdapter disposal failed',
+        cleanupError instanceof Error ? cleanupError : undefined,
+        {
+          agent: 'AdsdlcOrchestratorAgent',
+          error: cleanupError instanceof AppError ? cleanupError.toJSON() : String(cleanupError),
+        }
+      );
+      if (pipelineError === undefined) throw cleanupError;
+      // Preserve primary identity while exposing additional disposal failures to callers.
+      if (pipelineError instanceof Error)
+        Object.assign(pipelineError, { cleanupErrors: [cleanupError] });
+    }
+  }
+
   /**
    * Dispose the pipeline-scoped adapter without allowing cleanup failures to
    * replace the pipeline's real outcome.
    */
-  private async disposeExecutionAdapter(): Promise<void> {
+  private disposeExecutionAdapter(): Promise<void> {
+    if (this.adapterDisposal !== null) return this.adapterDisposal;
     const adapter = this.executionAdapter;
-    this.executionAdapter = null;
-    if (adapter === null) return;
-
-    try {
-      await adapter.dispose();
-    } catch (error: unknown) {
-      getLogger().debug('ExecutionAdapter dispose failed', {
-        agent: 'AdsdlcOrchestratorAgent',
-        error: error instanceof Error ? error.message : String(error),
-      });
-    }
+    this.adapterDisposal = Promise.resolve().then(async () => {
+      await adapter?.dispose();
+      this.executionAdapter = null;
+    });
+    return this.adapterDisposal;
   }
 
   /** Create the verifier used by the live scheduler. Tests may override it. */
@@ -822,8 +870,21 @@ export class AdsdlcOrchestratorAgent implements IAgent {
    */
   protected toStageOutput(stage: PipelineStageDefinition, result: StageExecutionResult): string {
     if (result.status !== 'success') {
-      const message = result.error?.message ?? `ExecutionAdapter status=${result.status}`;
-      throw new Error(`ExecutionAdapter failed: ${message}`);
+      const error =
+        result.error !== undefined
+          ? AppError.fromJSON(result.error)
+          : new AppError(
+              result.status === 'aborted' ? 'EXEC-005' : 'EXEC-003',
+              `ExecutionAdapter status=${result.status}`,
+              { category: result.status === 'aborted' ? 'fatal' : 'transient' }
+            );
+      throw error.withContext({
+        stage: stage.name,
+        status: result.status,
+        sessionId: result.sessionId,
+        toolCallCount: result.toolCallCount,
+        tokenUsage: result.tokenUsage,
+      });
     }
     return JSON.stringify({
       stage: stage.name,
@@ -1119,10 +1180,23 @@ export class AdsdlcOrchestratorAgent implements IAgent {
    *
    * Protected to allow test subclasses to override for fast execution.
    * @param ms - The number of milliseconds to sleep
+   * @param signal - Pipeline cancellation, including timer and listener removal
    * @returns A promise that resolves after the specified delay
    */
-  protected sleep(ms: number): Promise<void> {
-    return new Promise((resolve) => setTimeout(resolve, ms));
+  protected sleep(ms: number, signal?: AbortSignal): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+      const abort = (): void => {
+        clearTimeout(timer);
+        signal?.removeEventListener('abort', abort);
+        reject(new OperationAbortedError(undefined, 'Pipeline cancelled during backoff'));
+      };
+      const timer = setTimeout(() => {
+        signal?.removeEventListener('abort', abort);
+        resolve();
+      }, ms);
+      signal?.addEventListener('abort', abort, { once: true });
+      if (signal?.aborted === true) abort();
+    });
   }
 }
 

--- a/src/ad-sdlc-orchestrator/StageScheduler.ts
+++ b/src/ad-sdlc-orchestrator/StageScheduler.ts
@@ -16,6 +16,19 @@
 import { getLogger } from '../logging/index.js';
 import { RetryExecutor } from '../error-handler/RetryExecutor.js';
 import type { StageVerificationResult } from '../stage-verifier/types.js';
+import { AppError } from '../errors/AppError.js';
+import {
+  MaxRetriesExceededError,
+  NonRetryableError,
+  OperationAbortedError,
+} from '../error-handler/errors.js';
+import {
+  DEFAULT_CLEANUP_GRACE_MS,
+  SCHEDULER_CLEANUP_MARGIN_MS,
+  ExecutionCleanupError,
+  isExecutionCleanupError,
+  withinCleanupGrace,
+} from '../execution/cleanup.js';
 import { StageTimeoutError } from './errors.js';
 import type { ArtifactValidator } from './ArtifactValidator.js';
 import type { PipelineCheckpointManager } from './PipelineCheckpointManager.js';
@@ -48,6 +61,8 @@ export interface SchedulerHost {
   readonly haltOnVerificationFailure: boolean;
   readonly checkpointManager: PipelineCheckpointManager | null;
   getTimeoutForStage(name: StageName): number;
+  /** Current adapter budget; fallback includes a margin for diagnostic propagation. */
+  getCleanupGraceMs?(): number;
   createArtifactValidator(projectDir: string): ArtifactValidator;
   invokeAgent(
     stage: PipelineStageDefinition,
@@ -63,7 +78,7 @@ export interface SchedulerHost {
     stage: PipelineStageDefinition,
     priorResults: readonly StageResult[]
   ): Promise<ApprovalDecision>;
-  sleep(ms: number): Promise<void>;
+  sleep(ms: number, signal?: AbortSignal): Promise<void>;
 }
 
 /**
@@ -188,59 +203,111 @@ async function saveCheckpoint(
  * @param session
  * @param timeoutMs
  */
-function runStageAgentWithTimeout(
+async function runStageAgentWithTimeout(
   host: SchedulerHost,
   stage: PipelineStageDefinition,
   session: OrchestratorSession,
   timeoutMs: number
 ): Promise<string> {
-  return new Promise<string>((resolve, reject) => {
-    const attemptController = new AbortController();
-    const pipelineSignal = host.abortController?.signal;
-    let settled = false;
-
-    const cleanup = (): void => {
-      clearTimeout(timer);
-      host.stageTimers.delete(stage.name);
-      pipelineSignal?.removeEventListener('abort', abortFromPipeline);
-    };
-    const settle = (operation: () => void): void => {
-      if (settled) return;
-      settled = true;
-      cleanup();
-      operation();
-    };
-    const abortFromPipeline = (): void => {
-      attemptController.abort(pipelineSignal?.reason);
-    };
-    const timer = setTimeout(() => {
-      const error = new StageTimeoutError(stage.name, timeoutMs);
-      attemptController.abort(error);
-      settle(() => {
-        reject(error);
-      });
-    }, timeoutMs);
-
-    host.stageTimers.set(stage.name, timer);
-    if (pipelineSignal?.aborted === true) {
-      abortFromPipeline();
-    } else {
-      pipelineSignal?.addEventListener('abort', abortFromPipeline, { once: true });
-    }
-
-    host
-      .invokeAgent(stage, session, attemptController.signal)
-      .then((output) => {
-        settle(() => {
-          resolve(output);
-        });
-      })
-      .catch((error: unknown) => {
-        settle(() => {
-          reject(error instanceof Error ? error : new Error(String(error)));
-        });
-      });
+  const attemptController = new AbortController();
+  const pipelineSignal = host.abortController?.signal;
+  let cancellation: Error | undefined;
+  let notifyCancellation!: () => void;
+  const cancelled = new Promise<void>((resolve) => {
+    notifyCancellation = resolve;
   });
+  const cancel = (reason: unknown): void => {
+    if (cancellation !== undefined) return;
+    cancellation =
+      reason instanceof Error ? reason : new OperationAbortedError(stage.name, String(reason));
+    attemptController.abort(reason);
+    notifyCancellation();
+  };
+  const abortFromPipeline = (): void => {
+    cancel(pipelineSignal?.reason);
+  };
+  const timer = setTimeout(() => {
+    cancel(new StageTimeoutError(stage.name, timeoutMs));
+  }, timeoutMs);
+  host.stageTimers.set(stage.name, timer);
+  pipelineSignal?.addEventListener('abort', abortFromPipeline, { once: true });
+  if (pipelineSignal?.aborted === true) abortFromPipeline();
+
+  // Keep and observe the invocation even if cancellation wins the race.
+  const invocation = Promise.resolve()
+    .then(async () => {
+      if (attemptController.signal.aborted)
+        throw cancellation ?? new OperationAbortedError(stage.name);
+      return host.invokeAgent(stage, session, attemptController.signal);
+    })
+    .then(
+      (value) => ({ ok: true as const, value }),
+      (error: unknown) => ({ ok: false as const, error })
+    );
+  try {
+    const first = await Promise.race([invocation, cancelled.then(() => undefined)]);
+    if (cancellation !== undefined) {
+      const graceMs =
+        (host.getCleanupGraceMs?.() ?? DEFAULT_CLEANUP_GRACE_MS) + SCHEDULER_CLEANUP_MARGIN_MS;
+      const outcome = await withinCleanupGrace(
+        invocation,
+        graceMs,
+        () =>
+          new ExecutionCleanupError(
+            `Stage "${stage.name}" cleanup grace period exceeded; invocation may still be active`,
+            cancellation,
+            { stage: stage.name, phase: 'scheduler', cleanupGraceMs: graceMs, unresolved: true }
+          )
+      );
+      if (!outcome.ok && isExecutionCleanupError(outcome.error)) throw outcome.error;
+      // A late success cannot override cancellation. Retain partial execution data on timeouts.
+      if (!outcome.ok) {
+        if (cancellation instanceof StageTimeoutError && outcome.error !== cancellation)
+          cancellation.cause = outcome.error;
+        else if (outcome.error instanceof AppError) throw outcome.error;
+      }
+      throw cancellation;
+    }
+    if (first === undefined) throw new OperationAbortedError(stage.name);
+    if (!first.ok) throw first.error;
+    return first.value;
+  } finally {
+    clearTimeout(timer);
+    host.stageTimers.delete(stage.name);
+    pipelineSignal?.removeEventListener('abort', abortFromPipeline);
+  }
+}
+
+/** A host override may ignore the signal; still prevent retries and observe late rejection.
+ * @param host - Supplies the production or overridden delay
+ * @param ms - Backoff duration capped by the stage deadline
+ * @param signal - Pipeline cancellation
+ */
+async function waitForRetry(host: SchedulerHost, ms: number, signal?: AbortSignal): Promise<void> {
+  if (signal?.aborted === true)
+    throw new OperationAbortedError(undefined, 'Aborted before backoff');
+  let abort!: () => void;
+  const cancelled = new Promise<never>((_resolve, reject) => {
+    abort = (): void => {
+      reject(new OperationAbortedError(undefined, 'Aborted during backoff'));
+    };
+    signal?.addEventListener('abort', abort, { once: true });
+  });
+  try {
+    await Promise.race([host.sleep(ms, signal), cancelled]);
+  } finally {
+    signal?.removeEventListener('abort', abort);
+  }
+}
+
+/** Unwrap retry bookkeeping while keeping the execution's code, cause and partial usage.
+ * @param error - RetryExecutor's final error, possibly wrapped
+ * @returns The underlying execution error when available
+ */
+function originalExecutionError(error: Error | undefined): Error | undefined {
+  if (error instanceof NonRetryableError) return error.originalError;
+  if (error instanceof MaxRetriesExceededError) return error.lastError ?? error;
+  return error;
 }
 
 /**
@@ -279,7 +346,6 @@ export async function executeStageWithRetry(
   const maxRetries = host.maxRetries;
   const stageTimeoutMs = host.getTimeoutForStage(stage.name);
   const stageDeadline = Date.now() + stageTimeoutMs;
-  let lastError: string | null = null;
   let attempt = 0;
   let attemptStartTime = Date.now();
   const retryExecutor = new RetryExecutor({
@@ -292,26 +358,39 @@ export async function executeStageWithRetry(
   });
   const execution = await retryExecutor.executeWithResult(
     async () => {
-      attempt++;
+      if (host.abortController?.signal.aborted === true)
+        throw new OperationAbortedError(stage.name, 'Pipeline cancelled');
       attemptStartTime = Date.now();
       const remainingMs = stageDeadline - Date.now();
       if (remainingMs <= 0) {
-        lastError = `Stage '${stage.name}' budget exhausted before attempt ${String(attempt)}`;
-        throw new Error(lastError);
+        throw new Error(
+          `Stage '${stage.name}' budget exhausted before attempt ${String(attempt + 1)}`
+        );
       }
       const attemptTimeoutMs = Math.min(remainingMs, stageTimeoutMs);
 
+      attempt++;
       const output = await runStageAgentWithTimeout(host, stage, session, attemptTimeoutMs);
       return output;
     },
     {
       operationName: `pipeline-stage:${stage.name}`,
-      errorClassifier: () => 'retryable',
-      shouldRetry: (error) => {
-        lastError = error.message;
-        return Date.now() < stageDeadline;
+      ...(host.abortController !== null ? { signal: host.abortController.signal } : {}),
+      errorClassifier: (error) => {
+        if (isExecutionCleanupError(error)) {
+          // Stop queued DAG work even if an injected invocation ignored cancellation.
+          host.abortController?.abort(error);
+          return 'non-retryable';
+        }
+        return (error instanceof AppError && error.category === 'fatal') ||
+          host.abortController?.signal.aborted === true
+          ? 'non-retryable'
+          : 'retryable';
       },
-      delay: (ms) => host.sleep(ms),
+      shouldRetry: () =>
+        host.abortController?.signal.aborted !== true && Date.now() < stageDeadline,
+      delay: (ms, signal) =>
+        waitForRetry(host, Math.max(0, Math.min(ms, stageDeadline - Date.now())), signal),
     }
   );
 
@@ -328,15 +407,23 @@ export async function executeStageWithRetry(
     };
   }
 
+  const error = originalExecutionError(execution.error);
+  const details =
+    error instanceof AppError
+      ? error
+      : error instanceof StageTimeoutError && error.cause instanceof AppError
+        ? error.cause.withContext({ timeoutMs: error.timeoutMs })
+        : undefined;
   return {
     name: stage.name,
     agentType: stage.agentType,
     status: 'failed',
-    durationMs: 0,
+    durationMs: execution.totalDurationMs,
     output: '',
     artifacts: [],
-    error: lastError,
-    retryCount: maxRetries,
+    error: error?.message ?? 'Stage execution failed',
+    ...(details !== undefined ? { errorDetails: details.toJSON() } : {}),
+    retryCount: Math.max(0, attempt - 1),
   };
 }
 

--- a/src/ad-sdlc-orchestrator/errors.ts
+++ b/src/ad-sdlc-orchestrator/errors.ts
@@ -78,6 +78,8 @@ export class StageExecutionError extends OrchestratorError {
  * Error thrown when a stage times out
  */
 export class StageTimeoutError extends OrchestratorError {
+  /** Adapter failure details observed while joining timed-out execution cleanup. */
+  override cause?: unknown;
   public readonly stage: StageName;
   public readonly timeoutMs: number;
 

--- a/src/ad-sdlc-orchestrator/types.ts
+++ b/src/ad-sdlc-orchestrator/types.ts
@@ -5,6 +5,7 @@
  * Enhancement, and Import modes. Based on SDS-001 CMP-025 specification.
  */
 
+import type { SerializedError } from '../errors/types.js';
 import type { McpServerConfig } from '../execution/types.js';
 import type { StageVerificationResult } from '../stage-verifier/types.js';
 import { DEFAULT_VNV_CONFIG, type VnvConfig } from '../vnv/types.js';
@@ -164,6 +165,8 @@ export interface StageResult {
   readonly artifacts: readonly string[];
   /** Error message if failed */
   readonly error: string | null;
+  /** Machine-readable execution failure, including partial usage and cause. */
+  readonly errorDetails?: SerializedError;
   /** Number of retry attempts */
   readonly retryCount: number;
   /** Warning messages (e.g., stub backend detection) */

--- a/src/execution/README.md
+++ b/src/execution/README.md
@@ -105,8 +105,9 @@ The SDK runtime loads lazily through a literal, typed dynamic `import()`.
 Production options use the installed SDK's `Options` and `AgentDefinition`;
 query input is derived from `Parameters<typeof query>[0]` and messages use
 `SDKMessage`. The package must be installed for TypeScript checks. Offline
-tests inject only `query()` returning an async iterable, without implementing
-unrelated `Query` methods.
+tests inject `query()` returning `AsyncIterable<SDKMessage> &
+Pick<Query, 'close' | 'return'>`. The lifecycle methods use the official `Query`
+method types; doubles need not implement unrelated streaming control APIs.
 
 Before loading or calling the SDK, the adapter validates `agentType` and reads
 `<projectDir>/.claude/agents/<agentType>.md`. The resolver reuses AD-SDLC's
@@ -153,11 +154,112 @@ The adapter maps `StageExecutionRequest` → SDK options:
 | `hooks` (constructor) | `options.hooks`                   | Optional hook pipeline; see below                    |
 
 Readonly request skills and MCP stdio arguments are copied into mutable SDK
-arrays; other server settings are retained. Optional fields are omitted when
-unprovided. Pre-aborted requests do not load or query the SDK. The abort bridge
-removes its listener in `finally` on success, failure, and cancellation.
-Comprehensive active-query disposal and timeout/retry cleanup remain tracked
-separately in #948.
+arrays; other server settings are retained. Optional request fields are omitted
+when unprovided. Every execution receives a distinct owned `abortController`,
+including requests without a caller signal. A caller's abort reason (Error or
+non-Error) is forwarded unchanged; the adapter never aborts the caller's
+controller or another execution's controller.
+
+#### Completion and disposal
+
+Executions enter the active registry before agent resolution or SDK loading.
+Pre-aborted requests skip both. Cancellation and disposal are rechecked after
+each awaited setup step and before `query()`, so deferred setup cannot start a
+late query. Setup rejection remains observed even if cancellation has already
+returned a cleanup failure.
+
+For success, ordinary SDK failure, cancellation, timeout, and disposal, completion
+means **both the original Query lifecycle and message consumption have settled**,
+or the result explicitly reports `EXEC-004` cleanup failure. Cancellation aborts
+the owned controller promptly. Finalization initiates `query.close()` and awaits
+`query.return(undefined)` plus consumption. The same finalization is shared by
+execution and disposal. An SDK failure remains `failed` even when teardown aborts
+its controller; caller/pipeline cancellation and disposal are `aborted`. Cleanup
+failure adds a fatal diagnostic to those outcomes; it is never successful
+cancellation and must not be interpreted as proof that the query stopped.
+
+SDK 0.3.258's `close(): void` initiates shutdown. Its outer Query's asynchronous
+`return(undefined)` awaits cleanup. `query[Symbol.asyncIterator]()` returns a
+separate inner generator, so finishing/returning that iterator alone is
+insufficient. `interrupt()` is a streaming control request, not whole-query
+finalization. The adapter uses no private transport state or invented public
+process-wait API.
+
+`dispose()` stops admission synchronously, aborts **all** owned executions,
+including those without caller signals or still in setup, and joins their cleanup
+boundaries. Concurrent/repeated calls share the same promise and outcome. A
+failure in one execution does not skip cleanup of siblings. Failures are aggregated
+in a fatal `ExecutionCleanupError`. After successful disposal, no adapter-owned
+forwarding listeners, timers, active queries, or pending setups remain. Subsequent
+`execute()` rejects with `EXEC-002`.
+
+#### Cleanup grace and failure policy
+
+`SdkExecutionAdapterOptions.cleanupGraceMs` is a positive finite value, defaulting
+to **5,000 ms**, independent of the stage execution budget. SDK 0.3.258 bounds its
+internal process-exit wait at 2,000 ms; the default allows another 3,000 ms for
+other cleanup and message-consumption settlement. The `resolveAgent` and `loader`
+options allow deferred setup tests without a live SDK call.
+
+If close/return throws or setup/cleanup/consumption fails to settle within that
+grace, the adapter reports `EXEC-004`, category `fatal`, with the original reason
+as cause and cleanup details in context. `context.unresolved` identifies pending
+operations at the observation boundary; a settled but rejected cleanup still does
+not establish successful shutdown. Any observed cleanup failure blocks further
+execution through that adapter. An unresolved execution stays registered until
+its actual settlement; late fulfillment/rejection remains observed. Forwarding
+listeners and grace timers are removed at the bounded completion boundary, but
+unresolved SDK work is never silently erased. Even if that work later settles,
+the failed adapter remains disabled and repeated disposal retains its failure.
+
+The production scheduler retains every invocation. On timeout it preserves the
+`StageTimeoutError` and controller abort reason, then waits for invocation cleanup
+before surfacing the timeout. Pipeline cancellation follows the same ordering and
+cannot turn a late SDK success into a completed stage. Its fallback budget is the
+current adapter's `cleanupGraceMs` **plus 1,000 ms** (6,000 ms by default), allowing
+adapter diagnostics to reach the scheduler before a fallback error can mask them.
+An invocation that ignores cancellation produces the same fatal cleanup code with
+`context.phase: 'scheduler'`; adapter diagnostics use `'adapter'`.
+
+Fatal cleanup errors explicitly map to RetryExecutor's `non-retryable` category
+(the error contracts use different category vocabularies). They stop queued DAG
+work and never launch a replacement on the affected adapter. Normal retryable
+failures finish cleanup before the existing exponential backoff and next attempt.
+The stage deadline still covers all attempts and backoff; a timeout normally
+exhausts that total budget. Cancellation is checked before attempts/backoff, during
+backoff, and immediately before invocation after any delay. Production backoff
+cancellation clears its timer.
+
+The orchestrator retains its adapter while disposal is pending and blocks late
+stage invocations from creating a replacement. A new session can reset that
+barrier only after successful prior pipeline disposal. Public orchestrator
+disposal also joins concurrent callers. Stage `errorDetails` preserves serialized
+code, category, context, cause and partial usage through `AppError.fromJSON`;
+first-attempt fatal failures retain meaningful diagnostics and zero retries.
+Disposal failures are logged at ERROR and exposed on the primary thrown pipeline
+error's `cleanupErrors`; without a primary error, disposal failure rejects the
+pipeline itself.
+
+These boundaries are **SDK-observable cleanup**, not independent confirmation that
+every operating-system process exited. The SDK's own process-exit wait is bounded.
+Process-level confirmation belongs to the later live acceptance lane; the offline
+regressions do not establish lingering or terminated live SDK processes.
+
+#### Partial usage and outcomes
+
+All results retain the latest observed session ID (or requested resume ID), turn
+count, and available usage. Before a result message, assistant `message.usage` is
+accumulated once per distinct assistant message ID, using its latest observation.
+Repeated IDs replace that contribution and add no turns or duplicate usage. Aggregate result usage, including SDK error
+results, is authoritative and replaces the assistant fallback; it is never added
+to that same usage again. The turn count retains the maximum of observed assistant
+turns and result `num_turns`. `TokenUsage.cache` includes cache-read **plus**
+cache-creation input tokens. With no observed usage, counters remain zero.
+
+Thrown SDK failures and aborted executions retain these partial observations.
+They are available data, not comprehensive billing metrics. Successful artifact
+extraction is unchanged; artifact manifests and expanded metrics remain separate
+work.
 
 #### Example: production wiring
 
@@ -323,6 +425,24 @@ It also checks validation failures and overlapping A/B requests without mocking
 the resolver. `projectContext.test.ts` exercises the real orchestrator local-mode
 substitutions and resumed requests through the SDK adapter.
 
+`SdkExecutionAdapter.lifecycle.test.ts` uses a controlled asynchronous Query with
+an official owned controller, separate inner iterator, synchronous close initiation,
+deferred outer cleanup, and a sentinel artifact writer. Fake timers cover cleanup
+timeouts and late rejections. Production integration coverage lives in
+[`sdkLifecycle.test.ts`](../../tests/ad-sdlc-orchestrator/sdkLifecycle.test.ts), so
+it runs in the focused orchestrator lane (no separate integration configuration
+is needed). It verifies timeout cleanup, early-failure retry ordering, exhausted
+budgets, cancellation during backoff, fatal first-attempt diagnostics, queued DAG
+work, and concurrent orchestrator disposal.
+
+```bash
+npm run test:sdk-contract
+npx vitest run tests/execution tests/ad-sdlc-orchestrator
+npm run build
+npm run lint
+npm run docs:check
+```
+
 These tests verify the SDK boundary contract. They do not verify live model
 persona behavior; live Import acceptance is a separate scenario.
 
@@ -431,7 +551,6 @@ Checklist when implementing a new adapter:
 
 ## What this module does NOT do (yet)
 
-- Comprehensive query disposal and timeout/retry cleanup — see issue #948.
 - Telemetry bridge (`Stop` finalisation) — Phase 3.
 - Bedrock / Vertex endpoint selection — Phase 4.
 
@@ -442,3 +561,4 @@ Checklist when implementing a new adapter:
 - AD-07 (`#791` / PR #811): hook pipeline integration
 - AD-08 (`#792`): this README
 - AD-09 (`#793`): pilot stage cutover
+- #948: owned execution lifecycle, bounded cleanup, disposal and retry barriers

--- a/src/execution/SdkExecutionAdapter.ts
+++ b/src/execution/SdkExecutionAdapter.ts
@@ -1,11 +1,24 @@
 /**
  * SDK execution with an explicitly selected target-project agent and cwd.
  * Runtime loading stays lazy; production query input and messages use the
- * installed SDK types. Tests inject only query(), without unrelated Query APIs.
+ * installed SDK types. Tests inject query() and its supported lifecycle,
+ * without unrelated Query APIs.
  * @packageDocumentation
  */
 
-import type { Options, SDKMessage, SDKResultMessage, query } from '@anthropic-ai/claude-agent-sdk';
+import type {
+  Options,
+  Query,
+  SDKMessage,
+  SDKResultMessage,
+  query,
+} from '@anthropic-ai/claude-agent-sdk';
+import {
+  DEFAULT_CLEANUP_GRACE_MS,
+  ExecutionCleanupError,
+  isExecutionCleanupError,
+  withinCleanupGrace,
+} from './cleanup.js';
 import { resolveProjectAgent } from './resolveProjectAgent.js';
 import { AppError } from '../errors/AppError.js';
 import { ErrorSeverity } from '../errors/types.js';
@@ -24,9 +37,12 @@ export type SdkQueryOptions = Parameters<typeof query>[0];
 /** Official SDK messages; adapters narrow discriminated variants explicitly. */
 export type SdkMessage = SDKMessage;
 
-/** Injectable query boundary: offline doubles only implement async iteration. */
+/** Only the supported lifecycle and message iteration surface is required of doubles. */
+export type SdkQuery = AsyncIterable<SDKMessage> & Pick<Query, 'close' | 'return'>;
+
+/** Injectable query boundary using official lifecycle method types. */
 export interface SdkLike {
-  query(opts: SdkQueryOptions): AsyncIterable<SdkMessage>;
+  query(opts: SdkQueryOptions): SdkQuery;
 }
 
 /** Lazy runtime loader, replaceable by an offline query double. */
@@ -35,6 +51,10 @@ export type SdkLoader = () => Promise<SdkLike>;
 const defaultLoader: SdkLoader = async () => import('@anthropic-ai/claude-agent-sdk');
 
 export interface SdkExecutionAdapterOptions {
+  /** Finite cleanup budget, independent of stage execution time (default: 5000ms). */
+  readonly cleanupGraceMs?: number;
+  /** Override target-project resolution for controlled setup tests. */
+  readonly resolveAgent?: typeof resolveProjectAgent;
   /** Override the SDK loader for tests / alternative endpoints. */
   readonly loader?: SdkLoader;
   /**
@@ -45,114 +65,327 @@ export interface SdkExecutionAdapterOptions {
   readonly hooks?: HookPipeline;
 }
 
-/**
- *
- */
+interface OwnedExecution {
+  readonly controller: AbortController;
+  readonly cancelled: Promise<void>;
+  cancel(reason: unknown): void;
+  work: Promise<void>;
+  readonly completion: Promise<void>;
+  query?: SdkQuery;
+  cleanup?: Promise<AppError | undefined>;
+  cleanupSettled: boolean;
+  executionSettled: boolean;
+  outcome: 'running' | 'success' | 'failed' | 'aborted';
+  reason?: unknown;
+  sessionId: string;
+  toolCallCount: number;
+  tokenUsage: TokenUsage;
+  resultText?: string;
+}
+
+/** Each registered execution owns setup, consumption, and one shared cleanup operation. */
 export class SdkExecutionAdapter implements ExecutionAdapter {
+  readonly cleanupGraceMs: number;
   private readonly loader: SdkLoader;
+  private readonly resolveAgent: typeof resolveProjectAgent;
   private readonly hooks: HookPipeline | undefined;
   private sdkPromise: Promise<SdkLike> | null = null;
   private disposed = false;
+  private disposal: Promise<void> | undefined;
+  private readonly active = new Set<OwnedExecution>();
+  private readonly cleanupFailures = new Map<OwnedExecution, AppError>();
 
   constructor(options: SdkExecutionAdapterOptions = {}) {
     this.loader = options.loader ?? defaultLoader;
+    this.resolveAgent = options.resolveAgent ?? resolveProjectAgent;
     this.hooks = options.hooks;
+    this.cleanupGraceMs = options.cleanupGraceMs ?? DEFAULT_CLEANUP_GRACE_MS;
+    if (!Number.isFinite(this.cleanupGraceMs) || this.cleanupGraceMs <= 0) {
+      throw new RangeError('cleanupGraceMs must be finite and greater than zero');
+    }
   }
 
-  /**
-   *
-   * @param req
+  /** Register before any asynchronous setup and retain unresolved work until it settles.
+   * @param req - Target project, prompt and optional caller cancellation
+   * @returns Outcome after cleanup, or an explicit fatal cleanup diagnostic
    */
   async execute(req: StageExecutionRequest): Promise<StageExecutionResult> {
     if (this.disposed) {
       throw new AppError('EXEC-002', 'SdkExecutionAdapter: execute called after dispose', {
         severity: ErrorSeverity.HIGH,
+        category: 'fatal',
       });
     }
-    if (req.signal?.aborted === true) {
-      return abortedResult(req.resume);
-    }
+    const priorCleanupFailure = this.cleanupFailures.values().next().value;
+    if (priorCleanupFailure !== undefined) throw priorCleanupFailure;
 
-    const abortController = new AbortController();
+    const controller = new AbortController();
+    let notifyCancellation!: () => void;
+    const cancelled = new Promise<void>((resolve) => {
+      notifyCancellation = resolve;
+    });
+    let notifyCompletion!: () => void;
+    const completion = new Promise<void>((resolve) => {
+      notifyCompletion = resolve;
+    });
     const forwardAbort = (): void => {
-      abortController.abort(req.signal?.reason);
+      execution.cancel(req.signal?.reason);
     };
-    // Read through a function because abort state can change across awaited SDK work.
-    const isAborted = (): boolean => abortController.signal.aborted;
-    req.signal?.addEventListener('abort', forwardAbort, { once: true });
-
-    let sessionId = req.resume ?? 'unknown';
-    let toolCallCount = 0;
-    let tokenUsage: TokenUsage = { input: 0, output: 0, cache: 0 };
-    let resultText: string | undefined;
-    let isError = false;
-
-    try {
-      const definition = await resolveProjectAgent(req.projectDir, req.agentType);
-      const sdk = await this.getSdk();
-      // Cancellation may have arrived while resolving the definition or loader.
-      if (isAborted()) return abortedResult(sessionId);
-      const prompt = renderPrompt(req);
-      const sdkOptions: Options = {
-        cwd: req.projectDir,
-        agent: req.agentType,
-        agents: { [req.agentType]: definition },
-        settingSources: ['user', 'project', 'local'],
-        ...(req.skills !== undefined && { skills: [...req.skills] }),
-        ...(req.mcpServers !== undefined && {
-          mcpServers: copyMcpServers(req.mcpServers),
-        }),
-        ...(req.maxTurns !== undefined && { maxTurns: req.maxTurns }),
-        ...(req.permissionMode !== undefined && { permissionMode: req.permissionMode }),
-        ...(req.resume !== undefined && { resume: req.resume }),
-        ...(req.signal !== undefined && { abortController }),
-        ...(this.hooks !== undefined && { hooks: this.hooks }),
-      };
-      for await (const message of sdk.query({ prompt, options: sdkOptions })) {
-        if ('session_id' in message && message.session_id !== '') {
-          sessionId = message.session_id;
+    const execution: OwnedExecution = {
+      controller,
+      cancelled,
+      cancel: (reason): void => {
+        // Mechanical abort for failure cleanup must not change the causal outcome.
+        if (execution.outcome === 'running' || execution.outcome === 'success') {
+          execution.outcome = 'aborted';
+          execution.reason = reason;
         }
-        if (message.type === 'assistant') toolCallCount += 1;
-        if (message.type === 'result') {
-          resultText = message.subtype === 'success' ? message.result : message.errors.join('\n');
-          isError = message.is_error || message.subtype !== 'success';
-          toolCallCount = Math.max(toolCallCount, message.num_turns);
-          tokenUsage = mapUsage(message.usage);
+        controller.abort(reason);
+        notifyCancellation();
+      },
+      work: Promise.resolve(),
+      completion,
+      cleanupSettled: false,
+      executionSettled: false,
+      outcome: 'running',
+      sessionId: req.resume ?? 'unknown',
+      toolCallCount: 0,
+      tokenUsage: { input: 0, output: 0, cache: 0 },
+    };
+    this.active.add(execution);
+    req.signal?.addEventListener('abort', forwardAbort, { once: true });
+    if (req.signal?.aborted === true) forwardAbort();
+
+    // Deferring setup also makes synchronous loader/query throws observed failures.
+    execution.work = Promise.resolve().then(async () => {
+      try {
+        await this.consume(req, execution);
+      } catch (error) {
+        if (execution.outcome === 'running' || execution.outcome === 'success') {
+          execution.outcome = 'failed';
+          execution.reason = error;
         }
       }
-    } catch (err) {
-      if (isAborted()) return abortedResult(sessionId);
-      return failedResult(sessionId, err);
+    });
+    try {
+      return await this.complete(execution);
     } finally {
       req.signal?.removeEventListener('abort', forwardAbort);
+      execution.executionSettled = true;
+      notifyCompletion();
+      this.release(execution);
     }
+  }
 
-    if (isAborted()) return abortedResult(sessionId);
-
-    if (isError || resultText === undefined) {
-      return failedResult(sessionId, new Error(resultText ?? 'SDK returned no result'));
+  private async consume(req: StageExecutionRequest, execution: OwnedExecution): Promise<void> {
+    const stopped = (): boolean => {
+      if (execution.controller.signal.aborted || this.disposed) return true;
+      const failure = this.cleanupFailures.values().next().value;
+      if (failure !== undefined) throw failure;
+      return false;
+    };
+    if (stopped()) return;
+    const definition = await this.resolveAgent(req.projectDir, req.agentType);
+    if (stopped()) return;
+    const sdk = await this.getSdk();
+    if (stopped()) return;
+    const sdkOptions: Options = {
+      cwd: req.projectDir,
+      agent: req.agentType,
+      agents: { [req.agentType]: definition },
+      settingSources: ['user', 'project', 'local'],
+      abortController: execution.controller,
+      ...(req.skills !== undefined && { skills: [...req.skills] }),
+      ...(req.mcpServers !== undefined && { mcpServers: copyMcpServers(req.mcpServers) }),
+      ...(req.maxTurns !== undefined && { maxTurns: req.maxTurns }),
+      ...(req.permissionMode !== undefined && { permissionMode: req.permissionMode }),
+      ...(req.resume !== undefined && { resume: req.resume }),
+      ...(this.hooks !== undefined && { hooks: this.hooks }),
+    };
+    execution.query = sdk.query({ prompt: renderPrompt(req), options: sdkOptions });
+    const assistantUsage = new Map<string, TokenUsage>();
+    let hasResultUsage = false;
+    for await (const message of execution.query) {
+      if ('session_id' in message && message.session_id !== '')
+        execution.sessionId = message.session_id;
+      if (message.type === 'assistant') {
+        const previous = assistantUsage.get(message.message.id) ?? {
+          input: 0,
+          output: 0,
+          cache: 0,
+        };
+        const usage = mapUsage(message.message.usage);
+        assistantUsage.set(message.message.id, usage);
+        execution.toolCallCount = Math.max(execution.toolCallCount, assistantUsage.size);
+        if (!hasResultUsage) {
+          execution.tokenUsage = {
+            input: execution.tokenUsage.input + usage.input - previous.input,
+            output: execution.tokenUsage.output + usage.output - previous.output,
+            cache: execution.tokenUsage.cache + usage.cache - previous.cache,
+          };
+        }
+      }
+      if (message.type === 'result') {
+        execution.resultText =
+          message.subtype === 'success' ? message.result : message.errors.join('\n');
+        const isError = message.is_error || message.subtype !== 'success';
+        execution.toolCallCount = Math.max(execution.toolCallCount, message.num_turns);
+        execution.tokenUsage = mapUsage(message.usage);
+        hasResultUsage = true;
+        if (isError && execution.outcome === 'running') {
+          execution.outcome = 'failed';
+          execution.reason = new Error(execution.resultText);
+        }
+      }
     }
+    if (execution.outcome === 'aborted' || execution.outcome === 'failed') return;
+    if (execution.resultText === undefined) {
+      throw new Error('SDK returned no result');
+    }
+    execution.outcome = 'success';
+  }
 
+  private async complete(execution: OwnedExecution): Promise<StageExecutionResult> {
+    await Promise.race([execution.work, execution.cancelled]);
+    const cleanupError = await this.finalize(execution);
+    const status =
+      execution.outcome === 'aborted'
+        ? 'aborted'
+        : execution.outcome === 'success' && cleanupError === undefined
+          ? 'success'
+          : 'failed';
+    const reason = execution.reason;
+    const cause = reason instanceof Error ? reason : new Error(String(reason));
+    const error =
+      cleanupError ??
+      (isExecutionCleanupError(reason) ? reason : undefined) ??
+      (status === 'success'
+        ? undefined
+        : new AppError(
+            status === 'aborted' ? 'EXEC-005' : 'EXEC-003',
+            `SdkExecutionAdapter execute ${status}: ${cause.message}`,
+            {
+              severity: ErrorSeverity.HIGH,
+              category:
+                status === 'aborted'
+                  ? 'fatal'
+                  : execution.reason instanceof AppError
+                    ? execution.reason.category
+                    : 'transient',
+              context: {
+                reason:
+                  execution.reason instanceof Error ? execution.reason.message : execution.reason,
+              },
+              ...(reason !== undefined ? { cause } : {}),
+            }
+          ));
     return {
-      status: 'success',
-      artifacts: extractArtifacts(resultText),
-      sessionId,
-      toolCallCount,
-      tokenUsage,
+      status,
+      artifacts: status === 'success' ? extractArtifacts(execution.resultText ?? '') : [],
+      sessionId: execution.sessionId,
+      toolCallCount: execution.toolCallCount,
+      tokenUsage: execution.tokenUsage,
+      ...(error !== undefined ? { error: error.toJSON() } : {}),
     };
   }
 
-  /**
-   *
+  private finalize(execution: OwnedExecution): Promise<AppError | undefined> {
+    execution.cleanup ??= this.cleanup(execution);
+    return execution.cleanup;
+  }
+
+  private async cleanup(execution: OwnedExecution): Promise<AppError | undefined> {
+    if (execution.outcome !== 'success') execution.controller.abort(execution.reason);
+    const errors: string[] = [];
+    const failure = (unresolved: boolean): AppError =>
+      new ExecutionCleanupError('SDK cleanup failed', execution.reason, {
+        phase: 'adapter',
+        unresolved,
+        cleanupErrors: [...errors],
+      });
+    const recordFailure = (error: unknown): void => {
+      errors.push(error instanceof Error ? error.message : String(error));
+      // Stop admission immediately, including while sibling stages are completing.
+      this.cleanupFailures.set(execution, failure(!execution.cleanupSettled));
+    };
+    const query = execution.query;
+    // Keep the outer Query: its iterator is a different object in SDK 0.3.258.
+    try {
+      query?.close();
+    } catch (error) {
+      recordFailure(error);
+    }
+    const returned = Promise.resolve().then(async () => {
+      try {
+        await query?.return(undefined);
+      } catch (error) {
+        recordFailure(error);
+      }
+    });
+    const settled = Promise.allSettled([execution.work, returned]).then((results) => {
+      for (const result of results) if (result.status === 'rejected') recordFailure(result.reason);
+      execution.cleanupSettled = true;
+      delete execution.query;
+      this.release(execution);
+    });
+    try {
+      await withinCleanupGrace(
+        settled,
+        this.cleanupGraceMs,
+        () =>
+          new ExecutionCleanupError(
+            'SDK cleanup grace period exceeded; execution may still be active',
+            execution.reason,
+            {
+              cleanupGraceMs: this.cleanupGraceMs,
+              phase: 'adapter',
+              unresolved: true,
+              cleanupErrors: [...errors],
+            }
+          )
+      );
+      if (errors.length > 0) throw failure(false);
+    } catch (error) {
+      const diagnostic =
+        error instanceof AppError
+          ? error
+          : new ExecutionCleanupError('SDK cleanup failed', execution.reason);
+      this.cleanupFailures.set(execution, diagnostic);
+      return diagnostic;
+    }
+    return undefined;
+  }
+
+  private release(execution: OwnedExecution): void {
+    if (execution.cleanupSettled && execution.executionSettled) this.active.delete(execution);
+  }
+
+  /** Stop admission synchronously; every caller joins the same disposal and its failures.
+   * @returns Completion after all owned executions reached their bounded cleanup boundary
    */
-  async dispose(): Promise<void> {
+  dispose(): Promise<void> {
+    if (this.disposal !== undefined) return this.disposal;
     this.disposed = true;
-    this.sdkPromise = null;
-    await Promise.resolve();
+    const executions = [...this.active];
+    this.disposal = Promise.resolve().then(async (): Promise<void> => {
+      await Promise.allSettled(executions.map((execution) => execution.completion));
+      this.sdkPromise = null;
+      if (this.cleanupFailures.size > 0)
+        throw new ExecutionCleanupError(
+          'SdkExecutionAdapter disposal failed',
+          this.cleanupFailures.values().next().value,
+          {
+            unresolvedExecutions: this.active.size,
+            cleanupErrors: [...this.cleanupFailures.values()].map((error) => error.toJSON()),
+          }
+        );
+    });
+    for (const execution of executions) execution.cancel(new Error('SdkExecutionAdapter disposed'));
+    return this.disposal;
   }
 
   private getSdk(): Promise<SdkLike> {
-    if (!this.sdkPromise) this.sdkPromise = this.loader();
+    this.sdkPromise ??= this.loader();
     return this.sdkPromise;
   }
 }
@@ -190,8 +423,13 @@ function copyMcpServers(
   return copied;
 }
 
-function mapUsage(usage: SDKResultMessage['usage']): TokenUsage {
-  const cache = usage.cache_read_input_tokens + usage.cache_creation_input_tokens;
+function mapUsage(
+  usage: Pick<SDKResultMessage['usage'], 'input_tokens' | 'output_tokens'> & {
+    cache_read_input_tokens?: number | null;
+    cache_creation_input_tokens?: number | null;
+  }
+): TokenUsage {
+  const cache = (usage.cache_read_input_tokens ?? 0) + (usage.cache_creation_input_tokens ?? 0);
   return {
     input: usage.input_tokens,
     output: usage.output_tokens,
@@ -216,30 +454,4 @@ function extractArtifacts(resultText: string): ArtifactRef[] {
     out.push({ path, description: description.trim() });
   }
   return out;
-}
-
-function abortedResult(sessionId: string | undefined): StageExecutionResult {
-  return {
-    status: 'aborted',
-    artifacts: [],
-    sessionId: sessionId ?? 'unknown',
-    toolCallCount: 0,
-    tokenUsage: { input: 0, output: 0, cache: 0 },
-  };
-}
-
-function failedResult(sessionId: string, err: unknown): StageExecutionResult {
-  const cause = err instanceof Error ? err : new Error(String(err));
-  const error = new AppError('EXEC-003', `SdkExecutionAdapter execute failed: ${cause.message}`, {
-    severity: ErrorSeverity.HIGH,
-    cause,
-  });
-  return {
-    status: 'failed',
-    artifacts: [],
-    sessionId,
-    toolCallCount: 0,
-    tokenUsage: { input: 0, output: 0, cache: 0 },
-    error: error.toJSON(),
-  };
 }

--- a/src/execution/cleanup.ts
+++ b/src/execution/cleanup.ts
@@ -1,0 +1,59 @@
+/** SDK-observable cleanup policy shared by adapters and the stage scheduler. */
+import { AppError } from '../errors/AppError.js';
+import { ErrorSeverity, type ErrorContext } from '../errors/types.js';
+
+/** SDK 0.3.258 waits up to 2 seconds for process exit; allow 3 more for other cleanup. */
+export const DEFAULT_CLEANUP_GRACE_MS = 5000;
+
+/** Allow adapter diagnostics to propagate before the scheduler's fallback expires. */
+export const SCHEDULER_CLEANUP_MARGIN_MS = 1000;
+
+/** A fatal cleanup failure; the cause remains the original execution/cancellation reason. */
+export class ExecutionCleanupError extends AppError {
+  constructor(message: string, reason: unknown, context: ErrorContext = {}) {
+    const cause = reason instanceof Error ? reason : new Error(String(reason));
+    super('EXEC-004', message, {
+      severity: ErrorSeverity.CRITICAL,
+      category: 'fatal',
+      context: { ...context, reason: reason instanceof Error ? reason.message : reason },
+      ...(reason !== undefined ? { cause } : {}),
+    });
+    this.name = 'ExecutionCleanupError';
+  }
+}
+
+/** Recognize reconstituted cleanup errors without relying on subclass identity.
+ * @param error - Candidate error from an execution or serialization boundary
+ * @returns Whether the error carries the fatal cleanup code
+ */
+export function isExecutionCleanupError(error: unknown): error is AppError {
+  return error instanceof AppError && error.code === 'EXEC-004';
+}
+
+/**
+ * Bound observation, not the underlying work. Both late fulfillment and rejection
+ * remain observed, and the owned timer is always removed.
+ * @param work - The cleanup boundary to observe
+ * @param graceMs - Time budget independent of the execution budget
+ * @param onTimeout - Creates a diagnostic without asserting that work stopped
+ * @returns The observed result
+ */
+export async function withinCleanupGrace<T>(
+  work: Promise<T>,
+  graceMs: number,
+  onTimeout: () => Error
+): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      work,
+      new Promise<never>((_resolve, reject) => {
+        timer = setTimeout(() => {
+          reject(onTimeout());
+        }, graceMs);
+      }),
+    ]);
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/src/execution/index.ts
+++ b/src/execution/index.ts
@@ -28,6 +28,7 @@ export type {
   SdkLoader,
   SdkMessage,
   SdkQueryOptions,
+  SdkQuery,
 } from './SdkExecutionAdapter.js';
 
 export { buildHookPipeline } from './hooks.js';
@@ -48,3 +49,5 @@ export {
   isClaudeCodeSession,
 } from './env.js';
 export type { ExecutionEnvironmentLabel } from './env.js';
+
+export { DEFAULT_CLEANUP_GRACE_MS, ExecutionCleanupError } from './cleanup.js';

--- a/src/execution/types.ts
+++ b/src/execution/types.ts
@@ -35,7 +35,9 @@ export type McpServerConfig =
   | Readonly<McpHttpServerConfig>;
 
 /**
- * Token usage breakdown returned by every adapter call.
+ * Available token usage on every outcome. SDK result usage is authoritative;
+ * before a result, distinct assistant messages supply the fallback. Cache includes
+ * both cache-read and cache-creation tokens.
  */
 export interface TokenUsage {
   readonly input: number;
@@ -72,7 +74,9 @@ export interface StageExecutionRequest {
 
 /**
  * Result of a stage execution. `error` is populated only when
- * `status !== 'success'`.
+ * `status !== 'success'`. Available session/turn/usage observations survive failure
+ * and cancellation. EXEC-004 means cleanup could not be established, even when
+ * the causal status is aborted.
  */
 export interface StageExecutionResult {
   readonly status: StageExecutionStatus;
@@ -89,6 +93,10 @@ export interface StageExecutionResult {
  * and {@link MockExecutionAdapter} (testing).
  */
 export interface ExecutionAdapter {
+  /** Cleanup budget used to coordinate the scheduler fallback (default: 5000ms). */
+  readonly cleanupGraceMs?: number;
+  /** Completes after observable lifecycle cleanup, or reports a fatal cleanup error. */
   execute(req: StageExecutionRequest): Promise<StageExecutionResult>;
+  /** Stops admission and joins all owned cleanup; concurrent calls share the outcome. */
   dispose(): Promise<void>;
 }

--- a/tests/ad-sdlc-orchestrator/projectContext.test.ts
+++ b/tests/ad-sdlc-orchestrator/projectContext.test.ts
@@ -18,7 +18,12 @@ import {
   type SdkQueryOptions,
   type StageExecutionRequest,
 } from '../../src/execution/index.js';
-import { agentMarkdown, installAgent, sdkResult } from '../execution/fixtures/sdk.js';
+import {
+  agentMarkdown,
+  installAgent,
+  sdkResult,
+  withQueryLifecycle,
+} from '../execution/fixtures/sdk.js';
 
 class ProbeOrchestrator extends AdsdlcOrchestratorAgent {
   constructor(private readonly adapter: ExecutionAdapter) {
@@ -42,12 +47,13 @@ afterEach(async () => {
 
 function capturingAdapter(calls: SdkQueryOptions[]): SdkExecutionAdapter {
   return new SdkExecutionAdapter({
-    loader: async () => ({
-      async *query(input) {
-        calls.push(input);
-        yield sdkResult();
-      },
-    }),
+    loader: async () =>
+      withQueryLifecycle({
+        async *query(input) {
+          calls.push(input);
+          yield sdkResult();
+        },
+      }),
   });
 }
 

--- a/tests/ad-sdlc-orchestrator/sdkLifecycle.test.ts
+++ b/tests/ad-sdlc-orchestrator/sdkLifecycle.test.ts
@@ -1,0 +1,390 @@
+/** Offline integration lane: production scheduler, orchestrator and SDK adapter. */
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { AdsdlcOrchestratorAgent } from '../../src/ad-sdlc-orchestrator/AdsdlcOrchestratorAgent.js';
+import { PipelineFailedError, StageTimeoutError } from '../../src/ad-sdlc-orchestrator/errors.js';
+import {
+  IMPORT_STAGES,
+  type OrchestratorConfig,
+  type OrchestratorSession,
+  type PipelineStageDefinition,
+} from '../../src/ad-sdlc-orchestrator/types.js';
+import { AppError } from '../../src/errors/AppError.js';
+import { SdkExecutionAdapter } from '../../src/execution/SdkExecutionAdapter.js';
+import type { ExecutionAdapter, StageExecutionResult } from '../../src/execution/types.js';
+import { ControlledQuery, deferred } from '../execution/fixtures/controlledSdk.js';
+import { installAgent, sdkAssistant, sdkResult } from '../execution/fixtures/sdk.js';
+
+let projectDir: string;
+beforeAll(async () => {
+  projectDir = await mkdtemp(join(tmpdir(), 'scheduler-sdk-lifecycle-'));
+  for (const stage of IMPORT_STAGES) await installAgent(projectDir, stage.agentType);
+});
+afterAll(async () => {
+  await rm(projectDir, { recursive: true, force: true });
+});
+beforeEach(() => vi.useFakeTimers());
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+class SdkOrchestrator extends AdsdlcOrchestratorAgent {
+  creations = 0;
+  constructor(
+    readonly adapter: ExecutionAdapter,
+    config: OrchestratorConfig = {}
+  ) {
+    super({ maxRetries: 2, timeouts: { default: 20000 }, ...config });
+  }
+  protected override createExecutionAdapter(): ExecutionAdapter {
+    this.creations++;
+    return this.adapter;
+  }
+  // Probes the production admission barrier for an invocation queued before shutdown.
+  invokeQueued(stage: PipelineStageDefinition, session: OrchestratorSession) {
+    return this.executeViaAdapter(stage, session);
+  }
+  stageOutput(result: StageExecutionResult) {
+    return this.toStageOutput(IMPORT_STAGES[0]!, result);
+  }
+}
+
+async function pipeline(
+  config: OrchestratorConfig = {},
+  abortMode: 'reject' | 'end' | 'ignore' = 'reject'
+) {
+  const queries: ControlledQuery[] = [];
+  const arrivals = [
+    deferred<ControlledQuery>(),
+    deferred<ControlledQuery>(),
+    deferred<ControlledQuery>(),
+  ];
+  const adapter = new SdkExecutionAdapter({
+    cleanupGraceMs: 50,
+    loader: async () => ({
+      query: (input) => {
+        if (queries.some((query) => query.writerActive))
+          throw new Error('Replacement overlaps prior cleanup');
+        const query = new ControlledQuery(
+          input,
+          [
+            sdkAssistant('partial-sdk', {
+              usage: sdkResult({ usage: { input_tokens: 10, output_tokens: 3 } }).usage,
+            }),
+          ],
+          abortMode
+        );
+        queries.push(query);
+        arrivals[queries.length - 1]?.resolve(query);
+        return query;
+      },
+    }),
+  });
+  const orchestrator = new SdkOrchestrator(adapter, config);
+  const session = await orchestrator.startSession({
+    projectDir,
+    userRequest: 'offline',
+    overrideMode: 'import',
+    stopAfterStage: 'issue_reading',
+  });
+  let settled = false;
+  const execution = orchestrator.executePipeline(projectDir, 'offline').then(
+    (result) => {
+      settled = true;
+      return { result, error: undefined };
+    },
+    (error: unknown) => {
+      settled = true;
+      return { result: undefined, error };
+    }
+  );
+  const query = await arrivals[0]!.promise;
+  await query.reading.promise;
+  return {
+    orchestrator,
+    adapter,
+    session,
+    execution,
+    query,
+    queries,
+    arrivals,
+    isSettled: () => settled,
+  };
+}
+
+describe('production timeout and retry cleanup barriers', () => {
+  it('times out only after outer Query cleanup, retains the timeout and does not retry an exhausted budget', async () => {
+    const run = await pipeline({ timeouts: { default: 100 } });
+    await run.query.writeArtifact();
+    await vi.advanceTimersByTimeAsync(100);
+    expect(run.query.controller.signal.reason).toBeInstanceOf(StageTimeoutError);
+    await run.query.returning.promise;
+    expect(run.isSettled()).toBe(false);
+    expect(run.query.writerActive).toBe(true);
+    run.query.cleanupGate.resolve();
+    const outcome = await run.execution;
+    expect(outcome.error).toBeInstanceOf(PipelineFailedError);
+    expect(run.orchestrator.getStatus().stages[0]).toMatchObject({
+      status: 'failed',
+      retryCount: 0,
+      error: expect.stringContaining('timed out'),
+      errorDetails: {
+        code: 'EXEC-005',
+        context: {
+          status: 'aborted',
+          sessionId: 'partial-sdk',
+          toolCallCount: 1,
+          tokenUsage: { input: 10, output: 3, cache: 0 },
+          timeoutMs: 100,
+        },
+      },
+    });
+    expect(run.queries).toHaveLength(1);
+    await vi.advanceTimersByTimeAsync(30000);
+    expect(await run.query.writeArtifact()).toBe(false);
+    await run.orchestrator.dispose();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('starts a retryable early failure replacement strictly after cleanup and existing backoff', async () => {
+    const run = await pipeline();
+    run.query.terminal.resolve(new Error('temporary SDK failure'));
+    await run.query.returning.promise;
+    await vi.advanceTimersByTimeAsync(25);
+    expect(run.queries).toHaveLength(1);
+    expect(run.isSettled()).toBe(false);
+    run.query.cleanupGate.resolve();
+    await run.query.cleaned.promise;
+    await vi.advanceTimersByTimeAsync(4999);
+    expect(run.queries).toHaveLength(1);
+    await vi.advanceTimersByTimeAsync(1);
+    const replacement = await run.arrivals[1]!.promise;
+    expect(run.query.writerActive).toBe(false);
+    replacement.finish();
+    replacement.cleanupGate.resolve();
+    expect((await run.execution).result?.stages[0]).toMatchObject({
+      status: 'completed',
+      retryCount: 1,
+    });
+    expect(run.orchestrator.creations).toBe(1);
+    await run.orchestrator.dispose();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('does not invoke a replacement when the total budget expires during backoff', async () => {
+    const run = await pipeline({ timeouts: { default: 4000 } });
+    run.query.terminal.resolve(new Error('early failure'));
+    await run.query.returning.promise;
+    run.query.cleanupGate.resolve();
+    await run.query.cleaned.promise;
+    await vi.advanceTimersByTimeAsync(4000);
+    expect((await run.execution).error).toBeInstanceOf(PipelineFailedError);
+    expect(run.orchestrator.getStatus().stages[0]).toMatchObject({
+      retryCount: 0,
+      error: expect.stringContaining('budget exhausted'),
+    });
+    expect(run.queries).toHaveLength(1);
+    await run.orchestrator.dispose();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('pipeline cancellation joins cleanup and concurrent disposal without adapter recreation', async () => {
+    const run = await pipeline({}, 'ignore');
+    const disposal = run.orchestrator.dispose();
+    expect(run.orchestrator.dispose()).toBe(disposal);
+    await run.query.returning.promise;
+    await vi.advanceTimersByTimeAsync(0);
+    expect(run.isSettled()).toBe(false);
+    await expect(
+      run.orchestrator.invokeQueued(IMPORT_STAGES[0]!, run.session)
+    ).rejects.toMatchObject({ code: 'EXEC-002', category: 'fatal' });
+    expect(run.orchestrator.creations).toBe(1);
+    run.query.finish(); // SDK reports success after cancellation
+    run.query.cleanupGate.resolve();
+    await disposal;
+    expect((await run.execution).error).toBeInstanceOf(PipelineFailedError);
+    expect(run.queries).toHaveLength(1);
+    expect(run.orchestrator.dispose()).toBe(disposal);
+    await vi.advanceTimersByTimeAsync(30000);
+    expect(await run.query.writeArtifact()).toBe(false);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('cancels the production backoff timer and never invokes another attempt', async () => {
+    const run = await pipeline();
+    run.query.terminal.resolve(new Error('early failure'));
+    await run.query.returning.promise;
+    run.query.cleanupGate.resolve();
+    await run.query.cleaned.promise;
+    await vi.advanceTimersByTimeAsync(1000);
+    const disposal = run.orchestrator.dispose();
+    await disposal;
+    expect((await run.execution).error).toBeInstanceOf(PipelineFailedError);
+    await vi.advanceTimersByTimeAsync(30000);
+    expect(run.queries).toHaveLength(1);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it.each(['reject', 'timeout'] as const)(
+    'preserves a first-attempt fatal %s diagnostic, partial usage and secondary disposal error',
+    async (failure) => {
+      const run = await pipeline({ timeouts: { default: 100 } });
+      if (failure === 'timeout') await vi.advanceTimersByTimeAsync(100);
+      else run.query.terminal.resolve(new Error('original SDK failure'));
+      await run.query.returning.promise;
+      if (failure === 'timeout') await vi.advanceTimersByTimeAsync(50);
+      else run.query.cleanupGate.reject(new Error('outer cleanup rejected'));
+      const outcome = await run.execution;
+      expect(outcome.error).toBeInstanceOf(PipelineFailedError); // primary identity retained
+      expect(outcome.error).toMatchObject({
+        cleanupErrors: [expect.objectContaining({ code: 'EXEC-004' })],
+      });
+      const result = run.orchestrator.getStatus().stages[0];
+      expect(result).toMatchObject({
+        status: 'failed',
+        retryCount: 0,
+        error: expect.stringContaining('SDK cleanup'),
+        errorDetails: {
+          code: 'EXEC-004',
+          category: 'fatal',
+          context: {
+            phase: 'adapter',
+            status: failure === 'timeout' ? 'aborted' : 'failed',
+            sessionId: 'partial-sdk',
+            toolCallCount: 1,
+            tokenUsage: { input: 10, output: 3, cache: 0 },
+          },
+          cause: {
+            message: expect.stringContaining(
+              failure === 'timeout' ? 'timed out' : 'original SDK failure'
+            ),
+          },
+        },
+      });
+      expect(run.queries).toHaveLength(1);
+      expect(run.orchestrator.creations).toBe(1);
+      await expect(
+        run.orchestrator.invokeQueued(IMPORT_STAGES[0]!, run.session)
+      ).rejects.toMatchObject({ category: 'fatal' });
+      if (failure === 'timeout')
+        run.query.cleanupGate.reject(new Error('late lifecycle rejection'));
+      await vi.advanceTimersByTimeAsync(30000);
+      await expect(run.orchestrator.dispose()).rejects.toThrow('Orchestrator disposal failed');
+      expect(vi.getTimerCount()).toBe(0);
+    }
+  );
+
+  it('uses a bounded scheduler fallback for an invocation that ignores cancellation and observes late rejection', async () => {
+    const invocation = deferred<StageExecutionResult>();
+    const entered = deferred<void>();
+    let calls = 0;
+    const adapter: ExecutionAdapter = {
+      cleanupGraceMs: 50,
+      execute: () => {
+        calls++;
+        entered.resolve();
+        return invocation.promise;
+      },
+      dispose: async () => {},
+    };
+    const orchestrator = new SdkOrchestrator(adapter, { timeouts: { default: 100 } });
+    await orchestrator.startSession({ projectDir, userRequest: 'offline', overrideMode: 'import' });
+    const outcome = orchestrator.executePipeline(projectDir, 'offline').catch((error) => error);
+    await entered.promise;
+    await vi.advanceTimersByTimeAsync(1150); // execution + adapter grace + propagation margin
+    expect(await outcome).toBeInstanceOf(PipelineFailedError);
+    expect(orchestrator.getStatus().stages[0]).toMatchObject({
+      retryCount: 0,
+      errorDetails: {
+        code: 'EXEC-004',
+        category: 'fatal',
+        context: { phase: 'scheduler' },
+        cause: { message: expect.stringContaining('timed out') },
+      },
+    });
+    invocation.reject(new Error('late invocation rejection'));
+    await vi.advanceTimersByTimeAsync(30000);
+    expect(calls).toBe(1);
+    await orchestrator.dispose();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('never dispatches queued parallel stages after the shared adapter cleanup fails', async () => {
+    for (const name of ['document-reader', 'codebase-analyzer', 'code-reader'])
+      await installAgent(projectDir, name);
+    const started = deferred<ControlledQuery>();
+    let queries = 0;
+    const adapter = new SdkExecutionAdapter({
+      cleanupGraceMs: 50,
+      loader: async () => ({
+        query: (input) => {
+          queries++;
+          const query = new ControlledQuery(input);
+          started.resolve(query);
+          return query;
+        },
+      }),
+    });
+    const orchestrator = new SdkOrchestrator(adapter, { maxParallelAgents: 1 });
+    await orchestrator.startSession({
+      projectDir,
+      userRequest: 'offline',
+      overrideMode: 'enhancement',
+    });
+    const outcome = orchestrator.executePipeline(projectDir, 'offline').catch((error) => error);
+    const query = await started.promise;
+    await query.reading.promise;
+    query.terminal.resolve(new Error('early SDK failure'));
+    await query.returning.promise;
+    query.cleanupGate.reject(new Error('cleanup failed'));
+    expect(await outcome).toBeInstanceOf(PipelineFailedError);
+    expect(queries).toBe(1);
+    expect(orchestrator.creations).toBe(1);
+    const stages = orchestrator.getStatus().stages;
+    expect(stages[0]).toMatchObject({ retryCount: 0, errorDetails: { code: 'EXEC-004' } });
+    expect(stages.find((stage) => stage.name === 'codebase_analysis')).toMatchObject({
+      status: 'failed',
+      retryCount: 0,
+      error: expect.stringContaining('aborted'),
+    });
+    await expect(orchestrator.dispose()).rejects.toThrow('Orchestrator disposal failed');
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('preserves the serialized error category, code, cause and context through toStageOutput', async () => {
+    const cause = new AppError('TEST-CAUSE', 'original failure', { context: { detail: 42 } });
+    const serialized = new AppError('EXEC-004', 'cleanup failed', {
+      category: 'fatal',
+      cause,
+      context: { unresolved: true },
+    }).toJSON();
+    const adapter = new SdkExecutionAdapter();
+    const orchestrator = new SdkOrchestrator(adapter);
+    expect(() =>
+      orchestrator.stageOutput({
+        status: 'aborted',
+        artifacts: [],
+        sessionId: 'partial',
+        toolCallCount: 4,
+        tokenUsage: { input: 100, output: 30, cache: 5 },
+        error: serialized,
+      })
+    ).toThrow(
+      expect.objectContaining({
+        code: 'EXEC-004',
+        category: 'fatal',
+        cause: expect.objectContaining({ code: 'TEST-CAUSE', context: { detail: 42 } }),
+        context: expect.objectContaining({
+          unresolved: true,
+          status: 'aborted',
+          sessionId: 'partial',
+          toolCallCount: 4,
+        }),
+      })
+    );
+    await orchestrator.dispose();
+  });
+});

--- a/tests/execution/SdkExecutionAdapter.lifecycle.test.ts
+++ b/tests/execution/SdkExecutionAdapter.lifecycle.test.ts
@@ -1,0 +1,569 @@
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import type { SDKMessage, SDKResultError } from '@anthropic-ai/claude-agent-sdk';
+import { SdkExecutionAdapter, type SdkLike } from '../../src/execution/SdkExecutionAdapter.js';
+import { resolveProjectAgent } from '../../src/execution/resolveProjectAgent.js';
+import type { StageExecutionRequest } from '../../src/execution/types.js';
+import { ControlledQuery, deferred } from './fixtures/controlledSdk.js';
+import { installAgent, sdkAssistant, sdkResult } from './fixtures/sdk.js';
+
+let projectDir: string;
+beforeAll(async () => {
+  projectDir = await mkdtemp(join(tmpdir(), 'sdk-lifecycle-'));
+  await installAgent(projectDir);
+});
+afterAll(async () => {
+  await rm(projectDir, { recursive: true, force: true });
+});
+beforeEach(() => vi.useFakeTimers());
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+const request = (extra: Partial<StageExecutionRequest> = {}): StageExecutionRequest => ({
+  projectDir,
+  agentType: 'worker',
+  workOrder: 'offline lifecycle',
+  priorOutputs: {},
+  ...extra,
+});
+
+function boundary(
+  messages: readonly SDKMessage[] = [],
+  abortMode: 'reject' | 'end' | 'ignore' = 'reject'
+) {
+  const started = deferred<ControlledQuery>();
+  const queries: ControlledQuery[] = [];
+  const sdk: SdkLike = {
+    query: vi.fn((input) => {
+      const query = new ControlledQuery(input, messages, abortMode);
+      queries.push(query);
+      started.resolve(query);
+      return query;
+    }),
+  };
+  return { sdk, started, queries };
+}
+
+async function launch(
+  messages: readonly SDKMessage[] = [],
+  abortMode: 'reject' | 'end' | 'ignore' = 'reject'
+) {
+  const sdk = boundary(messages, abortMode);
+  const adapter = new SdkExecutionAdapter({ loader: async () => sdk.sdk, cleanupGraceMs: 50 });
+  const caller = new AbortController();
+  const execution = adapter.execute(request({ signal: caller.signal }));
+  const query = await sdk.started.promise;
+  await query.reading.promise;
+  return { ...sdk, adapter, caller, execution, query };
+}
+
+async function expectPending(promise: Promise<unknown>) {
+  const settled = vi.fn();
+  void promise.then(settled, settled);
+  await vi.advanceTimersByTimeAsync(0);
+  expect(settled).not.toHaveBeenCalled();
+}
+
+describe('owned execution lifecycle', () => {
+  it.each([new Error('exact error'), 'text reason', { why: 'object reason' }, 0])(
+    'forwards the exact reason %s into its distinct official controller',
+    async (reason) => {
+      const { adapter, caller, execution, query } = await launch();
+      expect(query.controller).not.toBe(caller);
+      caller.abort(reason);
+      expect(query.controller.signal.reason).toBe(reason);
+      await query.returning.promise;
+      await expectPending(execution);
+      query.cleanupGate.resolve();
+      expect((await execution).status).toBe('aborted');
+      await adapter.dispose();
+      expect(vi.getTimerCount()).toBe(0);
+    }
+  );
+
+  it.each(['reject', 'end'] as const)(
+    'joins the outer Query cleanup after abort with iterator %s',
+    async (abortMode) => {
+      const { adapter, caller, execution, query } = await launch([], abortMode);
+      expect(query[Symbol.asyncIterator]()).not.toBe(query);
+      const remove = vi.spyOn(caller.signal, 'removeEventListener');
+      await query.writeArtifact();
+      caller.abort(new Error('cancel writer'));
+      await query.returning.promise;
+      expect(query.closeCalls).toBe(1);
+      expect(query.returnCalls).toBe(1);
+      expect(query.writerActive).toBe(true); // close alone provides no cleanup evidence
+      await expectPending(execution);
+      query.cleanupGate.resolve();
+      const result = await execution;
+      expect(result.status).toBe('aborted');
+      expect(result.error?.cause?.message).toBe('cancel writer');
+      expect(remove).toHaveBeenCalledTimes(1);
+      await vi.advanceTimersByTimeAsync(10000);
+      expect(await query.writeArtifact()).toBe(false);
+      expect(await readFile(join(projectDir, 'lifecycle-sentinel.txt'), 'utf8')).toBe('1');
+      await adapter.dispose();
+      expect(query.returnCalls).toBe(1);
+      expect(vi.getTimerCount()).toBe(0);
+    }
+  );
+
+  it('joins consumption as well as return when an iterator ignores cancellation', async () => {
+    const { adapter, caller, execution, query } = await launch([], 'ignore');
+    caller.abort('cancel');
+    await query.returning.promise;
+    query.cleanupGate.resolve();
+    await expectPending(execution);
+    query.terminal.resolve(undefined);
+    expect((await execution).status).toBe('aborted');
+    await adapter.dispose();
+  });
+
+  it('never resolves a late SDK success as success after cancellation', async () => {
+    const { adapter, caller, execution, query } = await launch([], 'ignore');
+    caller.abort('cancel');
+    await query.returning.promise;
+    query.finish(sdkResult({ num_turns: 4, usage: { input_tokens: 100, output_tokens: 30 } }));
+    query.cleanupGate.resolve();
+    expect(await execution).toMatchObject({
+      status: 'aborted',
+      toolCallCount: 4,
+      tokenUsage: { input: 100, output: 30 },
+    });
+    await adapter.dispose();
+  });
+
+  it('cancelling one query preserves its sibling; disposal stops queries without caller signals', async () => {
+    const { sdk, queries } = boundary();
+    const arrivals = deferred<void>();
+    const original = sdk.query;
+    sdk.query = (input) => {
+      const query = original(input);
+      if (queries.length === 3) arrivals.resolve();
+      return query;
+    };
+    const adapter = new SdkExecutionAdapter({ loader: async () => sdk });
+    const caller = new AbortController();
+    const executions = [
+      adapter.execute(request({ signal: caller.signal, resume: 'first' })),
+      adapter.execute(request({ resume: 'second' })),
+      adapter.execute(request({ resume: 'third' })),
+    ];
+    await arrivals.promise;
+    await Promise.all(queries.map((query) => query.reading.promise));
+    const first = queries.find((query) => query.input.options?.resume === 'first');
+    const second = queries.find((query) => query.input.options?.resume === 'second');
+    const third = queries.find((query) => query.input.options?.resume === 'third');
+    expect(first && second && third).toBeTruthy();
+    expect(new Set(queries.map((query) => query.controller)).size).toBe(3);
+    caller.abort('only first');
+    first!.cleanupGate.resolve();
+    expect((await executions[0])?.status).toBe('aborted');
+    expect(second!.controller.signal.aborted).toBe(false);
+    expect(third!.controller.signal.aborted).toBe(false);
+    expect(await second!.writeArtifact()).toBe(true);
+
+    const disposal = adapter.dispose();
+    expect(adapter.dispose()).toBe(disposal);
+    const rejected = expect(adapter.execute(request())).rejects.toMatchObject({ code: 'EXEC-002' });
+    await rejected;
+    await Promise.all([second!.returning.promise, third!.returning.promise]);
+    expect(second!.controller.signal.aborted).toBe(true);
+    expect(third!.controller.signal.aborted).toBe(true);
+    second!.cleanupGate.resolve();
+    await expectPending(disposal);
+    third!.cleanupGate.resolve();
+    await disposal;
+    expect(adapter.dispose()).toBe(disposal);
+    expect((await Promise.all(executions)).map((result) => result.status)).toEqual([
+      'aborted',
+      'aborted',
+      'aborted',
+    ]);
+    await vi.advanceTimersByTimeAsync(10000);
+    expect(await second!.writeArtifact()).toBe(false);
+    expect(await third!.writeArtifact()).toBe(false);
+    expect(queries.every((query) => query.closeCalls === 1 && query.returnCalls === 1)).toBe(true);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('pre-abort skips both agent resolution and SDK loading', async () => {
+    const caller = new AbortController();
+    caller.abort('already cancelled');
+    const loader = vi.fn(async () => boundary().sdk);
+    const resolveAgent = vi.fn(resolveProjectAgent);
+    const adapter = new SdkExecutionAdapter({ loader, resolveAgent });
+    expect(
+      await adapter.execute(request({ signal: caller.signal, resume: 'previous' }))
+    ).toMatchObject({ status: 'aborted', sessionId: 'previous' });
+    expect(loader).not.toHaveBeenCalled();
+    expect(resolveAgent).not.toHaveBeenCalled();
+    await adapter.dispose();
+  });
+
+  it.each(['resolution', 'loading'] as const)(
+    'cancellation/disposal during deferred %s prevents a late query',
+    async (phase) => {
+      for (const action of ['cancel', 'dispose'] as const) {
+        const gate = deferred<void>();
+        const entered = deferred<void>();
+        const sdk = boundary();
+        const adapter = new SdkExecutionAdapter({
+          cleanupGraceMs: 50,
+          resolveAgent: async (...args) => {
+            if (phase === 'resolution') {
+              entered.resolve();
+              await gate.promise;
+            }
+            return resolveProjectAgent(...args);
+          },
+          loader: async () => {
+            if (phase === 'loading') {
+              entered.resolve();
+              await gate.promise;
+            }
+            return sdk.sdk;
+          },
+        });
+        const caller = new AbortController();
+        const execution = adapter.execute(request({ signal: caller.signal }));
+        await entered.promise;
+        const disposal = action === 'dispose' ? adapter.dispose() : undefined;
+        if (action === 'cancel') caller.abort('setup cancelled');
+        await expectPending(execution);
+        gate.resolve();
+        expect((await execution).status).toBe('aborted');
+        await disposal;
+        expect(sdk.sdk.query).not.toHaveBeenCalled();
+        await adapter.dispose();
+        expect(vi.getTimerCount()).toBe(0);
+      }
+    }
+  );
+
+  it.each(['resolve', 'reject'] as const)(
+    'bounds unresolved setup and observes its late %s',
+    async (settlement) => {
+      const gate = deferred<SdkLike>();
+      const entered = deferred<void>();
+      const sdk = boundary();
+      const adapter = new SdkExecutionAdapter({
+        cleanupGraceMs: 50,
+        loader: () => {
+          entered.resolve();
+          return gate.promise;
+        },
+      });
+      const execution = adapter.execute(request());
+      await entered.promise;
+      const disposal = adapter.dispose();
+      const disposalOutcome = disposal.catch((error) => error);
+      await vi.advanceTimersByTimeAsync(50);
+      expect(await execution).toMatchObject({
+        status: 'aborted',
+        error: { code: 'EXEC-004', category: 'fatal', context: { unresolved: true } },
+      });
+      expect(await disposalOutcome).toMatchObject({
+        code: 'EXEC-004',
+        context: { unresolvedExecutions: 1 },
+      });
+      if (settlement === 'resolve') gate.resolve(sdk.sdk);
+      else gate.reject(new Error('late loader rejection'));
+      await vi.advanceTimersByTimeAsync(0);
+      expect(sdk.sdk.query).not.toHaveBeenCalled();
+      expect(adapter.dispose()).toBe(disposal);
+      expect(vi.getTimerCount()).toBe(0);
+    }
+  );
+
+  it.each(['reject', 'timeout'] as const)(
+    'reports %s cleanup as fatal and rejects replacement work',
+    async (mode) => {
+      const { adapter, execution, query, sdk } = await launch();
+      query.terminal.resolve(new Error('primary SDK failure'));
+      await query.returning.promise;
+      if (mode === 'reject') query.cleanupGate.reject(new Error('cleanup rejected'));
+      else await vi.advanceTimersByTimeAsync(50);
+      const result = await execution;
+      expect(result).toMatchObject({
+        status: 'failed',
+        error: { code: 'EXEC-004', category: 'fatal', cause: { message: 'primary SDK failure' } },
+      });
+      expect(query.controller.signal.aborted).toBe(true); // teardown must not relabel SDK failure
+      await expect(adapter.execute(request())).rejects.toMatchObject({
+        code: 'EXEC-004',
+        category: 'fatal',
+      });
+      expect(sdk.query).toHaveBeenCalledTimes(1);
+      const disposal = adapter.dispose();
+      await expect(disposal).rejects.toMatchObject({ code: 'EXEC-004' });
+      expect(adapter.dispose()).toBe(disposal);
+      if (mode === 'timeout') query.cleanupGate.reject(new Error('late cleanup rejection'));
+      await vi.advanceTimersByTimeAsync(0);
+      expect(vi.getTimerCount()).toBe(0);
+    }
+  );
+
+  it('observes consumption even when the outer return resolves first', async () => {
+    const { adapter, caller, execution, query } = await launch([], 'ignore');
+    vi.spyOn(query, 'return').mockResolvedValue({ done: true, value: undefined });
+    caller.abort('stop');
+    await query.closed.promise;
+    await expectPending(execution);
+    expect(query.return).toHaveBeenCalledOnce();
+    query.terminal.resolve(new Error('late iterator rejection'));
+    expect((await execution).status).toBe('aborted');
+    await adapter.dispose();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('keeps permanently unresolved cleanup explicit instead of claiming the writer stopped', async () => {
+    const { adapter, caller, execution, query } = await launch();
+    caller.abort('cancel unresolved query');
+    await query.returning.promise;
+    await vi.advanceTimersByTimeAsync(50);
+    expect(await execution).toMatchObject({
+      status: 'aborted',
+      error: {
+        code: 'EXEC-004',
+        category: 'fatal',
+        context: { unresolved: true },
+        cause: { message: 'cancel unresolved query' },
+      },
+    });
+    const disposal = adapter.dispose();
+    await expect(disposal).rejects.toMatchObject({
+      code: 'EXEC-004',
+      context: { unresolvedExecutions: 1 },
+    });
+    await vi.advanceTimersByTimeAsync(100000);
+    expect(adapter.dispose()).toBe(disposal);
+    expect(query.writerActive).toBe(true);
+    expect(await query.writeArtifact()).toBe(true); // failed cleanup provides no shutdown guarantee
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('still invokes return after close throws and blocks admission while cleanup is pending', async () => {
+    const { adapter, caller, execution, query } = await launch();
+    vi.spyOn(query, 'close').mockImplementation(() => {
+      throw new Error('close failed');
+    });
+    caller.abort('original cancellation');
+    await query.returning.promise;
+    await expect(adapter.execute(request())).rejects.toMatchObject({
+      code: 'EXEC-004',
+      category: 'fatal',
+    });
+    await expectPending(execution);
+    query.cleanupGate.resolve();
+    expect(await execution).toMatchObject({
+      status: 'aborted',
+      error: {
+        code: 'EXEC-004',
+        cause: { message: 'original cancellation' },
+        context: { cleanupErrors: ['close failed'] },
+      },
+    });
+    await expect(adapter.dispose()).rejects.toMatchObject({ code: 'EXEC-004' });
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('reentrant disposal from an SDK abort listener joins the same operation', async () => {
+    const { adapter, execution, query } = await launch();
+    let reentrant: Promise<void> | undefined;
+    query.controller.signal.addEventListener(
+      'abort',
+      () => {
+        reentrant = adapter.dispose();
+      },
+      { once: true }
+    );
+    const disposal = adapter.dispose();
+    expect(reentrant).toBe(disposal);
+    await query.returning.promise;
+    query.cleanupGate.resolve();
+    await disposal;
+    expect((await execution).status).toBe('aborted');
+    expect(query.closeCalls).toBe(1);
+    expect(query.returnCalls).toBe(1);
+  });
+
+  it('attempts every disposal cleanup even when one rejects', async () => {
+    const sdk = boundary();
+    const secondStarted = deferred<ControlledQuery>();
+    const adapter = new SdkExecutionAdapter({
+      loader: async () => ({
+        query: (input) => {
+          const query = sdk.sdk.query(input);
+          if (sdk.queries.length === 2) secondStarted.resolve(sdk.queries[1]!);
+          return query;
+        },
+      }),
+    });
+    const executions = [adapter.execute(request()), adapter.execute(request())];
+    const second = await secondStarted.promise;
+    const first = sdk.queries[0]!;
+    const disposal = adapter.dispose();
+    const outcome = disposal.catch((error) => error);
+    await Promise.all(sdk.queries.map((query) => query.returning.promise));
+    first.cleanupGate.reject(new Error('first cleanup failed'));
+    await expectPending(disposal);
+    second.cleanupGate.resolve();
+    expect(await outcome).toMatchObject({
+      code: 'EXEC-004',
+      context: { cleanupErrors: [expect.objectContaining({ code: 'EXEC-004' })] },
+    });
+    expect((await Promise.all(executions)).every((result) => result.status === 'aborted')).toBe(
+      true
+    );
+    expect(second.writerActive).toBe(false);
+  });
+
+  it('prevents an already-admitted setup from starting a query after sibling cleanup fails', async () => {
+    const sdk = boundary();
+    const setupEntered = deferred<void>();
+    const setupGate = deferred<void>();
+    let resolutions = 0;
+    const adapter = new SdkExecutionAdapter({
+      loader: async () => sdk.sdk,
+      resolveAgent: async (...args) => {
+        if (++resolutions === 2) {
+          setupEntered.resolve();
+          await setupGate.promise;
+        }
+        return resolveProjectAgent(...args);
+      },
+    });
+    const first = adapter.execute(request());
+    const query = await sdk.started.promise;
+    await query.reading.promise;
+    const second = adapter.execute(request());
+    await setupEntered.promise;
+    query.terminal.resolve(new Error('first SDK failure'));
+    await query.returning.promise;
+    query.cleanupGate.reject(new Error('first cleanup failed'));
+    expect((await first).error?.code).toBe('EXEC-004');
+    setupGate.resolve();
+    expect(await second).toMatchObject({
+      status: 'failed',
+      error: { code: 'EXEC-004', category: 'fatal' },
+    });
+    expect(sdk.sdk.query).toHaveBeenCalledTimes(1);
+    await expect(adapter.dispose()).rejects.toMatchObject({ code: 'EXEC-004' });
+  });
+});
+
+describe('partial usage and causal outcomes', () => {
+  const usage = {
+    input_tokens: 100,
+    output_tokens: 30,
+    cache_read_input_tokens: 2,
+    cache_creation_input_tokens: 3,
+  };
+  const result = sdkResult({
+    session_id: 'latest',
+    num_turns: 4,
+    usage,
+    result: 'src/ok.ts: artifact',
+  });
+  const assistant = sdkAssistant('partial', { id: 'one', usage: sdkResult({ usage }).usage });
+
+  it('does not relabel an observed SDK error result when cancellation arrives later', async () => {
+    const { adapter, caller, execution, query } = await launch([
+      sdkResult({ ...result, is_error: true, result: 'SDK failed first' }),
+    ]);
+    caller.abort('later cancellation');
+    await query.returning.promise;
+    query.cleanupGate.resolve();
+    expect(await execution).toMatchObject({
+      status: 'failed',
+      sessionId: 'latest',
+      toolCallCount: 4,
+      tokenUsage: { input: 100, output: 30, cache: 5 },
+      error: { cause: { message: 'SDK failed first' } },
+    });
+    await adapter.dispose();
+  });
+
+  it.each(['success', 'throw', 'sdk-error', 'abort'] as const)(
+    'retains authoritative result usage on %s',
+    async (outcome) => {
+      const { result: _text, subtype: _subtype, ...base } = result;
+      const sdkError: SDKResultError = {
+        ...base,
+        subtype: 'error_max_turns',
+        is_error: true,
+        errors: ['limit reached'],
+      };
+      const { adapter, caller, execution, query } = await launch([
+        assistant,
+        assistant,
+        outcome === 'sdk-error' ? sdkError : result,
+      ]);
+      if (outcome === 'abort') caller.abort('partial abort');
+      else query.terminal.resolve(outcome === 'throw' ? new Error('after result') : undefined);
+      await query.returning.promise;
+      await expectPending(execution);
+      query.cleanupGate.resolve();
+      expect(await execution).toMatchObject({
+        status: outcome === 'success' ? 'success' : outcome === 'abort' ? 'aborted' : 'failed',
+        sessionId: 'latest',
+        toolCallCount: 4,
+        tokenUsage: { input: 100, output: 30, cache: 5 },
+      });
+      if (outcome === 'success')
+        expect((await execution).artifacts).toEqual([
+          { path: 'src/ok.ts', description: 'artifact' },
+        ]);
+      if (outcome === 'sdk-error')
+        expect((await execution).error?.cause?.message).toBe('limit reached');
+      await adapter.dispose();
+    }
+  );
+
+  it.each(['throw', 'abort'] as const)(
+    'deduplicates assistant IDs and retains fallback usage on %s',
+    async (outcome) => {
+      const second = sdkAssistant('latest-assistant', {
+        id: 'two',
+        usage: sdkResult({
+          usage: { input_tokens: 5, output_tokens: 2, cache_creation_input_tokens: 1 },
+        }).usage,
+      });
+      const { adapter, caller, execution, query } = await launch([assistant, assistant, second]);
+      if (outcome === 'abort') caller.abort('partial');
+      else query.terminal.resolve(new Error('before result'));
+      await query.returning.promise;
+      query.cleanupGate.resolve();
+      expect(await execution).toMatchObject({
+        status: outcome === 'abort' ? 'aborted' : 'failed',
+        sessionId: 'latest-assistant',
+        toolCallCount: 2,
+        tokenUsage: { input: 105, output: 32, cache: 6 },
+      });
+      await adapter.dispose();
+    }
+  );
+
+  it('uses the latest usage per repeated assistant ID without inflating turns', async () => {
+    const updated = sdkAssistant('latest-repeat', {
+      id: 'one',
+      usage: sdkResult({ usage: { ...usage, output_tokens: 40 } }).usage,
+    });
+    const { adapter, caller, execution, query } = await launch([assistant, updated]);
+    caller.abort('partial');
+    await query.returning.promise;
+    query.cleanupGate.resolve();
+    expect(await execution).toMatchObject({
+      status: 'aborted',
+      sessionId: 'latest-repeat',
+      toolCallCount: 1,
+      tokenUsage: { input: 100, output: 40, cache: 5 },
+    });
+    await adapter.dispose();
+  });
+});

--- a/tests/execution/SdkExecutionAdapter.test.ts
+++ b/tests/execution/SdkExecutionAdapter.test.ts
@@ -2,7 +2,14 @@ import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
 import { mkdtemp, rm } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { installAgent, sdkResult, sdkStatus, sdkAssistant } from './fixtures/sdk.js';
+import {
+  installAgent,
+  sdkResult,
+  sdkStatus,
+  sdkAssistant,
+  sdkQuery,
+  withQueryLifecycle,
+} from './fixtures/sdk.js';
 import {
   renderPrompt,
   SdkExecutionAdapter,
@@ -19,9 +26,11 @@ function fakeSdk(
   return {
     query(q) {
       opts.onCall?.(q);
-      return (async function* () {
-        for (const m of messages) yield m;
-      })();
+      return sdkQuery(
+        (async function* () {
+          for (const m of messages) yield m;
+        })()
+      );
     },
   };
 }
@@ -316,7 +325,7 @@ describe('official SDK options and cancellation bridge', () => {
     const server = captured?.options?.mcpServers?.stdio;
     expect(server && 'args' in server ? server.args : undefined).not.toBe(args);
     expect(captured?.options).not.toHaveProperty('resume');
-    expect(captured?.options).not.toHaveProperty('abortController');
+    expect(captured?.options?.abortController).toBeInstanceOf(AbortController);
   });
 
   it.each(['success', 'failure', 'aborted'] as const)(
@@ -328,27 +337,29 @@ describe('official SDK options and cancellation bridge', () => {
       let sdkController: AbortController | undefined;
       const reason = new Error('cancel this stage');
       const adapter = new SdkExecutionAdapter({
-        loader: async () => ({
-          async *query({ options }) {
-            sdkController = options?.abortController;
-            expect(sdkController).toBeInstanceOf(AbortController);
-            if (outcome === 'aborted') {
-              controller.abort(reason);
-              expect(sdkController?.signal.aborted).toBe(true);
-              expect(sdkController?.signal.reason).toBe(reason);
-              throw reason;
-            }
-            if (outcome === 'failure') throw new Error('SDK failure');
-            yield sdkResult();
-          },
-        }),
+        loader: async () =>
+          withQueryLifecycle({
+            async *query({ options }) {
+              sdkController = options?.abortController;
+              expect(sdkController).toBeInstanceOf(AbortController);
+              if (outcome === 'aborted') {
+                controller.abort(reason);
+                expect(sdkController?.signal.aborted).toBe(true);
+                expect(sdkController?.signal.reason).toBe(reason);
+                throw reason;
+              }
+              if (outcome === 'failure') throw new Error('SDK failure');
+              yield sdkResult();
+            },
+          }),
       });
       const result = await adapter.execute({ ...baseRequest, signal: controller.signal });
       expect(result.status).toBe(outcome === 'failure' ? 'failed' : outcome);
       expect(remove).toHaveBeenCalledWith('abort', add.mock.calls[0]?.[1]);
       if (outcome !== 'aborted') {
-        controller.abort();
-        expect(sdkController?.signal.aborted).toBe(false);
+        const originalReason: unknown = sdkController?.signal.reason;
+        controller.abort('late cancellation');
+        expect(sdkController?.signal.reason).toBe(originalReason);
       }
     }
   );

--- a/tests/execution/fixtures/controlledSdk.ts
+++ b/tests/execution/fixtures/controlledSdk.ts
@@ -1,0 +1,95 @@
+import { writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import type { SDKMessage } from '@anthropic-ai/claude-agent-sdk';
+import type { SdkQuery, SdkQueryOptions } from '../../../src/execution/SdkExecutionAdapter.js';
+import { sdkResult } from './sdk.js';
+
+export function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((yes, no) => {
+    resolve = yes;
+    reject = no;
+  });
+  return { promise, resolve, reject };
+}
+
+/**
+ * SDK boundary only: never receives the public request signal. Like SDK 0.3.258,
+ * close initiates shutdown synchronously and the outer return awaits cleanup.
+ * The separate inner iterator cannot complete that outer cleanup for the adapter.
+ */
+export class ControlledQuery implements SdkQuery {
+  readonly controller: AbortController;
+  readonly reading = deferred<void>();
+  readonly closed = deferred<void>();
+  readonly returning = deferred<void>();
+  readonly cleaned = deferred<void>();
+  readonly cleanupGate = deferred<void>();
+  readonly terminal = deferred<SDKMessage | Error | undefined>();
+  readonly iterator: AsyncGenerator<SDKMessage, void>;
+  closeCalls = 0;
+  returnCalls = 0;
+  artifactWrites = 0;
+  writerActive = true;
+  private readonly abort: () => void;
+
+  constructor(
+    readonly input: SdkQueryOptions,
+    messages: readonly SDKMessage[] = [],
+    abortMode: 'reject' | 'end' | 'ignore' = 'reject'
+  ) {
+    const controller = input.options?.abortController;
+    if (controller === undefined) throw new Error('Missing official abortController');
+    this.controller = controller;
+    this.abort = () => {
+      if (abortMode === 'reject') this.terminal.resolve(new Error('SDK iterator aborted'));
+      if (abortMode === 'end') this.terminal.resolve(undefined);
+    };
+    controller.signal.addEventListener('abort', this.abort, { once: true });
+    if (controller.signal.aborted) this.abort();
+    this.iterator = this.messages(messages);
+  }
+
+  private async *messages(messages: readonly SDKMessage[]): AsyncGenerator<SDKMessage, void> {
+    for (const message of messages) yield message;
+    this.reading.resolve();
+    const terminal = await this.terminal.promise;
+    if (terminal instanceof Error) throw terminal;
+    if (terminal !== undefined) yield terminal;
+  }
+
+  [Symbol.asyncIterator](): AsyncGenerator<SDKMessage, void> {
+    return this.iterator;
+  }
+
+  close(): void {
+    this.closeCalls++;
+    this.closed.resolve();
+  }
+
+  async return(value: void | PromiseLike<void>): Promise<IteratorResult<SDKMessage, void>> {
+    this.returnCalls++;
+    this.returning.resolve();
+    await this.cleanupGate.promise;
+    this.writerActive = false;
+    this.controller.signal.removeEventListener('abort', this.abort);
+    const result = await this.iterator.return(value);
+    this.cleaned.resolve();
+    return result;
+  }
+
+  finish(message: SDKMessage = sdkResult()): void {
+    this.terminal.resolve(message);
+  }
+
+  async writeArtifact(): Promise<boolean> {
+    if (!this.writerActive) return false;
+    this.artifactWrites++;
+    await writeFile(
+      join(this.input.options?.cwd ?? '', 'lifecycle-sentinel.txt'),
+      String(this.artifactWrites)
+    );
+    return true;
+  }
+}

--- a/tests/execution/fixtures/projectIsolation.ts
+++ b/tests/execution/fixtures/projectIsolation.ts
@@ -5,7 +5,7 @@ import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 import type { Options } from '@anthropic-ai/claude-agent-sdk';
 import { SdkExecutionAdapter, type SdkLike } from '../../../src/execution/SdkExecutionAdapter.js';
-import { agentMarkdown, installAgent, sdkResult } from './sdk.js';
+import { agentMarkdown, installAgent, sdkResult, withQueryLifecycle } from './sdk.js';
 
 const projectA = process.cwd();
 const projectB = process.argv[2];
@@ -17,7 +17,7 @@ let release: () => void = () => {};
 const rendezvous = new Promise<void>((resolve) => {
   release = resolve;
 });
-const sdk: SdkLike = {
+const sdk: SdkLike = withQueryLifecycle({
   async *query({ options }) {
     assert.ok(options?.cwd);
     assert.ok(options.agent);
@@ -32,7 +32,7 @@ const sdk: SdkLike = {
     await writeFile(join(options.cwd, artifact), definition.prompt);
     yield sdkResult({ result: `${artifact}: sentinel` });
   },
-};
+});
 const adapter = new SdkExecutionAdapter({ loader: async () => sdk });
 const request = (projectDir: string, agentType = 'worker') => ({
   projectDir,

--- a/tests/execution/fixtures/sdk.ts
+++ b/tests/execution/fixtures/sdk.ts
@@ -1,3 +1,9 @@
+import type { SDKMessage } from '@anthropic-ai/claude-agent-sdk';
+import type {
+  SdkLike,
+  SdkQuery,
+  SdkQueryOptions,
+} from '../../../src/execution/SdkExecutionAdapter.js';
 import type {
   SDKAssistantMessage,
   SDKResultSuccess,
@@ -52,7 +58,10 @@ export function sdkStatus(sessionId: string): SDKStatusMessage {
   };
 }
 
-export function sdkAssistant(sessionId: string): SDKAssistantMessage {
+export function sdkAssistant(
+  sessionId: string,
+  overrides: Partial<SDKAssistantMessage['message']> = {}
+): SDKAssistantMessage {
   return {
     type: 'assistant',
     session_id: sessionId,
@@ -71,6 +80,7 @@ export function sdkAssistant(sessionId: string): SDKAssistantMessage {
       context_management: null,
       diagnostics: null,
       stop_details: null,
+      ...overrides,
     },
   };
 }
@@ -94,4 +104,19 @@ export async function installAgent(
   const path = join(directory, `${name}.md`);
   await writeFile(path, content);
   return path;
+}
+
+/** Minimal outer lifecycle for finite scripted streams; the iterator remains distinct. */
+export function sdkQuery(messages: AsyncGenerator<SDKMessage, void>): SdkQuery {
+  return {
+    [Symbol.asyncIterator]: () => messages,
+    close: () => {},
+    return: (value) => messages.return(value),
+  };
+}
+
+export function withQueryLifecycle(sdk: {
+  query(options: SdkQueryOptions): AsyncGenerator<SDKMessage, void>;
+}): SdkLike {
+  return { query: (options) => sdkQuery(sdk.query(options)) };
 }

--- a/tests/execution/hooks.test.ts
+++ b/tests/execution/hooks.test.ts
@@ -1,3 +1,4 @@
+import { sdkQuery, withQueryLifecycle } from './fixtures/sdk.js';
 import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
 import { mkdtemp, rm } from 'node:fs/promises';
 import { join } from 'node:path';
@@ -187,9 +188,11 @@ describe('SdkExecutionAdapter — hooks wiring', () => {
     const sdk: SdkLike = {
       query(q) {
         captured.value = q;
-        return (async function* () {
-          for (const m of messages) yield m;
-        })();
+        return sdkQuery(
+          (async function* () {
+            for (const m of messages) yield m;
+          })()
+        );
       },
     };
     return { sdk, captured };
@@ -319,32 +322,33 @@ describe('SDK invokes official hook entries', () => {
     const outputs: unknown[] = [];
     const adapter = new SdkExecutionAdapter({
       hooks: buildHookPipeline(sink),
-      loader: async () => ({
-        async *query({ options }) {
-          for (const entry of options?.hooks?.PostToolUse ?? []) {
-            expect(entry).not.toHaveProperty('callback');
-            for (const callback of entry.hooks) {
-              outputs.push(
-                await callback(
-                  {
-                    hook_event_name: 'PostToolUse',
-                    tool_name: 'Write',
-                    tool_input: { file_path: 'sentinel.txt' },
-                    tool_response: {},
-                    tool_use_id: 'tool-offline',
-                    session_id: 'hook-session',
-                    transcript_path: join(projectDir, 'transcript.jsonl'),
-                    cwd: options?.cwd ?? '',
-                  },
-                  'tool-offline',
-                  { signal: new AbortController().signal }
-                )
-              );
+      loader: async () =>
+        withQueryLifecycle({
+          async *query({ options }) {
+            for (const entry of options?.hooks?.PostToolUse ?? []) {
+              expect(entry).not.toHaveProperty('callback');
+              for (const callback of entry.hooks) {
+                outputs.push(
+                  await callback(
+                    {
+                      hook_event_name: 'PostToolUse',
+                      tool_name: 'Write',
+                      tool_input: { file_path: 'sentinel.txt' },
+                      tool_response: {},
+                      tool_use_id: 'tool-offline',
+                      session_id: 'hook-session',
+                      transcript_path: join(projectDir, 'transcript.jsonl'),
+                      cwd: options?.cwd ?? '',
+                    },
+                    'tool-offline',
+                    { signal: new AbortController().signal }
+                  )
+                );
+              }
             }
-          }
-          yield sdkResult();
-        },
-      }),
+            yield sdkResult();
+          },
+        }),
     });
     const result = await adapter.execute({
       projectDir,

--- a/tsconfig.sdk-contract.json
+++ b/tsconfig.sdk-contract.json
@@ -7,7 +7,8 @@
   "include": [
     "src/execution/**/*.ts",
     "tests/execution/**/*.ts",
-    "tests/ad-sdlc-orchestrator/projectContext.test.ts"
+    "tests/ad-sdlc-orchestrator/projectContext.test.ts",
+    "tests/ad-sdlc-orchestrator/sdkLifecycle.test.ts"
   ],
   "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
## Summary

Disposing an adapter or timing out a stage could return while SDK work was still running, and failure results discarded observed usage. Each execution now owns an official abort controller and joins the original Query's lifecycle and message consumption before completing, or reports an explicit fatal cleanup failure.

This builds on #963's official SDK types, target-project selection, and reason-preserving cancellation bridge. Scheduler retries and pipeline shutdown now honor the same cleanup boundary.

## Related Issue

Closes #948

## Type of Change

- [x] Bug fix
- [x] Documentation update

## Changes Made

- Register executions before asynchronous setup, always supply distinct owned controllers, and prevent cancelled/disposed setup from starting late queries.
- Retain the outer Query and finalize with supported `close()` and asynchronous `return(undefined)`, joining consumption with a configurable 5,000 ms cleanup grace. Retain unresolved work and reject further execution after cleanup failure.
- Make concurrent disposal share one operation, attempt every cleanup, and expose aggregated failures. Preserve the orchestrator's adapter admission barrier throughout shutdown.
- Join timeout/cancellation cleanup before surfacing stage failure or retrying. Preserve structured fatal classification, original causes, partial usage, meaningful first-attempt errors, and actual retry counts; cancel backoff and block queued work after cleanup failure.
- Preserve session IDs, turns, assistant usage deduplicated by message ID, and authoritative aggregate result usage across success, SDK failure, and cancellation.
- Add controlled asynchronous SDK lifecycle doubles and production scheduler/orchestrator integration coverage; update execution lifecycle documentation and SDK contract coverage.

## Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated

### Test Results

| Check | Result |
| --- | --- |
| `npm run test:sdk-contract` | Passed against installed SDK 0.3.258 |
| `npx vitest run tests/execution tests/ad-sdlc-orchestrator` | 363 tests passed across 16 files, including 10 production-boundary integration tests |
| `npm run build` | Passed; 40 assets validated |
| `npm run lint` | Passed: 0 errors, 457 warnings, matching untouched `develop` |
| `npm run docs:check` | Passed symbol and inventory checks |
| Prettier on all 18 changed/new files | Passed |
| CRLF-aware `git diff --check` and trailing-whitespace scan | Passed |

Integration coverage is in `tests/ad-sdlc-orchestrator/sdkLifecycle.test.ts`, so the focused command above executes it. Tests use deferred promises and fake timers; SDK execution remains offline.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented the lifecycle and cancellation ordering
- [x] I have updated the documentation
- [x] My changes generate no new lint warnings
- [x] I have added behavioral regression tests
- [x] New and existing tests in the affected execution/orchestrator lanes pass locally

## Additional Notes

Based on current `develop@f5d4cba6b65fa52a03729f9a79df3121376e0a8b`, in an isolated worktree preserving the original checkout.

No paid live SDK pipeline was run. SDK 0.3.258's public lifecycle establishes SDK-observable cleanup and bounds its internal process-exit wait; it does not independently prove that every operating-system process exited. Process-level confirmation remains for the later live acceptance lane.
