### PR TITLE
fix(docs): compare documented dependencies by release line

### DIFF
--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -46,6 +46,14 @@ permissions:
   pull-requests: write
 
 jobs:
+  # Checks documented symbols and inventory counts against the code
+  # (npm run docs:check). Policy for dependency-only PRs such as Dependabot
+  # updates: the dependency tables in README.md and
+  # docs/architecture/overview.md are compared by release line
+  # (DocInventoryValidator.isSameReleaseLine). A patch or minor bump passes
+  # without a doc edit; a major bump, or a minor bump of a 0.x package, fails
+  # until the documented version is updated in the same PR. Whoever merges the
+  # dependency PR pushes that doc edit to its branch.
   validate-doc-code:
     name: Validate Documentation Against Code
     runs-on: ubuntu-latest

--- a/src/doc-code-comparator/DocInventoryValidator.ts
+++ b/src/doc-code-comparator/DocInventoryValidator.ts
@@ -326,7 +326,7 @@ export class DocInventoryValidator {
       const documentedVersions = this.extractDependencyVersions(dependencySection);
       for (const [dependency, documented] of documentedVersions) {
         const actual = versions[dependency];
-        if (actual !== undefined && documented !== actual) {
+        if (actual !== undefined && !DocInventoryValidator.isSameReleaseLine(documented, actual)) {
           violations.push({
             code: 'DEPENDENCY_VERSION',
             path: table.path,
@@ -343,6 +343,37 @@ export class DocInventoryValidator {
         });
       }
     }
+  }
+
+  /**
+   * Dependency tables document the release line a package is on, not the exact
+   * range in package.json. Two caret ranges are on the same line when they share
+   * the major version (the minor version for 0.x, as in semver caret semantics),
+   * so patch and minor bumps such as Dependabot updates pass without a doc edit,
+   * while a major bump fails until the table is updated in the same PR. Anything
+   * other than a plain caret range must match exactly.
+   *
+   * @param documented - Version range written in the documentation table
+   * @param declared - Version range declared in package.json
+   * @returns True when both ranges are on the same release line
+   */
+  static isSameReleaseLine(documented: string, declared: string): boolean {
+    if (documented === declared) {
+      return true;
+    }
+    const releaseLine = (range: string): string | undefined => {
+      const match = /^\^(\d+)\.(\d+)\.\d+$/.exec(range);
+      if (match === null) {
+        return undefined;
+      }
+      const [, major, minor] = match;
+      if (major === undefined || minor === undefined) {
+        return undefined;
+      }
+      return major === '0' ? `0.${minor}` : major;
+    };
+    const documentedLine = releaseLine(documented);
+    return documentedLine !== undefined && documentedLine === releaseLine(declared);
   }
 
   private extractDependencyVersions(markdown: string): ReadonlyMap<string, string> {

--- a/tests/doc-code-comparator/DocInventoryValidator.test.ts
+++ b/tests/doc-code-comparator/DocInventoryValidator.test.ts
@@ -93,6 +93,39 @@ describe('DocInventoryValidator', () => {
     );
   });
 
+  it('accepts patch and minor dependency bumps on the documented release line', () => {
+    write(
+      'package.json',
+      JSON.stringify({ dependencies: { '@anthropic-ai/claude-agent-sdk': '^1.4.0' } })
+    );
+
+    expect(new DocInventoryValidator(root).validate().violations).toEqual([]);
+  });
+
+  it('reports a major dependency bump until the documented version is updated', () => {
+    write(
+      'package.json',
+      JSON.stringify({ dependencies: { '@anthropic-ai/claude-agent-sdk': '^2.0.0' } })
+    );
+
+    const result = new DocInventoryValidator(root).validate();
+
+    expect(result.violations).toContainEqual(
+      expect.objectContaining({ code: 'DEPENDENCY_VERSION', path: 'README.md' })
+    );
+    expect(result.violations).toContainEqual(
+      expect.objectContaining({ code: 'DEPENDENCY_VERSION', path: 'docs/architecture/overview.md' })
+    );
+  });
+
+  it('compares 0.x caret ranges by minor version', () => {
+    expect(DocInventoryValidator.isSameReleaseLine('^0.3.258', '^0.3.260')).toBe(true);
+    expect(DocInventoryValidator.isSameReleaseLine('^0.3.258', '^0.4.0')).toBe(false);
+    expect(DocInventoryValidator.isSameReleaseLine('^14.2.0', '^14.2.1')).toBe(true);
+    expect(DocInventoryValidator.isSameReleaseLine('^4.0.16', '^5.0.0')).toBe(false);
+    expect(DocInventoryValidator.isSameReleaseLine('~1.2.3', '~1.2.4')).toBe(false);
+  });
+
   it('reports a legacy ADR tree and stale generated inventory block', () => {
     write('docs/architecture/decisions/ADR-001-old.md', '# Legacy ADR\n');
     write(


### PR DESCRIPTION
## What

`DocInventoryValidator` compares the dependency tables in README.md and docs/architecture/overview.md with package.json by release line instead of by exact string. The docs-check workflow documents the resulting policy for dependency-only pull requests.

## Why

Every Dependabot pull request failed "Validate Documentation Against Code", whatever its size:

| PR | Violations |
|---|---|
| #966 (production group) | `@anthropic-ai/claude-agent-sdk` documented `^0.3.258`, declared `^0.3.260`; `inquirer` documented `^14.2.0`, declared `^14.2.1` (README and overview, 4 violations) |
| #965 (development group) | `vitest` documented `^4.0.16`, declared `^5.0.0`; `@vitest/coverage-v8` documented `^4.1.11`, declared `^5.0.0` |

A patch bump does not change documented behavior, so failing it only blocks updates. A major bump can, so it should still stop until the table is updated.

## How

- New `DocInventoryValidator.isSameReleaseLine(documented, declared)`: two caret ranges match when they share the major version, or the minor version for 0.x (semver caret semantics). Other range forms must match exactly, as before.
- `validateDependencyVersions` uses it instead of `!==`.
- docs-check.yml: comment above `validate-doc-code` stating the policy: patch and minor bumps pass; a major bump, or a minor bump of a 0.x package, fails until the documented version is updated in the same pull request; whoever merges the dependency PR pushes that doc edit to its branch.

## Test

- `npx vitest run tests/doc-code-comparator/DocInventoryValidator.test.ts` -> 8 passed (3 new: patch/minor bump accepted, major bump reported in both tables, 0.x compared by minor).
- `npx prettier --check` on the changed files -> clean; `npx eslint src/doc-code-comparator/DocInventoryValidator.ts` -> 0 problems; `npx tsc --noEmit` -> no errors.
- `npm run docs:check` on this branch -> passed.

Part of #969
